### PR TITLE
Define which step ids to remove from the session

### DIFF
--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -5,12 +5,8 @@ class UserSession
     @session = session
   end
 
-  def remove_keys_after(key)
-    keys_to_remove = session.keys.map(&:to_i).uniq.select { |k| k > key }
-
-    return if keys_to_remove.empty?
-
-    session.delete(*keys_to_remove)
+  def remove_step_ids(ids)
+    ids.map{ |id| session.delete(id) } unless ids.empty?
   end
 
   def import_date

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -10,41 +10,41 @@ class UserSession
   end
 
   def import_date
-    return unless session.key?(Wizard::Steps::ImportDate::STEP_ID)
+    return unless session.key?(Wizard::Steps::ImportDate.id)
 
-    Date.parse(session[Wizard::Steps::ImportDate::STEP_ID])
+    Date.parse(session[Wizard::Steps::ImportDate.id])
   end
 
   def import_date=(value)
-    session[Wizard::Steps::ImportDate::STEP_ID] = value
+    session[Wizard::Steps::ImportDate.id] = value
   end
 
   def import_destination
-    session[Wizard::Steps::ImportDestination::STEP_ID]
+    session[Wizard::Steps::ImportDestination.id]
   end
 
   def import_destination=(value)
-    session[Wizard::Steps::ImportDestination::STEP_ID] = value
+    session[Wizard::Steps::ImportDestination.id] = value
   end
 
   def country_of_origin
-    session[Wizard::Steps::CountryOfOrigin::STEP_ID]
+    session[Wizard::Steps::CountryOfOrigin.id]
   end
 
   def country_of_origin=(value)
-    session[Wizard::Steps::CountryOfOrigin::STEP_ID] = value
+    session[Wizard::Steps::CountryOfOrigin.id] = value
   end
 
   def trader_scheme
-    session[Wizard::Steps::TraderScheme::STEP_ID]
+    session[Wizard::Steps::TraderScheme.id]
   end
 
   def trader_scheme=(value)
-    session[Wizard::Steps::TraderScheme::STEP_ID] = value
+    session[Wizard::Steps::TraderScheme.id] = value
   end
 
   def customs_value=(values)
