### PR TITLE
Hott 526 routing change

### DIFF
--- a/app/controllers/wizard/steps/base_controller.rb
+++ b/app/controllers/wizard/steps/base_controller.rb
@@ -30,21 +30,18 @@ module Wizard
         if step.valid?
           step.save
 
-          redirect_to step.next_step_path(
-            service_choice: params[:service_choice],
-            commodity_code: params[:commodity_code],
-          )
+          redirect_to step.next_step_path
         else
           render 'show'
         end
       end
 
       def commodity_code
-        params[:commodity_code]
+        params[:commodity_code] || user_session.commodity_code
       end
 
       def service_choice
-        params[:service_choice].to_sym
+        (params[:service_choice] || user_session.service_choice).to_sym
       end
     end
   end

--- a/app/controllers/wizard/steps/base_controller.rb
+++ b/app/controllers/wizard/steps/base_controller.rb
@@ -3,18 +3,18 @@ module Wizard
     class BaseController < ::ApplicationController
       default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
-      helper_method :commodity, :commodity_code, :service_choice
+      helper_method :commodity, :commodity_code, :commodity_source
 
       def commodity
         @commodity ||= Api::Commodity.build(
-          service_choice,
+          commodity_source,
           commodity_code,
         )
       end
 
-      def filtered_commodity(service_source:, filter:)
+      def filtered_commodity(commodity_source:, filter:)
         Api::Commodity.build(
-          service_source,
+          commodity_source,
           commodity_code,
           filter,
         )
@@ -40,8 +40,8 @@ module Wizard
         params[:commodity_code] || user_session.commodity_code
       end
 
-      def service_choice
-        (params[:service_choice] || user_session.service_choice).to_sym
+      def commodity_source
+        (params[:referred_service] || user_session.commodity_source).to_sym
       end
     end
   end

--- a/app/controllers/wizard/steps/country_of_origin_controller.rb
+++ b/app/controllers/wizard/steps/country_of_origin_controller.rb
@@ -20,7 +20,7 @@ module Wizard
       end
 
       def opts
-        return opts_for_ni_to_gb_route if answer == 'GB' && user_session.import_destination == 'XI'
+        return opts_for_ni_to_gb_route if %w[GB XU].include?(answer) && user_session.import_destination == 'XI'
 
         {}
       end
@@ -36,7 +36,7 @@ module Wizard
       def opts_for_ni_to_gb_route
         {
           trade_defence: commodity.trade_defence,
-          zero_mfn_duty: filtered_commodity(service_source: :xi, filter: geographical_area_id_filter).zero_mfn_duty,
+          zero_mfn_duty: filtered_commodity(commodity_source: :xi, filter: geographical_area_id_filter).zero_mfn_duty,
         }
       end
     end

--- a/app/controllers/wizard/steps/country_of_origin_controller.rb
+++ b/app/controllers/wizard/steps/country_of_origin_controller.rb
@@ -20,7 +20,7 @@ module Wizard
       end
 
       def opts
-        return opts_for_ni_to_gb_route if %w[GB XU].include?(answer) && user_session.import_destination == 'XI'
+        return opts_for_ni_to_gb_route if answer == 'GB' && user_session.import_destination == 'XI'
 
         {}
       end

--- a/app/controllers/wizard/steps/import_date_controller.rb
+++ b/app/controllers/wizard/steps/import_date_controller.rb
@@ -3,6 +3,9 @@ module Wizard
     class ImportDateController < BaseController
       def show
         @step = Wizard::Steps::ImportDate.new(user_session)
+
+        user_session.commodity_code = commodity_code
+        user_session.service_choice = service_choice
       end
 
       def create

--- a/app/controllers/wizard/steps/import_date_controller.rb
+++ b/app/controllers/wizard/steps/import_date_controller.rb
@@ -5,7 +5,11 @@ module Wizard
         @step = Wizard::Steps::ImportDate.new(user_session)
 
         user_session.commodity_code = commodity_code
-        user_session.service_choice = service_choice
+
+        if params[:referred_service].present?
+          user_session.referred_service = params[:referred_service]
+          user_session.commodity_source = params[:referred_service]
+        end
       end
 
       def create

--- a/app/decorators/confirmation_decorator.rb
+++ b/app/decorators/confirmation_decorator.rb
@@ -17,8 +17,8 @@ class ConfirmationDecorator < SimpleDelegator
     @commodity = commodity
   end
 
-  def path_for(key:, commodity_code:, service_choice:)
-    send("#{key}_path", commodity_code: commodity_code, service_choice: service_choice)
+  def path_for(key:)
+    send("#{key}_path")
   end
 
   def user_answers

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -28,8 +28,10 @@ module ServiceHelper
   end
 
   def service_choice_url
-    return '' if params[:service_choice] == 'uk'
+    service_choice == 'uk' ? '' : service_choice.to_s
+  end
 
-    params[:service_choice]
+  def service_choice
+    params[:service_choice] || session['service_choice']
   end
 end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -20,18 +20,18 @@ module ServiceHelper
   def service_url_for(relative_path)
     return '#' if trade_tariff_frontend_url.blank?
 
-    File.join(trade_tariff_frontend_url, service_choice_url, relative_path)
+    File.join(trade_tariff_frontend_url, referred_service_url, relative_path)
   end
 
   def trade_tariff_frontend_url
     @trade_tariff_frontend_url ||= Rails.configuration.trade_tariff_frontend_url
   end
 
-  def service_choice_url
-    service_choice == 'uk' ? '' : service_choice.to_s
+  def referred_service_url
+    referred_service == 'uk' ? '' : referred_service.to_s
   end
 
-  def service_choice
-    params[:service_choice] || session['service_choice']
+  def referred_service
+    params[:referred_service] || session['referred_service']
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -92,12 +92,20 @@ class UserSession
     }
   end
 
-  def service_choice=(value)
-    session['service_choice'] = value
+  def commodity_source=(value)
+    session['commodity_source'] = value
   end
 
-  def service_choice
-    session['service_choice']
+  def commodity_source
+    session['commodity_source']
+  end
+
+  def referred_service=(value)
+    session['referred_service'] = value
+  end
+
+  def referred_service
+    session['referred_service']
   end
 
   def commodity_code=(value)

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -92,6 +92,22 @@ class UserSession
     }
   end
 
