### PR TITLE
Connect the Customs Value page to the user flow

### DIFF
--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -2,7 +2,6 @@ module Wizard
   module Steps
     class CountryOfOrigin < Wizard::Steps::Base
       STEPS_TO_REMOVE_FROM_SESSION = %w[
-        customs_value
         trader_scheme
         final_use
         certificate_of_origin

--- a/app/models/wizard/steps/customs_value.rb
+++ b/app/models/wizard/steps/customs_value.rb
@@ -33,11 +33,19 @@ module Wizard
       end
 
       def next_step_path(service_choice:, commodity_code:)
-        # To be added on the ticket that creates the next step
+        measure_amount_path(service_choice: service_choice, commodity_code: commodity_code)
       end
 
       def previous_step_path(service_choice:, commodity_code:)
-        country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code)
+        return previous_step_for_gb_to_ni(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+      end
+
+      private
+
+      def previous_step_for_gb_to_ni(service_choice:, commodity_code:)
+        return trade_remedies_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.trade_defence
+
+        certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code)
       end
     end
   end

--- a/app/models/wizard/steps/final_use.rb
+++ b/app/models/wizard/steps/final_use.rb
@@ -8,7 +8,6 @@ module Wizard
 
       STEPS_TO_REMOVE_FROM_SESSION = %w[
         certificate_of_origin
-        customs_value
         planned_processing
       ].freeze
 

--- a/app/models/wizard/steps/import_date.rb
+++ b/app/models/wizard/steps/import_date.rb
@@ -6,7 +6,6 @@ module Wizard
       STEPS_TO_REMOVE_FROM_SESSION = %w[
         import_destination
         country_of_origin
-        customs_value
         trader_scheme
         final_use
         certificate_of_origin

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -8,7 +8,6 @@ module Wizard
 
       STEPS_TO_REMOVE_FROM_SESSION = %w[
         country_of_origin
-        customs_value
         trader_scheme
         final_use
         certificate_of_origin

--- a/app/models/wizard/steps/planned_processing.rb
+++ b/app/models/wizard/steps/planned_processing.rb
@@ -13,7 +13,6 @@ module Wizard
 
       STEPS_TO_REMOVE_FROM_SESSION = %w[
         certificate_of_origin
-        customs_value
       ].freeze
 
       attribute :planned_processing, :string

--- a/app/models/wizard/steps/trader_scheme.rb
+++ b/app/models/wizard/steps/trader_scheme.rb
@@ -9,7 +9,6 @@ module Wizard
       STEPS_TO_REMOVE_FROM_SESSION = %w[
         final_use
         certificate_of_origin
-        customs_value
         planned_processing
       ].freeze
 

--- a/spec/features/customs_value_page_spec.rb
+++ b/spec/features/customs_value_page_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'Customs Value Page', type: :feature do
+  include_context 'GB to NI' do
+    before do
+      allow(commodity).to receive(:applicable_measure_units).and_return({})
+
+      choose(option: 'no')
+      click_on('Continue')
+
+      choose(option: 'no')
+      click_on('Continue')
+    end
+
+    let(:expected_value) do
+      {
+        'insurance_cost' => '',
+        'monetary_value' => '1_200',
+        'shipping_cost' => '',
+      }
+    end
+
+    it 'does not store an empty answer on the session' do
+      click_on('Continue')
+
+      expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::CustomsValue.id)).to be false
+    end
+
+    it 'does store the answer on the session' do
+      fill_in('wizard_steps_customs_value[monetary_value]', with: '1_200')
+
+      click_on('Continue')
+
+      expect(Capybara.current_session.driver.request.session[Wizard::Steps::CustomsValue.id]).to eq(expected_value)
+    end
+
+    it 'does not lose its session key when going back to the previous question' do
+      fill_in('wizard_steps_customs_value[monetary_value]', with: '1_200')
+
+      click_on('Continue')
+
+      visit planned_processing_path(commodity_code: commodity_code, service_choice: service_choice)
+
+      expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::CustomsValue.id)).to be true
+    end
+
+    it 'redirects to measure_amount_path' do
+      fill_in('wizard_steps_customs_value[monetary_value]', with: '1_200')
+
+      click_on('Continue')
+
+      expect(page).to have_current_path(measure_amount_path(service_choice: service_choice, commodity_code: commodity_code))
+    end
+  end
+end