-    session[Wizard::Steps::CustomsValue::STEP_ID] = {
+    session[Wizard::Steps::CustomsValue.id] = {
       'monetary_value' => values['monetary_value'],
       'shipping_cost' => values['shipping_cost'],
       'insurance_cost' => values['insurance_cost'],
@@ -52,15 +52,15 @@ class UserSession
   end
 
   def monetary_value
-    session[Wizard::Steps::CustomsValue::STEP_ID].try(:[], 'monetary_value')
+    session[Wizard::Steps::CustomsValue.id].try(:[], 'monetary_value')
   end
 
   def shipping_cost
-    session[Wizard::Steps::CustomsValue::STEP_ID].try(:[], 'shipping_cost')
+    session[Wizard::Steps::CustomsValue.id].try(:[], 'shipping_cost')
   end
 
   def insurance_cost
-    session[Wizard::Steps::CustomsValue::STEP_ID].try(:[], 'insurance_cost')
+    session[Wizard::Steps::CustomsValue.id].try(:[], 'insurance_cost')
   end
 
   def ni_to_gb_route?

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -6,7 +6,7 @@ class UserSession
   end
 
   def remove_step_ids(ids)
-    ids.map{ |id| session.delete(id) } unless ids.empty?
+    ids.map { |id| session.delete(id) } unless ids.empty?
   end
 
   def import_date

--- a/app/models/wizard/steps/base.rb
+++ b/app/models/wizard/steps/base.rb
@@ -19,6 +19,10 @@ module Wizard
         false
       end
 
+      def self.id
+        name.split('::').last.underscore
+      end
+
       protected
 
       def next_step_path(*)

--- a/app/models/wizard/steps/base.rb
+++ b/app/models/wizard/steps/base.rb
@@ -32,7 +32,7 @@ module Wizard
       private
 
       def clean_user_session
-        @user_session.remove_keys_after(self.class::STEP_ID.to_i)
+        @user_session.remove_step_ids(self.class::STEPS_TO_REMOVE_FROM_SESSION)
       end
     end
   end

--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -1,8 +1,11 @@
 module Wizard
   module Steps
     class CountryOfOrigin < Wizard::Steps::Base
-      STEP_ID = '3'.freeze
-      STEPS_TO_REMOVE_FROM_SESSION = %w[4].freeze
+      STEPS_TO_REMOVE_FROM_SESSION = %w[
+        customs_value
+        trader_scheme
+        final_use
+      ].freeze
 
       attribute :country_of_origin, :string
 

--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -2,6 +2,7 @@ module Wizard
   module Steps
     class CountryOfOrigin < Wizard::Steps::Base
       STEP_ID = '3'.freeze
+      STEPS_TO_REMOVE_FROM_SESSION = %w[4].freeze
 
       attribute :country_of_origin, :string
 

--- a/app/models/wizard/steps/customs_value.rb
+++ b/app/models/wizard/steps/customs_value.rb
@@ -2,6 +2,7 @@ module Wizard
   module Steps
     class CustomsValue < Wizard::Steps::Base
       STEP_ID = '4'.freeze
+      STEPS_TO_REMOVE_FROM_SESSION = %w[].freeze
 
       attribute :monetary_value, :string
       attribute :shipping_cost, :string

--- a/app/models/wizard/steps/customs_value.rb
+++ b/app/models/wizard/steps/customs_value.rb
@@ -1,7 +1,6 @@
 module Wizard
   module Steps
     class CustomsValue < Wizard::Steps::Base
-      STEP_ID = '4'.freeze
       STEPS_TO_REMOVE_FROM_SESSION = %w[].freeze
 
       attribute :monetary_value, :string

--- a/app/models/wizard/steps/import_date.rb
+++ b/app/models/wizard/steps/import_date.rb
@@ -3,8 +3,13 @@ module Wizard
     class ImportDate < Wizard::Steps::Base
       include ActiveRecord::AttributeAssignment
 
-      STEP_ID = '1'.freeze
-      STEPS_TO_REMOVE_FROM_SESSION = %w[2 3 4].freeze
+      STEPS_TO_REMOVE_FROM_SESSION = %w[
+        import_destination
+        country_of_origin
+        customs_value
+        trader_scheme
+        final_use
+      ].freeze
 
       attribute :import_date, :date
 

--- a/app/models/wizard/steps/import_date.rb
+++ b/app/models/wizard/steps/import_date.rb
@@ -4,6 +4,7 @@ module Wizard
       include ActiveRecord::AttributeAssignment
 
       STEP_ID = '1'.freeze
+      STEPS_TO_REMOVE_FROM_SESSION = %w[2 3 4].freeze
 
       attribute :import_date, :date
 

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -6,8 +6,12 @@ module Wizard
         OpenStruct.new(id: 'XI', name: 'Northern Ireland'),
       ].freeze
 
-      STEP_ID = '2'.freeze
-      STEPS_TO_REMOVE_FROM_SESSION = %w[3 4].freeze
+      STEPS_TO_REMOVE_FROM_SESSION = %w[
+        country_of_origin
+        customs_value
+        trader_scehme
+        final_use
+      ].freeze
 
       attribute :import_destination, :string
 

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -7,6 +7,7 @@ module Wizard
       ].freeze
 
       STEP_ID = '2'.freeze
+      STEPS_TO_REMOVE_FROM_SESSION = %w[3 4].freeze
 
       attribute :import_destination, :string
 

--- a/app/models/wizard/steps/trader_scheme.rb
+++ b/app/models/wizard/steps/trader_scheme.rb
@@ -6,9 +6,11 @@ module Wizard
         OpenStruct.new(id: 0, name: 'No, I am not registered with the UK Trader Scheme'),
       ].freeze
 
-      STEP_ID = '5'.freeze
+      STEPS_TO_REMOVE_FROM_SESSION = %w[
+        final_use
+      ].freeze
 
-      attribute 'trader_scheme', :string
+      attribute :trader_scheme, :string
 
       validates :trader_scheme, presence: true
 

--- a/spec/features/country_of_origin_page_spec.rb
+++ b/spec/features/country_of_origin_page_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Country of Origin Page', type: :feature do
   it 'does not store an empty geographical area id on the session' do
     click_on('Continue')
 
-    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::CountryOfOrigin::STEP_ID)).to be false
+    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::CountryOfOrigin.id)).to be false
   end
 
   it 'does store the country of origin date on the session' do
@@ -30,7 +30,7 @@ RSpec.describe 'Country of Origin Page', type: :feature do
 
     click_on('Continue')
 
-    expect(Capybara.current_session.driver.request.session[Wizard::Steps::CountryOfOrigin::STEP_ID]).to eq('XI')
+    expect(Capybara.current_session.driver.request.session[Wizard::Steps::CountryOfOrigin.id]).to eq('XI')
   end
 
   it 'loses its session key when going back to the previous question' do