+  def service_choice=(value)
+    session['service_choice'] = value
+  end
+
+  def service_choice
+    session['service_choice']
+  end
+
+  def commodity_code=(value)
+    session['commodity_code'] = value
+  end
+
+  def commodity_code
+    session['commodity_code']
+  end
+
   def measure_amount=(values)
     session['answers'][Wizard::Steps::MeasureAmount.id] = values
   end

--- a/app/models/wizard/steps/base.rb
+++ b/app/models/wizard/steps/base.rb
@@ -21,11 +21,11 @@ module Wizard
 
       protected
 
-      def next_step_path(*)
+      def next_step_path
         raise NotImplementedError
       end
 
-      def previous_step_path(*)
+      def previous_step_path
         raise NotImplementedError
       end
 

--- a/app/models/wizard/steps/certificate_of_origin.rb
+++ b/app/models/wizard/steps/certificate_of_origin.rb
@@ -20,17 +20,17 @@ module Wizard
         user_session.certificate_of_origin = certificate_of_origin
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        return duty_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.certificate_of_origin == 'yes'
+      def next_step_path
+        return duty_path if user_session.certificate_of_origin == 'yes'
 
-        customs_value_path(service_choice: service_choice, commodity_code: commodity_code)
+        customs_value_path
       end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        return planned_processing_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.planned_processing == 'commercial_purposes'
-        return final_use_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.final_use == 'no'
+      def previous_step_path
+        return planned_processing_path if user_session.planned_processing == 'commercial_purposes'
+        return final_use_path if user_session.final_use == 'no'
 
-        trader_scheme_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.trader_scheme == 'no'
+        trader_scheme_path if user_session.trader_scheme == 'no'
       end
     end
   end

--- a/app/models/wizard/steps/confirmation.rb
+++ b/app/models/wizard/steps/confirmation.rb
@@ -3,10 +3,10 @@ module Wizard
     class Confirmation < Wizard::Steps::Base
       STEPS_TO_REMOVE_FROM_SESSION = %w[].freeze
 
-      def next_step_path(service_choice:, commodity_code:); end
+      def next_step_path; end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        return measure_amount_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+      def previous_step_path
+        return measure_amount_path if user_session.gb_to_ni_route?
       end
     end
   end

--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -35,23 +35,23 @@ module Wizard
         Api::GeographicalArea.list_countries(service.to_sym)
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        return duty_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.ni_to_gb_route? || user_session.eu_to_ni_route?
+      def next_step_path
+        return duty_path if user_session.ni_to_gb_route? || user_session.eu_to_ni_route?
 
-        return next_step_for_gb_to_ni(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+        return next_step_for_gb_to_ni if user_session.gb_to_ni_route?
       end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        import_destination_path(service_choice: service_choice, commodity_code: commodity_code)
+      def previous_step_path
+        import_destination_path
       end
 
       private
 
-      def next_step_for_gb_to_ni(service_choice:, commodity_code:)
-        return trade_remedies_path(service_choice: service_choice, commodity_code: commodity_code) if trade_defence
-        return duty_path(service_choice: service_choice, commodity_code: commodity_code) if zero_mfn_duty
+      def next_step_for_gb_to_ni
+        return trade_remedies_path if trade_defence
+        return duty_path if zero_mfn_duty
 
-        trader_scheme_path(service_choice: service_choice, commodity_code: commodity_code)
+        trader_scheme_path
       end
     end
   end

--- a/app/models/wizard/steps/customs_value.rb
+++ b/app/models/wizard/steps/customs_value.rb
@@ -32,20 +32,20 @@ module Wizard
         }
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        measure_amount_path(service_choice: service_choice, commodity_code: commodity_code)
+      def next_step_path
+        measure_amount_path
       end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        return previous_step_for_gb_to_ni(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+      def previous_step_path
+        return previous_step_for_gb_to_ni if user_session.gb_to_ni_route?
       end
 
       private
 
-      def previous_step_for_gb_to_ni(service_choice:, commodity_code:)
-        return trade_remedies_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.trade_defence
+      def previous_step_for_gb_to_ni
+        return trade_remedies_path if user_session.trade_defence
 
-        certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code)
+        certificate_of_origin_path
       end
     end
   end

--- a/app/models/wizard/steps/final_use.rb
+++ b/app/models/wizard/steps/final_use.rb
@@ -23,13 +23,13 @@ module Wizard
         user_session.final_use = final_use
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        return planned_processing_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.final_use == 'yes'
-        return certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+      def next_step_path
+        return planned_processing_path if user_session.final_use == 'yes'
+        return certificate_of_origin_path if user_session.gb_to_ni_route?
       end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        trader_scheme_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+      def previous_step_path
+        trader_scheme_path if user_session.gb_to_ni_route?
       end
     end
   end

--- a/app/models/wizard/steps/import_date.rb
+++ b/app/models/wizard/steps/import_date.rb
@@ -34,8 +34,8 @@ module Wizard
         user_session.import_date = input_date.strftime('%Y-%m-%d')
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        import_destination_path(service_choice: service_choice, commodity_code: commodity_code)
+      def next_step_path
+        import_destination_path
       end
 
     private

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -24,6 +24,8 @@ module Wizard
 
       def save
         user_session.import_destination = import_destination
+
+        update_commodity_source
       end
 
       def next_step_path
@@ -32,6 +34,12 @@ module Wizard
 
       def previous_step_path
         import_date_path
+      end
+
+      private
+
+      def update_commodity_source
+        user_session.commodity_source = (import_destination == 'XI' ? 'xi' : 'uk')
       end
     end
   end

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -26,12 +26,12 @@ module Wizard
         user_session.import_destination = import_destination
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code)
+      def next_step_path
+        country_of_origin_path
       end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        import_date_path(service_choice: service_choice, commodity_code: commodity_code)
+      def previous_step_path
+        import_date_path
       end
     end
   end

--- a/app/models/wizard/steps/measure_amount.rb
+++ b/app/models/wizard/steps/measure_amount.rb
@@ -51,12 +51,12 @@ module Wizard
         user_session.measure_amount = answers if answers.present?
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        confirm_path(service_choice: service_choice, commodity_code: commodity_code)
+      def next_step_path
+        confirm_path
       end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        customs_value_path(service_choice: service_choice, commodity_code: commodity_code)
