### PR TITLE
Support meta_attribute dsl

### DIFF
--- a/app/models/api/base.rb
+++ b/app/models/api/base.rb
@@ -1,7 +1,20 @@
 module Api
   class Base
-    include ActiveModel::Model
-    include ActiveModel::Attributes
+    def self.inherited(child)
+      child.include ActiveModel::Model
+      child.include ActiveModel::Attributes
+
+      child.attribute :meta
+    end
+
+    def self.meta_attribute(*attribute_path)
+      attribute_path = attribute_path.map(&:to_s)
+      method_name = attribute_path.last
+
+      define_method(method_name) do
+        meta.dig(*attribute_path)
+      end
+    end
 
     def self.attributes(*attribute_list)
       attribute_list.each do |resource_attribute|

--- a/app/models/api/commodity.rb
+++ b/app/models/api/commodity.rb
@@ -5,6 +5,9 @@ module Api
     has_many :import_measures, Measure
     has_many :export_measures, Measure
 
+    meta_attribute :duty_calculator, :zero_mfn_duty
+    meta_attribute :duty_calculator, :trade_defence
+
     attributes :producline_suffix,
                :number_indents,
                :description,

--- a/spec/fixtures/commodity.json
+++ b/spec/fixtures/commodity.json
@@ -1,4 +1,10 @@
 {
+  "meta": {
+    "duty_calculator": {
+      "zero_mfn_duty": false,
+      "trade_defence": true
+    }
+  },
   "producline_suffix": "80",
   "description": "Cherry Tomatoes",
   "number_indents": 1,

--- a/spec/models/api/commodity_spec.rb
+++ b/spec/models/api/commodity_spec.rb
@@ -47,4 +47,16 @@ RSpec.describe Api::Commodity, type: :model do
       expect(all_are_measures).to be(true)
     end
   end
+
+  describe '#zero_mfn_duty' do
+    it 'returns false' do
+      expect(commodity.zero_mfn_duty).to be(false)
+    end
+  end
+
+  describe '#trade_defence' do
+    it 'returns true' do
+      expect(commodity.trade_defence).to be(true)
+    end
+  end
 end

--- a/spec/models/api/geographical_area_spec.rb
+++ b/spec/models/api/geographical_area_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Api::GeographicalArea do
     allow(Uktt::GeographicalArea).to receive(:new).and_call_original
   end
 
+  describe '#meta' do
+    it 'returns nil' do
+      expect(geographical_area.meta).to be_nil
+    end
+  end
+
   describe '#id' do
     it 'returns the name from the attributes' do
       expect(geographical_area.id).to eq('NI')


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Encapsulate meta attributes we're interested in behind a DSL

### Why?

I am doing this because:

- We want an easy way to fetch them for the duty calculator and we'll almost certainly be adding more