@@ -41,7 +41,7 @@ RSpec.describe 'Country of Origin Page', type: :feature do
     click_on('Back')
     click_on('Back')
 
-    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::CountryOfOrigin::STEP_ID)).to be false
+    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::CountryOfOrigin.id)).to be false
   end
 
   context 'when importing from NI to GB' do

--- a/spec/features/import_date_page_spec.rb
+++ b/spec/features/import_date_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Import Date Page', type: :feature do
 
     click_on('Continue')
 
-    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::ImportDate::STEP_ID)).to be false
+    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::ImportDate.id)).to be false
   end
 
   it 'does store a invalid import date on the session' do
@@ -25,7 +25,7 @@ RSpec.describe 'Import Date Page', type: :feature do
 
     click_on('Continue')
 
-    expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDate::STEP_ID]).to eq('3000-12-12')
+    expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDate.id]).to eq('3000-12-12')
   end
 
   it 'redirects to import destination page if the validation is successful' do

--- a/spec/features/import_destination_page_spec.rb
+++ b/spec/features/import_destination_page_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Import Destination Page', type: :feature do
   it 'does not store an invalid import destination on the session' do
     click_on('Continue')
 
-    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::ImportDestination::STEP_ID)).to be false
+    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::ImportDestination.id)).to be false
   end
 
   it 'does store a invalid import date on the session' do
@@ -25,7 +25,7 @@ RSpec.describe 'Import Destination Page', type: :feature do
 
     click_on('Continue')
 
-    expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDestination::STEP_ID]).to eq('XI')
+    expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDestination.id]).to eq('XI')
   end
 
   it 'loses its session key when going back to the previous question' do
@@ -36,6 +36,6 @@ RSpec.describe 'Import Destination Page', type: :feature do
     click_on('Back')
     click_on('Back')
 
-    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::ImportDestination::STEP_ID)).to be false
+    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::ImportDestination.id)).to be false
   end
 end

--- a/spec/models/duty_calculator_spec.rb
+++ b/spec/models/duty_calculator_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe DutyCalculator do
     context 'when importing from NI to GB' do
       let(:session) do
         {
-          '2' => 'GB',
-          '3' => 'XI',
+          'import_destination' => 'GB',
+          'country_of_origin' => 'XI',
         }
       end
 
@@ -22,8 +22,8 @@ RSpec.describe DutyCalculator do
     context 'when importing from an EU country to NI' do
       let(:session) do
         {
-          '2' => 'XI',
-          '3' => 'RO',
+          'import_destination' => 'XI',
+          'country_of_origin' => 'RO',
         }
       end
 

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Wizard::Steps::UserSession do
     context 'when the key is present on the session' do
       let(:session) do
         {
-          Wizard::Steps::ImportDate::STEP_ID => '2025-01-01',
+          Wizard::Steps::ImportDate.id => '2025-01-01',
         }
       end
 
@@ -31,7 +31,7 @@ RSpec.describe Wizard::Steps::UserSession do
     it 'sets the key on the session' do
       user_session.import_date = '2025-01-01'
 
-      expect(session[Wizard::Steps::ImportDate::STEP_ID]).to eq(expected_date)
+      expect(session[Wizard::Steps::ImportDate.id]).to eq(expected_date)
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe Wizard::Steps::UserSession do
     context 'when the key is present on the session' do
       let(:session) do
         {
-          Wizard::Steps::ImportDestination::STEP_ID => 'ni',
+          Wizard::Steps::ImportDestination.id => 'ni',
         }
       end
 
@@ -61,7 +61,7 @@ RSpec.describe Wizard::Steps::UserSession do
     it 'sets the key on the session' do
       user_session.import_destination = 'ni'
 
-      expect(session[Wizard::Steps::ImportDestination::STEP_ID]).to eq(expected_country)
+      expect(session[Wizard::Steps::ImportDestination.id]).to eq(expected_country)
     end
   end
 
@@ -73,7 +73,7 @@ RSpec.describe Wizard::Steps::UserSession do
     context 'when the key is present on the session' do
       let(:session) do
         {
-          Wizard::Steps::TraderScheme::STEP_ID => '1',
+          Wizard::Steps::TraderScheme.id => '1',
         }
       end
 
@@ -91,7 +91,7 @@ RSpec.describe Wizard::Steps::UserSession do
     it 'sets the key on the session' do
       user_session.trader_scheme = '1'
 