+      def previous_step_path
+        customs_value_path
       end
 
       def self.id

--- a/app/models/wizard/steps/planned_processing.rb
+++ b/app/models/wizard/steps/planned_processing.rb
@@ -27,20 +27,20 @@ module Wizard
         user_session.planned_processing = planned_processing
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        return next_step_for_gb_to_ni(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+      def next_step_path
+        return next_step_for_gb_to_ni if user_session.gb_to_ni_route?
       end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        final_use_path(service_choice: service_choice, commodity_code: commodity_code)
+      def previous_step_path
+        final_use_path
       end
 
       private
 
-      def next_step_for_gb_to_ni(service_choice:, commodity_code:)
-        return duty_path(service_choice: service_choice, commodity_code: commodity_code) unless user_session.planned_processing == 'commercial_purposes'
+      def next_step_for_gb_to_ni
+        return duty_path unless user_session.planned_processing == 'commercial_purposes'
 
-        certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code)
+        certificate_of_origin_path
       end
     end
   end

--- a/app/models/wizard/steps/trader_scheme.rb
+++ b/app/models/wizard/steps/trader_scheme.rb
@@ -24,13 +24,13 @@ module Wizard
         user_session.trader_scheme = trader_scheme
       end
 
-      def next_step_path(service_choice:, commodity_code:)
-        return final_use_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.trader_scheme == 'yes'
-        return certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+      def next_step_path
+        return final_use_path if user_session.trader_scheme == 'yes'
+        return certificate_of_origin_path if user_session.gb_to_ni_route?
       end
 
-      def previous_step_path(service_choice:, commodity_code:)
-        country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.gb_to_ni_route?
+      def previous_step_path
+        country_of_origin_path if user_session.gb_to_ni_route?
       end
     end
   end

--- a/app/views/pages/trade_remedies.html.erb
+++ b/app/views/pages/trade_remedies.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', country_of_origin_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', country_of_origin_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">
@@ -9,5 +9,5 @@
       <p class="govuk-body">Click on the 'Continue' button to enter the monetary value of your import, to help to calculate the applicable import duties.</p>
     </div>
   </div>
-  <%= link_to('Continue', customs_value_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: 'govuk-button') %>
+  <%= link_to('Continue', customs_value_path, class: 'govuk-button') %>
 </main>

--- a/app/views/wizard/steps/certificate_of_origin/show.html.erb
+++ b/app/views/wizard/steps/certificate_of_origin/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">

--- a/app/views/wizard/steps/confirmation/_entry.html.erb
+++ b/app/views/wizard/steps/confirmation/_entry.html.erb
@@ -2,6 +2,6 @@
   <dt class="govuk-summary-list__key"><%= entry[:label] %></dt>
   <dd class="govuk-summary-list__value"><%= entry[:value] %></dd>
   <dd class="govuk-summary-list__actions">
-    <%= link_to('Change', @decorated_step.path_for(key: entry[:key], commodity_code: commodity_code, service_choice: service_choice), class: 'govuk-link') %>
+    <%= link_to('Change', @decorated_step.path_for(key: entry[:key]), class: 'govuk-link') %>
   </dd>
 </div>

--- a/app/views/wizard/steps/confirmation/show.html.erb
+++ b/app/views/wizard/steps/confirmation/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @decorated_step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @decorated_step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">

--- a/app/views/wizard/steps/country_of_origin/show.html.erb
+++ b/app/views/wizard/steps/country_of_origin/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">
@@ -16,7 +16,7 @@
             <div id="destination-hint" class="govuk-hint">
               The duty you are charged may be dependent on the country of dispatch of the goods being imported.
             </div>
-            <%= f.govuk_collection_select :country_of_origin, Wizard::Steps::CountryOfOrigin.options_for(params[:service_choice]), :id, :name, options: { prompt: true }, label: { text: 'Enter the country of dispatch:' } %>
+            <%= f.govuk_collection_select :country_of_origin, Wizard::Steps::CountryOfOrigin.options_for(service_choice), :id, :name, options: { prompt: true }, label: { text: 'Enter the country of dispatch:' } %>
             <p class="govuk-!-margin-top-3 govuk-hint">When autocomplete results are available, use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.</p>
           </div>
           <%= f.govuk_submit %>

--- a/app/views/wizard/steps/country_of_origin/show.html.erb
+++ b/app/views/wizard/steps/country_of_origin/show.html.erb
@@ -16,7 +16,7 @@
             <div id="destination-hint" class="govuk-hint">
               The duty you are charged may be dependent on the country of dispatch of the goods being imported.
             </div>
-            <%= f.govuk_collection_select :country_of_origin, Wizard::Steps::CountryOfOrigin.options_for(service_choice), :id, :name, options: { prompt: true }, label: { text: 'Enter the country of dispatch:' } %>
+            <%= f.govuk_collection_select :country_of_origin, Wizard::Steps::CountryOfOrigin.options_for(commodity_source), :id, :name, options: { prompt: true }, label: { text: 'Enter the country of dispatch:' } %>
             <p class="govuk-!-margin-top-3 govuk-hint">When autocomplete results are available, use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.</p>
           </div>
           <%= f.govuk_submit %>

--- a/app/views/wizard/steps/customs_value/show.html.erb
+++ b/app/views/wizard/steps/customs_value/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">

--- a/app/views/wizard/steps/duty/gb_to_ni/_no_duty.html.erb
+++ b/app/views/wizard/steps/duty/gb_to_ni/_no_duty.html.erb
@@ -30,4 +30,4 @@
   <%= render('wizard/steps/duty/gb_to_ni/shared/note') %>
 <% end %>
 
-<%= link_to('Start again', import_date_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: 'govuk-button') %>
+<%= link_to('Start again', import_date_path, class: 'govuk-button') %>

--- a/app/views/wizard/steps/final_use/show.html.erb
+++ b/app/views/wizard/steps/final_use/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">

--- a/app/views/wizard/steps/import_destination/show.html.erb
+++ b/app/views/wizard/steps/import_destination/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">

--- a/app/views/wizard/steps/measure_amount/show.html.erb
+++ b/app/views/wizard/steps/measure_amount/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">

