### PR TITLE
Adds cache-control header globally

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action :expires_now
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      render plain: 'Hari Seldon'
+    end
+  end
+
+  before do
+    get :index
+  end
+
+  let(:expected_cache_control) { 'no-cache' }
+
+  it 'has the correct Cache-Control header' do
+    expect(response.headers['Cache-Control']).to eq(expected_cache_control)
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe ApplicationController, type: :controller do
     get :index
   end
 
-  let(:expected_cache_control) { 'no-cache' }
-
   it 'has the correct Cache-Control header' do
-    expect(response.headers['Cache-Control']).to eq(expected_cache_control)
+    get :index
+
+    expect(response.headers['Cache-Control']).to eq('no-cache')
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds Cache-Control: no-cache header globally

### Why?

I am doing this because:

- We don't want the CDN to cache our duty calculator responses