-      expect(session[Wizard::Steps::TraderScheme::STEP_ID]).to eq(expected_response)
+      expect(session[Wizard::Steps::TraderScheme.id]).to eq(expected_response)
     end
   end
 
@@ -103,7 +103,7 @@ RSpec.describe Wizard::Steps::UserSession do
     context 'when the key is present on the session' do
       let(:session) do
         {
-          Wizard::Steps::CountryOfOrigin::STEP_ID => '1234',
+          Wizard::Steps::CountryOfOrigin.id => '1234',
         }
       end
 
@@ -121,14 +121,14 @@ RSpec.describe Wizard::Steps::UserSession do
     it 'sets the key on the session' do
       user_session.country_of_origin = '1234'
 
-      expect(session[Wizard::Steps::CountryOfOrigin::STEP_ID]).to eq(expected_country)
+      expect(session[Wizard::Steps::CountryOfOrigin.id]).to eq(expected_country)
     end
   end
 
   describe '#insurance_cost' do
     let(:session) do
       {
-        Wizard::Steps::CustomsValue::STEP_ID => {
+        Wizard::Steps::CustomsValue.id => {
           'monetary_value' => '12_000',
           'shipping_cost' => '1_200',
           'insurance_cost' => '340',
@@ -144,7 +144,7 @@ RSpec.describe Wizard::Steps::UserSession do
   describe '#shipping_cost' do
     let(:session) do
       {
-        Wizard::Steps::CustomsValue::STEP_ID => {
+        Wizard::Steps::CustomsValue.id => {
           'monetary_value' => '12_000',
           'shipping_cost' => '1_200',
           'insurance_cost' => '340',
@@ -160,7 +160,7 @@ RSpec.describe Wizard::Steps::UserSession do
   describe '#monetary_value' do
     let(:session) do
       {
-        Wizard::Steps::CustomsValue::STEP_ID => {
+        Wizard::Steps::CustomsValue.id => {
           'monetary_value' => '12_000',
           'shipping_cost' => '1_200',
           'insurance_cost' => '340',
@@ -185,7 +185,7 @@ RSpec.describe Wizard::Steps::UserSession do
     it 'stores the hash on the session' do
       user_session.customs_value = value
 
-      expect(session[Wizard::Steps::CustomsValue::STEP_ID]).to eq(value)
+      expect(session[Wizard::Steps::CustomsValue.id]).to eq(value)
     end
   end
 
@@ -193,8 +193,8 @@ RSpec.describe Wizard::Steps::UserSession do
     context 'when import country is GB and origin country is NI' do
       let(:session) do
         {
-          '2' => 'GB',
-          '3' => 'XI',
+          'import_destination' => 'GB',
+          'country_of_origin' => 'XI',
         }
       end
 
@@ -212,8 +212,8 @@ RSpec.describe Wizard::Steps::UserSession do
     context 'when import country is NI and origin country is a EU Member' do
       let(:session) do
         {
-          '2' => 'XI',
-          '3' => 'RO',
+          'import_destination' => 'XI',
+          'country_of_origin' => 'RO',
         }
       end
 
@@ -231,8 +231,8 @@ RSpec.describe Wizard::Steps::UserSession do
     context 'when import country is XI and origin country is GB' do
       let(:session) do
         {
-          '2' => 'XI',
-          '3' => 'GB',
+          'import_destination' => 'XI',
+          'country_of_origin' => 'GB',
         }
       end
 

--- a/spec/models/wizard/steps/country_of_origin_spec.rb
+++ b/spec/models/wizard/steps/country_of_origin_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
 
     let(:session) do
       {
-        '2' => 'GB',
-        '3' => 'XI',
+        'import_destination' => 'GB',
+        'country_of_origin' => 'XI',
       }
     end
 

--- a/spec/models/wizard/steps/trader_scheme_spec.rb
+++ b/spec/models/wizard/steps/trader_scheme_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe Wizard::Steps::TraderScheme do
     let(:commodity_code) { '1233455' }
     let(:session) do
       {
-        '2' => 'XI',
-        '3' => 'GB',
+        'import_destination' => 'XI',
+        'country_of_origin' => 'GB',
       }
     end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

This change allows devs to define which questions to be
removed from the session while positioned on a particular step.
This way the STEP_ID now becomes purely a unique identifier
for that step.

### Why?

Because some of the questions will be shared by
other routes, we can no longer rely on the position
of that question in the wizard.

The same question could be on position 4 or 8 depending
on which route the user lands on.