--- a/app/views/wizard/steps/planned_processing/show.html.erb
+++ b/app/views/wizard/steps/planned_processing/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">

--- a/app/views/wizard/steps/trader_scheme/show.html.erb
+++ b/app/views/wizard/steps/trader_scheme/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  scope path: '/:service_choice/duty-calculator/:commodity_code' do
+  scope path: '/duty-calculator/' do
     get 'import-date', to: 'wizard/steps/import_date#show'
     post 'import-date', to: 'wizard/steps/import_date#create'
 

--- a/spec/decorators/confirmation_decorator_spec.rb
+++ b/spec/decorators/confirmation_decorator_spec.rb
@@ -147,10 +147,8 @@ RSpec.describe ConfirmationDecorator do
       expect(
         confirmation_decorator.path_for(
           key: 'import_date',
-          commodity_code: '1111111111',
-          service_choice: 'uk',
         ),
-      ).to eq('/uk/duty-calculator/1111111111/import-date')
+      ).to eq('/duty-calculator/import-date')
     end
   end
 end

--- a/spec/decorators/confirmation_decorator_spec.rb
+++ b/spec/decorators/confirmation_decorator_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe ConfirmationDecorator do
 
   let(:commodity) { double(Uktt::Commodity) }
   let(:commodity_code) { '1234567890' }
-  let(:service_choice) { 'uk' }
+  let(:commodity_source) { 'uk' }
   let(:user_session) { UserSession.new(session) }
   let(:session) { {} }
 
   before do
     allow(commodity).to receive(:code).and_return(commodity_code)
-    allow(Api::Commodity).to receive(:build).with(service_choice.to_sym, commodity_code).and_return(commodity)
+    allow(Api::Commodity).to receive(:build).with(commodity_source.to_sym, commodity_code).and_return(commodity)
   end
 
   describe 'ORDERED_STEPS' do

--- a/spec/features/certificate_of_origin_page_spec.rb
+++ b/spec/features/certificate_of_origin_page_spec.rb
@@ -32,19 +32,9 @@ RSpec.describe 'Certificate of Origin Page', type: :feature do
 
       click_on('Continue')
 
-      visit planned_processing_path(commodity_code: commodity_code, service_choice: service_choice)
+      visit planned_processing_path
 
       expect(Capybara.current_session.driver.request.session['answers'].key?(Wizard::Steps::CertificateOfOrigin.id)).to be false
-    end
-
-    context 'when no trade trade defence and non zero duty and no certificate of origin' do
-      it 'redirects to customs_value_path' do
-        choose(option: 'no')
-
-        click_on('Continue')
-
-        expect(page).to have_current_path(customs_value_path(service_choice: service_choice, commodity_code: commodity_code))
-      end
     end
   end
 end

--- a/spec/features/country_of_origin_page_spec.rb
+++ b/spec/features/country_of_origin_page_spec.rb
@@ -43,46 +43,4 @@ RSpec.describe 'Country of Origin Page', type: :feature do
 
     expect(Capybara.current_session.driver.request.session['answers'].key?(Wizard::Steps::CountryOfOrigin.id)).to be false
   end
-
-  context 'when importing from NI to GB' do
-    it 'redirects to duty path' do
-      select('United Kingdom (Northern Ireland)', from: 'wizard_steps_country_of_origin[country_of_origin]')
-
-      click_on('Continue')
-
-      expect(page).to have_current_path(duty_path(service_choice: service_choice, commodity_code: commodity_code))
-    end
-  end
-
-  context 'when importing from GB to NI, with no trade trade defence and non zero duty' do
-    let(:import_into) { 'XI' }
-    let(:import_from) { 'GB' }
-
-    let(:filter) do
-      {
-        'filter[geographical_area_id]' => import_from,
-      }
-    end
-
-    let(:commodity) { double(Uktt::Commodity) }
-    let(:filtered_commodity) { double(Uktt::Commodity) }
-    let(:description) { 'Some description' }
-
-    before do
-      allow(commodity).to receive(:trade_defence).and_return(false)
-      allow(commodity).to receive(:code).and_return(commodity_code)
-      allow(commodity).to receive(:description).and_return(description)
-      allow(filtered_commodity).to receive(:zero_mfn_duty).and_return(false)
-      allow(Api::Commodity).to receive(:build).with(service_choice.to_sym, commodity_code).and_return(commodity)
-      allow(Api::Commodity).to receive(:build).with(:xi, commodity_code, filter).and_return(filtered_commodity)
-    end
-
-    it 'redirects to trader_scheme_path' do
-      select('United Kingdom', from: 'wizard_steps_country_of_origin[country_of_origin]')
-
-      click_on('Continue')
-
-      expect(page).to have_current_path(trader_scheme_path(service_choice: service_choice, commodity_code: commodity_code))
-    end
-  end
 end

--- a/spec/features/country_of_origin_page_spec.rb
+++ b/spec/features/country_of_origin_page_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Country of Origin Page', type: :feature do
   let(:commodity_code) { '1234567890' }
-  let(:service_choice) { 'uk' }
+  let(:referred_service) { 'uk' }
   let(:import_into) { 'GB' }
 
   before do
-    visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
+    visit import_date_path(commodity_code: commodity_code, referred_service: referred_service)
 
     fill_in('wizard_steps_import_date[import_date(3i)]', with: '12')
     fill_in('wizard_steps_import_date[import_date(2i)]', with: '12')

--- a/spec/features/customs_value_page_spec.rb
+++ b/spec/features/customs_value_page_spec.rb
@@ -39,17 +39,9 @@ RSpec.describe 'Customs Value Page', type: :feature do
 
       click_on('Continue')
 
-      visit planned_processing_path(commodity_code: commodity_code, service_choice: service_choice)
+      visit planned_processing_path
 
       expect(Capybara.current_session.driver.request.session['answers'].key?(Wizard::Steps::CustomsValue.id)).to be true
-    end
-
-    it 'redirects to measure_amount_path' do
-      fill_in('wizard_steps_customs_value[monetary_value]', with: '1_200')
-
-      click_on('Continue')
-
-      expect(page).to have_current_path(measure_amount_path(service_choice: service_choice, commodity_code: commodity_code))
     end
   end
 end

