### PR TITLE
Fix summary page import destination country bug

### DIFF
--- a/app/decorators/confirmation_decorator.rb
+++ b/app/decorators/confirmation_decorator.rb
@@ -47,7 +47,7 @@ class ConfirmationDecorator < SimpleDelegator
     return format_import_date(value) if key == 'import_date'
     return format_customs_value(value) if key == 'customs_value'
     return format_measure_amount(value) if key == 'measure_amount'
-    return format_country(value) if %w[import_destination country_of_origin].include?(key)
+    return country_name_for(value, key) if %w[import_destination country_of_origin].include?(key)
 
     value.humanize
   end
@@ -72,7 +72,9 @@ class ConfirmationDecorator < SimpleDelegator
     Date.parse(value).strftime('%d %B %Y')
   end
 
-  def format_country(value)
-    Api::GeographicalArea.find(value).description
+  def country_name_for(value, key)
+    return Wizard::Steps::ImportDestination::OPTIONS.find { |c| c.id == value }.name if key == 'import_destination'
+
+    Api::GeographicalArea.find(value, session_answers['import_destination'].downcase.to_sym).description
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -137,7 +137,7 @@ class UserSession
   end
 
   def ni_to_gb_route?
-    import_destination == 'GB' && country_of_origin == 'XI'
+    import_destination == 'UK' && country_of_origin == 'XI'
   end
 
   def gb_to_ni_route?

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -2,7 +2,7 @@ module Wizard
   module Steps
     class ImportDestination < Wizard::Steps::Base
       OPTIONS = [
-        OpenStruct.new(id: 'GB', name: 'England, Scotland or Wales (GB)'),
+        OpenStruct.new(id: 'UK', name: 'England, Scotland or Wales (GB)'),
         OpenStruct.new(id: 'XI', name: 'Northern Ireland'),
       ].freeze
 

--- a/spec/decorators/confirmation_decorator_spec.rb
+++ b/spec/decorators/confirmation_decorator_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ConfirmationDecorator do
         {
           key: 'import_destination',
           label: 'Destination',
-          value: 'United Kingdom (Northern Ireland)',
+          value: 'Northern Ireland',
         },
         {
           key: 'country_of_origin',
@@ -111,7 +111,6 @@ RSpec.describe ConfirmationDecorator do
       ]
     end
 
-    let(:xi) { instance_double(Api::GeographicalArea) }
     let(:gb) { instance_double(Api::GeographicalArea) }
 
     let(:applicable_measure_units) do
@@ -128,9 +127,7 @@ RSpec.describe ConfirmationDecorator do
     end
 
     before do
-      allow(Api::GeographicalArea).to receive(:find).with('XI').and_return(xi)
-      allow(xi).to receive(:description).and_return('United Kingdom (Northern Ireland)')
-      allow(Api::GeographicalArea).to receive(:find).with('GB').and_return(gb)
+      allow(Api::GeographicalArea).to receive(:find).with('GB', :xi).and_return(gb)
       allow(gb).to receive(:description).and_return('United Kingdom')
       allow(commodity).to receive(:applicable_measure_units).and_return(applicable_measure_units)
     end

--- a/spec/features/country_of_origin_page_spec.rb
+++ b/spec/features/country_of_origin_page_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Country of Origin Page', type: :feature do
   let(:commodity_code) { '1234567890' }
   let(:referred_service) { 'uk' }
-  let(:import_into) { 'GB' }
+  let(:import_into) { 'UK' }
 
   before do
     visit import_date_path(commodity_code: commodity_code, referred_service: referred_service)

--- a/spec/models/duty_calculator_spec.rb
+++ b/spec/models/duty_calculator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DutyCalculator do
       let(:session) do
         {
           'answers' => {
-            'import_destination' => 'GB',
+            'import_destination' => 'UK',
             'country_of_origin' => 'XI',
           },
         }

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe Wizard::Steps::UserSession do
       let(:session) do
         {
           'answers' => {
-            'import_destination' => 'GB',
+            'import_destination' => 'UK',
             'country_of_origin' => 'XI',
           },
         }

--- a/spec/models/wizard/steps/country_of_origin_spec.rb
+++ b/spec/models/wizard/steps/country_of_origin_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
       let(:session) do
         {
           'answers' => {
-            'import_destination' => 'GB',
+            'import_destination' => 'UK',
             'country_of_origin' => 'XI',
           },
         }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] When rendering the import destination country on the
summary page, we can't use the Geographical Areas API,
since the countries of interest (Northern Ireland/UK) will
be missing. We have to get the country name from
Wizard::Steps::ImportDestination::OPTIONS instead.

### Why?

- The summary page would break since the import country would not exist among the countries returned from the Geographical Area API.