--- a/spec/models/wizard/steps/country_of_origin_spec.rb
+++ b/spec/models/wizard/steps/country_of_origin_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
     it 'returns the correct list of steps' do
       expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(
         %w[
-          customs_value
           trader_scheme
           final_use
           certificate_of_origin

--- a/spec/models/wizard/steps/customs_value_spec.rb
+++ b/spec/models/wizard/steps/customs_value_spec.rb
@@ -248,22 +248,57 @@ RSpec.describe Wizard::Steps::CustomsValue do
     let(:service_choice) { 'uk' }
     let(:commodity_code) { '1233455' }
 
-    it 'returns country_of_origin_path' do
-      expect(
-        step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
-      ).to eq(
-        country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
-      )
+    context 'when on GB to NI route' do
+      before do
+        allow(user_session).to receive(:gb_to_ni_route?).and_return(true)
+      end
+
+      context 'when there is a trade defence' do
+        let(:session) do
+          {
+            'trade_defence' => true,
+          }
+        end
+
+        it 'returns trade_remedies_path' do
+          expect(
+            step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          ).to eq(
+            trade_remedies_path(service_choice: service_choice, commodity_code: commodity_code),
+          )
+        end
+      end
+
+      context 'when there is no trade defence, and the certificate of origin answer is NO' do
+        let(:session) do
+          {
+            'certificate_of_origin' => 'no',
+          }
+        end
+
+        it 'returns trade_remedies_path' do
+          expect(
+            step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          ).to eq(
+            certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
+          )
+        end
+      end
     end
   end
 
-  xdescribe '#next_step_path' do
+  describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
     let(:service_choice) { 'uk' }
     let(:commodity_code) { '1233455' }
 
-    it 'must be implemented' do
+    it 'returns measure_amount_path' do
+      expect(
+        step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+      ).to eq(
+        measure_amount_path(service_choice: service_choice, commodity_code: commodity_code),
+      )
     end
   end
 end

--- a/spec/models/wizard/steps/customs_value_spec.rb
+++ b/spec/models/wizard/steps/customs_value_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe Wizard::Steps::CustomsValue do
           }
         end
 
-        it 'returns trade_remedies_path' do
+        it 'returns certificate_of_origin_path' do
           expect(
             step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
           ).to eq(

--- a/spec/models/wizard/steps/final_use_spec.rb
+++ b/spec/models/wizard/steps/final_use_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Wizard::Steps::FinalUse do
       expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(
         %w[
           certificate_of_origin
-          customs_value
           planned_processing
         ],
       )

--- a/spec/models/wizard/steps/import_date_spec.rb
+++ b/spec/models/wizard/steps/import_date_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Wizard::Steps::ImportDate do
         %w[
           import_destination
           country_of_origin
-          customs_value
           trader_scheme
           final_use
           certificate_of_origin

--- a/spec/models/wizard/steps/import_destination_spec.rb
+++ b/spec/models/wizard/steps/import_destination_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Wizard::Steps::ImportDestination do
       expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(
         %w[
           country_of_origin
-          customs_value
           trader_scheme
           final_use
           certificate_of_origin

--- a/spec/models/wizard/steps/trader_scheme_spec.rb
+++ b/spec/models/wizard/steps/trader_scheme_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Wizard::Steps::TraderScheme do
         %w[
           final_use
           certificate_of_origin
-          customs_value
           planned_processing
         ],
       )


### PR DESCRIPTION
### Jira link

HOTT-517

### What?

Also do not remove the session keys for the following:
- customs value page
- measure amount page
when going back to previous steps.

Reason: Users will have to fill in a few fields on these pages,
and going back to previous steps should not force them to fill
in these fields over and over again.