--- a/spec/features/final_use_page_spec.rb
+++ b/spec/features/final_use_page_spec.rb
@@ -32,15 +32,5 @@ RSpec.describe 'Final Use Page', type: :feature do
 
       expect(Capybara.current_session.driver.request.session['answers'].key?(Wizard::Steps::FinalUse.id)).to be false
     end
-
-    context 'when importing from GB to NI, with no trade trade defence and non zero duty' do
-      it 'redirects to planned_processing_path' do
-        choose(option: 'yes')
-
-        click_on('Continue')
-
-        expect(page).to have_current_path(planned_processing_path(service_choice: service_choice, commodity_code: commodity_code))
-      end
-    end
   end
 end

--- a/spec/features/import_date_page_spec.rb
+++ b/spec/features/import_date_page_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Import Date Page', type: :feature do
   let(:commodity_code) { '1234567890' }
-  let(:service_choice) { 'uk' }
+  let(:referred_service) { 'uk' }
 
   it 'does not store an invalid import date on the session' do
-    visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
+    visit import_date_path(commodity_code: commodity_code, referred_service: referred_service)
 
     fill_in('wizard_steps_import_date[import_date(3i)]', with: '12')
     fill_in('wizard_steps_import_date[import_date(2i)]', with: '12')
@@ -17,7 +17,7 @@ RSpec.describe 'Import Date Page', type: :feature do
   end
 
   it 'does store a invalid import date on the session' do
-    visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
+    visit import_date_path(commodity_code: commodity_code, referred_service: referred_service)
 
     fill_in('wizard_steps_import_date[import_date(3i)]', with: '12')
     fill_in('wizard_steps_import_date[import_date(2i)]', with: '12')

--- a/spec/features/import_date_page_spec.rb
+++ b/spec/features/import_date_page_spec.rb
@@ -27,16 +27,4 @@ RSpec.describe 'Import Date Page', type: :feature do
 
     expect(Capybara.current_session.driver.request.session['answers'][Wizard::Steps::ImportDate.id]).to eq('3000-12-12')
   end
-
-  it 'redirects to import destination page if the validation is successful' do
-    visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
-
-    fill_in('wizard_steps_import_date[import_date(3i)]', with: '12')
-    fill_in('wizard_steps_import_date[import_date(2i)]', with: '12')
-    fill_in('wizard_steps_import_date[import_date(1i)]', with: '3000')
-
-    click_on('Continue')
-
-    expect(page).to have_current_path(import_destination_path(commodity_code: commodity_code, service_choice: service_choice))
-  end
 end

--- a/spec/features/import_destination_page_spec.rb
+++ b/spec/features/import_destination_page_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Import Destination Page', type: :feature do
   let(:commodity_code) { '1234567890' }
-  let(:service_choice) { 'uk' }
+  let(:referred_service) { 'uk' }
 
   before do
-    visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
+    visit import_date_path(commodity_code: commodity_code, referred_service: referred_service)
 
     fill_in('wizard_steps_import_date[import_date(3i)]', with: '12')
     fill_in('wizard_steps_import_date[import_date(2i)]', with: '12')

--- a/spec/features/measure_amount_page_spec.rb
+++ b/spec/features/measure_amount_page_spec.rb
@@ -67,17 +67,9 @@ RSpec.describe 'Measure Amount Page', type: :feature do
 
       click_on('Continue')
 
-      visit planned_processing_path(commodity_code: commodity_code, service_choice: service_choice)
+      visit planned_processing_path
 
       expect(Capybara.current_session.driver.request.session['answers'].key?(Wizard::Steps::MeasureAmount.id)).to be true
-    end
-
-    it 'redirects to measure_amount_path' do
-      fill_in('wizard_steps_measure_amount[dtn]', with: '1_200')
-
-      click_on('Continue')
-
-      expect(page).to have_current_path(confirm_path(service_choice: service_choice, commodity_code: commodity_code))
     end
   end
 end

--- a/spec/features/planned_processing_page_spec.rb
+++ b/spec/features/planned_processing_page_spec.rb
@@ -31,19 +31,9 @@ RSpec.describe 'Planned Processing Page', type: :feature do
 
       click_on('Continue')
 
-      visit final_use_path(commodity_code: commodity_code, service_choice: service_choice)
+      visit final_use_path
 
       expect(Capybara.current_session.driver.request.session['answers'].key?(Wizard::Steps::PlannedProcessing.id)).to be false
-    end
-
-    context 'when no trade trade defence and non zero duty' do
-      it 'redirects to planned_processing_path' do
-        choose(option: 'commercial_purposes')
-
-        click_on('Continue')
-
-        expect(page).to have_current_path(certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code))
-      end
     end
   end
 end

--- a/spec/features/trade_remedies_page_spec.rb
+++ b/spec/features/trade_remedies_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Trade Remedies Page', type: :feature do
     it 'redirects to customs_value_path' do
       click_on('Continue')
 
-      expect(page).to have_current_path(customs_value_path(service_choice: service_choice, commodity_code: commodity_code))
+      expect(page).to have_current_path(customs_value_path)
     end
   end
 end

--- a/spec/features/trader_scheme_page_spec.rb
+++ b/spec/features/trader_scheme_page_spec.rb
@@ -21,19 +21,9 @@ RSpec.describe 'Trader Scheme Page', type: :feature do
 
       click_on('Continue')
 
-      visit country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code)
+      visit country_of_origin_path
 
       expect(Capybara.current_session.driver.request.session['answers'].key?(Wizard::Steps::TraderScheme.id)).to be false
-    end
-
-    context 'when importing from GB to NI, with no trade trade defence and non zero duty' do
-      it 'redirects to final_use_path' do
-        choose(option: 'yes')
-
-        click_on('Continue')
-
-        expect(page).to have_current_path(final_use_path(service_choice: service_choice, commodity_code: commodity_code))
-      end
     end
   end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe ServiceHelper do
 
   let(:params) do
     ActionController::Parameters.new(
-      service_choice: service,
-    ).permit(:service_choice)
+      referred_service: service,
+    ).permit(:referred_service)
   end
 
   let(:service) { 'uk' }

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -247,6 +247,14 @@ RSpec.describe Wizard::Steps::UserSession do
     end
   end
 
+  describe '#trade_defence=' do
+    it 'sets the key on the session' do
+      user_session.trade_defence = true
+
+      expect(session['trade_defence']).to eq(true)
+    end
+  end
+
   describe '#zero_mfn_duty=' do
     it 'sets the key on the session' do
       user_session.zero_mfn_duty = true
@@ -270,14 +278,6 @@ RSpec.describe Wizard::Steps::UserSession do
       it 'returns the value from the session' do
         expect(user_session.zero_mfn_duty).to eq(true)
       end
-    end
-  end
-
-  describe '#trade_defence=' do
-    it 'sets the key on the session' do
-      user_session.trade_defence = true
-
-      expect(session['trade_defence']).to eq(true)
     end
   end
 
@@ -372,6 +372,58 @@ RSpec.describe Wizard::Steps::UserSession do
       user_session.measure_amount = value
 
       expect(session['answers'][Wizard::Steps::MeasureAmount.id]).to eq(value)
+    end
+  end
+
+  describe '#commodity_code' do
+    it 'returns nil if the key is not on the session' do
+      expect(user_session.commodity_code).to be nil
+    end
+
+    context 'when the key is present on the session' do
+      let(:session) do
+        {
+          'commodity_code' => '1111111111',
+        }
+      end
+
+      it 'returns the value from the session' do
+        expect(user_session.commodity_code).to eq('1111111111')
+      end
+    end
+  end
+
+  describe '#commodity_code=' do
+    it 'sets the key on the session' do
+      user_session.commodity_code = '1111111111'
+
+      expect(session['commodity_code']).to eq('1111111111')
+    end
+  end
+
+  describe '#service_choice' do
+    it 'returns nil if the key is not on the session' do
+      expect(user_session.service_choice).to be nil
+    end
+
+    context 'when the key is present on the session' do
+      let(:session) do
+        {
+          'service_choice' => 'uk',
+        }
+      end
+
+      it 'returns the value from the session' do
+        expect(user_session.service_choice).to eq('uk')
+      end
+    end
+  end
+
+  describe '#service_choice=' do
+    it 'sets the key on the session' do
+      user_session.service_choice = 'uk'
+
+      expect(session['service_choice']).to eq('uk')
     end
   end
 

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -401,29 +401,55 @@ RSpec.describe Wizard::Steps::UserSession do
     end
   end
 
-  describe '#service_choice' do
+  describe '#commodity_source' do
     it 'returns nil if the key is not on the session' do
-      expect(user_session.service_choice).to be nil
+      expect(user_session.commodity_source).to be nil
     end
 
     context 'when the key is present on the session' do
       let(:session) do
         {
-          'service_choice' => 'uk',
+          'commodity_source' => 'uk',
         }
       end
 
       it 'returns the value from the session' do
-        expect(user_session.service_choice).to eq('uk')
+        expect(user_session.commodity_source).to eq('uk')
       end
     end
   end
 
-  describe '#service_choice=' do
+  describe '#commodity_source=' do
     it 'sets the key on the session' do
-      user_session.service_choice = 'uk'
+      user_session.commodity_source = 'uk'
 
-      expect(session['service_choice']).to eq('uk')
+      expect(session['commodity_source']).to eq('uk')
+    end
+  end
+
+  describe '#referred_service' do
+    it 'returns nil if the key is not on the session' do
+      expect(user_session.referred_service).to be nil
+    end
+
+    context 'when the key is present on the session' do
+      let(:session) do
+        {
+          'referred_service' => 'uk',
+        }
+      end
+
+      it 'returns the value from the session' do
+        expect(user_session.referred_service).to eq('uk')
+      end
+    end
+  end
+
+  describe '#referred_service=' do
+    it 'sets the key on the session' do
+      user_session.referred_service = 'uk'
+
+      expect(session['referred_service']).to eq('uk')
     end
   end
 

--- a/spec/models/wizard/steps/certificate_of_origin_spec.rb
+++ b/spec/models/wizard/steps/certificate_of_origin_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Wizard::Steps::CertificateOfOrigin do
 
   let(:session) { {} }
   let(:user_session) { UserSession.new(session) }
-  let(:service_choice) { 'uk' }
-  let(:commodity_code) { '1233455' }
   let(:attributes) do
     ActionController::Parameters.new(
       certificate_of_origin: '',
@@ -81,9 +79,9 @@ RSpec.describe Wizard::Steps::CertificateOfOrigin do
 
       it 'returns duty_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          duty_path(service_choice: service_choice, commodity_code: commodity_code),
+          duty_path,
         )
       end
     end
@@ -99,9 +97,9 @@ RSpec.describe Wizard::Steps::CertificateOfOrigin do
 
       it 'returns customs_value_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          customs_value_path(service_choice: service_choice, commodity_code: commodity_code),
+          customs_value_path,
         )
       end
     end
@@ -121,9 +119,9 @@ RSpec.describe Wizard::Steps::CertificateOfOrigin do
 
       it 'returns final_use_path' do
         expect(
-          step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.previous_step_path,
         ).to eq(
-          final_use_path(service_choice: service_choice, commodity_code: commodity_code),
+          final_use_path,
         )
       end
     end
@@ -139,9 +137,9 @@ RSpec.describe Wizard::Steps::CertificateOfOrigin do
 
       it 'returns trader_scheme_path' do
         expect(
-          step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.previous_step_path,
         ).to eq(
-          trader_scheme_path(service_choice: service_choice, commodity_code: commodity_code),
+          trader_scheme_path,
         )
       end
     end
@@ -157,9 +155,9 @@ RSpec.describe Wizard::Steps::CertificateOfOrigin do
 
       it 'returns planned_processing_path' do
         expect(
-          step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.previous_step_path,
         ).to eq(
-          planned_processing_path(service_choice: service_choice, commodity_code: commodity_code),
+          planned_processing_path,
         )
       end
     end

--- a/spec/models/wizard/steps/confirmation_spec.rb
+++ b/spec/models/wizard/steps/confirmation_spec.rb
@@ -15,18 +15,12 @@ RSpec.describe Wizard::Steps::Confirmation do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     xit 'to be added' do
     end
   end
 
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
-
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
 
     context 'when on GB to NI route' do
       before do
@@ -35,9 +29,9 @@ RSpec.describe Wizard::Steps::Confirmation do
 
       it 'returns measure_amount_path' do
         expect(
-          step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.previous_step_path,
         ).to eq(
-          measure_amount_path(service_choice: service_choice, commodity_code: commodity_code),
+          measure_amount_path,
         )
       end
     end

--- a/spec/models/wizard/steps/country_of_origin_spec.rb
+++ b/spec/models/wizard/steps/country_of_origin_spec.rb
@@ -94,23 +94,17 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     it 'returns import_destination_path' do
       expect(
-        step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+        step.previous_step_path,
       ).to eq(
-        import_destination_path(service_choice: service_choice, commodity_code: commodity_code),
+        import_destination_path,
       )
     end
   end
 
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
-
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
 
     context 'when on NI to GB route' do
       let(:session) do
@@ -124,9 +118,9 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
 
       it 'returns duty_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          duty_path(service_choice: service_choice, commodity_code: commodity_code),
+          duty_path,
         )
       end
     end
@@ -149,9 +143,9 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
 
       it 'returns the trade_remedies_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          trade_remedies_path(service_choice: service_choice, commodity_code: commodity_code),
+          trade_remedies_path,
         )
       end
     end
@@ -175,9 +169,9 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
 
       it 'returns the duty_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          duty_path(service_choice: service_choice, commodity_code: commodity_code),
+          duty_path,
         )
       end
     end
@@ -201,9 +195,9 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
 
       it 'returns the trader_scheme_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          trader_scheme_path(service_choice: service_choice, commodity_code: commodity_code),
+          trader_scheme_path,
         )
       end
     end

--- a/spec/models/wizard/steps/customs_value_spec.rb
+++ b/spec/models/wizard/steps/customs_value_spec.rb
@@ -245,9 +245,6 @@ RSpec.describe Wizard::Steps::CustomsValue do
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     context 'when on GB to NI route' do
       before do
         allow(user_session).to receive(:gb_to_ni_route?).and_return(true)
@@ -262,9 +259,9 @@ RSpec.describe Wizard::Steps::CustomsValue do
 
         it 'returns trade_remedies_path' do
           expect(
-            step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+            step.previous_step_path,
           ).to eq(
-            trade_remedies_path(service_choice: service_choice, commodity_code: commodity_code),
+            trade_remedies_path,
           )
         end
       end
@@ -278,9 +275,9 @@ RSpec.describe Wizard::Steps::CustomsValue do
 
         it 'returns certificate_of_origin_path' do
           expect(
-            step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+            step.previous_step_path,
           ).to eq(
-            certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
+            certificate_of_origin_path,
           )
         end
       end
@@ -290,14 +287,11 @@ RSpec.describe Wizard::Steps::CustomsValue do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     it 'returns measure_amount_path' do
       expect(
-        step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+        step.next_step_path,
       ).to eq(
-        measure_amount_path(service_choice: service_choice, commodity_code: commodity_code),
+        measure_amount_path,
       )
     end
   end

--- a/spec/models/wizard/steps/final_use_spec.rb
+++ b/spec/models/wizard/steps/final_use_spec.rb
@@ -71,9 +71,6 @@ RSpec.describe Wizard::Steps::FinalUse do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     context 'when on GB to NI route and final use answer is yes' do
       let(:session) do
         {
@@ -88,9 +85,9 @@ RSpec.describe Wizard::Steps::FinalUse do
 
       it 'returns planned_processing_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          planned_processing_path(service_choice: service_choice, commodity_code: commodity_code),
+          planned_processing_path,
         )
       end
     end
@@ -109,9 +106,9 @@ RSpec.describe Wizard::Steps::FinalUse do
 
       it 'returns certificate_of_origin_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
+          certificate_of_origin_path,
         )
       end
     end
@@ -119,9 +116,6 @@ RSpec.describe Wizard::Steps::FinalUse do
 
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
-
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
 
     context 'when on GB to NI route' do
       let(:session) do
@@ -136,9 +130,9 @@ RSpec.describe Wizard::Steps::FinalUse do
 
       it 'returns country_of_origin_path' do
         expect(
-          step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.previous_step_path,
         ).to eq(
-          trader_scheme_path(service_choice: service_choice, commodity_code: commodity_code),
+          trader_scheme_path,
         )
       end
     end

--- a/spec/models/wizard/steps/import_date_spec.rb
+++ b/spec/models/wizard/steps/import_date_spec.rb
@@ -179,14 +179,11 @@ RSpec.describe Wizard::Steps::ImportDate do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     it 'returns import_destination_path' do
       expect(
-        step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+        step.next_step_path,
       ).to eq(
-        import_destination_path(service_choice: service_choice, commodity_code: commodity_code),
+        import_destination_path,
       )
     end
   end

--- a/spec/models/wizard/steps/import_destination_spec.rb
+++ b/spec/models/wizard/steps/import_destination_spec.rb
@@ -60,14 +60,36 @@ RSpec.describe Wizard::Steps::ImportDestination do
   describe '#save' do
     let(:attributes) do
       ActionController::Parameters.new(
-        import_destination: 'ni',
+        import_destination: 'XI',
       ).permit(:import_destination)
     end
 
-    it 'saves the import_date to the session' do
+    it 'saves the import_destination to the session' do
       step.save
 
-      expect(user_session.import_destination).to eq('ni')
+      expect(user_session.import_destination).to eq('XI')
+    end
+
+    context 'when importing to XI' do
+      it 'sets the commodity source as XI on the session' do
+        step.save
+
+        expect(user_session.commodity_source).to eq('xi')
+      end
+    end
+
+    context 'when importing to GB' do
+      let(:attributes) do
+        ActionController::Parameters.new(
+          import_destination: 'GB',
+        ).permit(:import_destination)
+      end
+
+      it 'sets the commodity source as UK on the session' do
+        step.save
+
+        expect(user_session.commodity_source).to eq('uk')
+      end
     end
   end
 

--- a/spec/models/wizard/steps/import_destination_spec.rb
+++ b/spec/models/wizard/steps/import_destination_spec.rb
@@ -74,14 +74,11 @@ RSpec.describe Wizard::Steps::ImportDestination do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     it 'returns country_of_origin_path' do
       expect(
-        step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+        step.next_step_path,
       ).to eq(
-        country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
+        country_of_origin_path,
       )
     end
   end
@@ -89,14 +86,11 @@ RSpec.describe Wizard::Steps::ImportDestination do
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     it 'returns import_date_path' do
       expect(
-        step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+        step.previous_step_path,
       ).to eq(
-        import_date_path(service_choice: service_choice, commodity_code: commodity_code),
+        import_date_path,
       )
     end
   end

--- a/spec/models/wizard/steps/measure_amount_spec.rb
+++ b/spec/models/wizard/steps/measure_amount_spec.rb
@@ -134,14 +134,11 @@ RSpec.describe Wizard::Steps::MeasureAmount do
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     it 'returns customs_value_path' do
       expect(
-        step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+        step.previous_step_path,
       ).to eq(
-        customs_value_path(service_choice: service_choice, commodity_code: commodity_code),
+        customs_value_path,
       )
     end
   end
@@ -149,14 +146,11 @@ RSpec.describe Wizard::Steps::MeasureAmount do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
-
     it 'returns confirm_path' do
       expect(
-        step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+        step.next_step_path,
       ).to eq(
-        confirm_path(service_choice: service_choice, commodity_code: commodity_code),
+        confirm_path,
       )
     end
   end

--- a/spec/models/wizard/steps/planned_processing_spec.rb
+++ b/spec/models/wizard/steps/planned_processing_spec.rb
@@ -70,8 +70,6 @@ RSpec.describe Wizard::Steps::PlannedProcessing do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
     let(:answer) { 'without_any_processing' }
     let(:session) do
       {
@@ -88,9 +86,9 @@ RSpec.describe Wizard::Steps::PlannedProcessing do
     context 'when on GB to NI route and answer is not commercial_purposes' do
       it 'returns duty_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          duty_path(service_choice: service_choice, commodity_code: commodity_code),
+          duty_path,
         )
       end
     end
@@ -100,9 +98,9 @@ RSpec.describe Wizard::Steps::PlannedProcessing do
 
       it 'returns duty_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
+          certificate_of_origin_path,
         )
       end
     end
@@ -111,8 +109,6 @@ RSpec.describe Wizard::Steps::PlannedProcessing do
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
     let(:session) do
       {
         'answers' => {
@@ -126,9 +122,9 @@ RSpec.describe Wizard::Steps::PlannedProcessing do
     context 'when on GB to NI route' do
       it 'returns country_of_origin_path' do
         expect(
-          step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.previous_step_path,
         ).to eq(
-          final_use_path(service_choice: service_choice, commodity_code: commodity_code),
+          final_use_path,
         )
       end
     end

--- a/spec/models/wizard/steps/trader_scheme_spec.rb
+++ b/spec/models/wizard/steps/trader_scheme_spec.rb
@@ -72,8 +72,6 @@ RSpec.describe Wizard::Steps::TraderScheme do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
     let(:answer) { 'yes' }
     let(:session) do
       {
@@ -88,9 +86,9 @@ RSpec.describe Wizard::Steps::TraderScheme do
     context 'when on GB to NI route and answer is yes' do
       it 'returns country_of_origin_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          final_use_path(service_choice: service_choice, commodity_code: commodity_code),
+          final_use_path,
         )
       end
     end
@@ -100,9 +98,9 @@ RSpec.describe Wizard::Steps::TraderScheme do
 
       it 'returns country_of_origin_path' do
         expect(
-          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.next_step_path,
         ).to eq(
-          certificate_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
+          certificate_of_origin_path,
         )
       end
     end
@@ -111,8 +109,6 @@ RSpec.describe Wizard::Steps::TraderScheme do
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
 
-    let(:service_choice) { 'uk' }
-    let(:commodity_code) { '1233455' }
     let(:session) do
       {
         'answers' => {
@@ -125,9 +121,9 @@ RSpec.describe Wizard::Steps::TraderScheme do
     context 'when on GB to NI route' do
       it 'returns country_of_origin_path' do
         expect(
-          step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+          step.previous_step_path,
         ).to eq(
-          country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
+          country_of_origin_path,
         )
       end
     end

--- a/spec/support/shared_examples/gb_to_ni.rb
+++ b/spec/support/shared_examples/gb_to_ni.rb
@@ -5,7 +5,7 @@ RSpec.shared_context 'GB to NI' do # rubocop: disable RSpec/ContextWording
   let(:import_into) { 'XI' }
   let(:import_from) { 'GB' }
   let(:commodity_code) { '1234567890' }
-  let(:service_choice) { 'uk' }
+  let(:referred_service) { 'uk' }
   let(:trade_defence) { false }
   let(:zero_mfn_duty) { false }
 
@@ -20,10 +20,11 @@ RSpec.shared_context 'GB to NI' do # rubocop: disable RSpec/ContextWording
     allow(commodity).to receive(:code).and_return(commodity_code)
     allow(commodity).to receive(:description).and_return(description)
     allow(filtered_commodity).to receive(:zero_mfn_duty).and_return(zero_mfn_duty)
-    allow(Api::Commodity).to receive(:build).with(service_choice.to_sym, commodity_code).and_return(commodity)
+    allow(Api::Commodity).to receive(:build).with(:uk, commodity_code).and_return(commodity)
+    allow(Api::Commodity).to receive(:build).with(:xi, commodity_code).and_return(commodity)
     allow(Api::Commodity).to receive(:build).with(:xi, commodity_code, filter).and_return(filtered_commodity)
 
-    visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
+    visit import_date_path(commodity_code: commodity_code, referred_service: referred_service)
 
     fill_in('wizard_steps_import_date[import_date(3i)]', with: '12')
     fill_in('wizard_steps_import_date[import_date(2i)]', with: '12')


### PR DESCRIPTION
### Jira link

HOTT-526

### What?

I have added/removed/altered:

- [x] Remove commodity code and service from URLs.
- [x] Store the commodity code and service choice on the session
instead, so we don't have to keep passing them as params
on every URL.
- [x] Also removed testing the redirections at feature specs level
since that is unit tested at the model level. Removes test
redundancy.
- [x] Rename service_choice to referred_service
- [x] Also add the commodity_source key on the session that
will initially be the same as referred_service, but it will
update depending on what users select on the import_destination
step.
- [x] This key will help us know further down which source
to fetch the commodity from UK or XI.