### PR TITLE
Adds compound component evaluator

### DIFF
--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -29,6 +29,8 @@ module Api
         ExpressionEvaluators::AdValorem.new(self, user_session)
       elsif specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, user_session)
+      else
+        ExpressionEvaluators::Compound.new(self, user_session)
       end
     end
 
@@ -36,23 +38,23 @@ module Api
       @component ||= all_components.first
     end
 
-    private
-
     def all_components
       # TODO: This needs to include measure condition components
       @all_components ||= measure_components
     end
 
+    private
+
     def ad_valorem?
       single_component? &&
         amount_or_percentage? &&
-        component.no_expresses_unit?
+        component.no_specific_duty?
     end
 
     def specific_duty?
       single_component? &&
         amount_or_percentage? &&
-        component.expresses_unit?
+        component.specific_duty?
     end
 
     def amount_or_percentage?

--- a/app/models/api/measure_component.rb
+++ b/app/models/api/measure_component.rb
@@ -1,4 +1,7 @@
 module Api
+  CONJUNCTION_OPERATORS = %w[MAX MIN].freeze
+  MATHEMATICAL_OPERATORS = %w[+ -].freeze
+
   class MeasureComponent < Api::Base
     attributes :duty_expression_id,
                :duty_amount,
@@ -9,12 +12,24 @@ module Api
                :measurement_unit_code,
                :measurement_unit_qualifier_code
 
-    def expresses_unit?
+    def ad_valorem?
+      no_specific_duty? && duty_expression_id == '01'
+    end
+
+    def specific_duty?
       monetary_unit_code || measurement_unit_code
     end
 
-    def no_expresses_unit?
-      !expresses_unit?
+    def no_specific_duty?
+      !specific_duty?
+    end
+
+    def conjunction_operator?
+      duty_expression_abbreviation.in?(CONJUNCTION_OPERATORS)
+    end
+
+    def operator
+      duty_expression_abbreviation
     end
   end
 end

--- a/app/services/expression_evaluators/ad_valorem.rb
+++ b/app/services/expression_evaluators/ad_valorem.rb
@@ -2,7 +2,7 @@ module ExpressionEvaluators
   class AdValorem < ExpressionEvaluators::Base
     def call
       {
-        calculation: "#{measure.component.duty_amount}% * #{number_to_currency(total_amount)}",
+        calculation: "#{component.duty_amount}% * #{number_to_currency(total_amount)}",
         value: value,
         formatted_value: number_to_currency(value),
       }
@@ -11,7 +11,7 @@ module ExpressionEvaluators
     private
 
     def value
-      @value ||= total_amount / 100.0 * measure.component.duty_amount
+      @value ||= total_amount / 100.0 * component.duty_amount
     end
 
     def total_amount

--- a/app/services/expression_evaluators/base.rb
+++ b/app/services/expression_evaluators/base.rb
@@ -9,6 +9,11 @@ module ExpressionEvaluators
 
     protected
 
+    def component
+      @component || measure.component
+    end
+
     attr_reader :measure, :user_session
+    attr_writer :component
   end
 end

--- a/app/services/expression_evaluators/compound.rb
+++ b/app/services/expression_evaluators/compound.rb
@@ -1,0 +1,92 @@
+module ExpressionEvaluators
+  class Compound < ExpressionEvaluators::Base
+    def call
+      {
+        calculation: measure.duty_expression.base,
+        value: evaluation_result,
+        formatted_value: number_to_currency(evaluation_result),
+      }
+    end
+
+    private
+
+    def build_expression
+      measure.all_components.flat_map do |component|
+        if component.conjunction_operator?
+          [
+            {
+              operator: component.operator,
+            },
+            {
+              operator: '+',
+              value: value_for(component),
+            },
+          ]
+        else
+          {
+            operator: component.operator,
+            value: value_for(component),
+          }
+        end
+      end
+    end
+
+    # TODO: This needs to be refactored. Ticket: HOTT-547
+    def evaluator_for(component)
+      evaluator = if component.ad_valorem?
+                    ExpressionEvaluators::AdValorem.new(measure, user_session)
+                  elsif component.specific_duty?
+                    ExpressionEvaluators::MeasureUnit.new(measure, user_session)
+                  end
+
+      evaluator.component = component
+
+      evaluator
+    end
+
+    def value_for(component)
+      evaluator = evaluator_for(component)
+
+      evaluator.call[:value]
+    end
+
+    def evaluate(expression)
+      conjunction_operator = last_conjunction_operator(expression)
+
+      if conjunction_operator.present?
+        left_expression = evaluate(expression[0..conjunction_operator[:index] - 1])
+        right_expression = evaluate(expression[conjunction_operator[:index] + 1..expression.length - 1])
+
+        case conjunction_operator[:operator]
+        when 'MAX' then [left_expression, right_expression].min
+        when 'MIN' then [left_expression, right_expression].max
+        end
+      else
+        evaluate_subexpression(expression)
+      end
+    end
+
+    def evaluate_subexpression(expression)
+      expression.reduce(0) do |acc, element|
+        case element[:operator]
+        when '%' then acc + element[:value]
+        when '+' then acc + element[:value]
+        when '-' then acc - element[:value]
+        end
+      end
+    end
+
+    def last_conjunction_operator(expression)
+      expression.each.with_index.each_with_object({}) do |(e, index), hash|
+        if Api::CONJUNCTION_OPERATORS.include?(e[:operator])
+          hash[:index] = index
+          hash[:operator] = e[:operator]
+        end
+      end
+    end
+
+    def evaluation_result
+      @evaluation_result ||= evaluate(build_expression)
+    end
+  end
+end

--- a/app/services/expression_evaluators/measure_unit.rb
+++ b/app/services/expression_evaluators/measure_unit.rb
@@ -14,9 +14,9 @@ module ExpressionEvaluators
 
     def value
       @value ||= begin
-        return total_quantity * measure.component.duty_amount * eur_to_gbp_rate if duty_amount_in_eur?
+        return total_quantity * component.duty_amount * eur_to_gbp_rate if duty_amount_in_eur?
 
-        total_quantity * measure.component.duty_amount
+        total_quantity * component.duty_amount
       end
     end
 
@@ -51,7 +51,7 @@ module ExpressionEvaluators
     end
 
     def duty_amount_in_eur?
-      measure.component.monetary_unit_code == 'EUR'
+      component.monetary_unit_code == 'EUR'
     end
   end
 end

--- a/spec/fixtures/commodities/0102291010.json
+++ b/spec/fixtures/commodities/0102291010.json
@@ -1,0 +1,9557 @@
+{
+  "meta": {
+    "duty_calculator": {
+      "zero_mfn_duty": false,
+      "trade_defence": false,
+      "applicable_measure_units": {
+        "DTN": {
+          "measurement_unit_code": "DTN",
+          "measurement_unit_qualifier_code": "",
+          "abbreviation": "100 kg",
+          "unit_question": "What is the weight of the goods you will be importing?",
+          "unit_hint": "Enter the value in decitonnes (100kg)",
+          "unit": "x 100 kg",
+          "measure_sids": [
+            3211138
+          ]
+        }
+      },
+      "meursing_code": false
+    }
+  },
+  "import_measures": [
+    {
+      "id": -581592,
+      "origin": "uk",
+      "effective_start_date": "2020-08-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": true,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "VAT zero rate",
+        "national": true,
+        "measure_type_series_id": "P",
+        "id": "VTZ"
+      },
+      "legal_acts": [
+
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos Islands (or Keeling Islands)",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo, Democratic Republic of",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo (Republic of)",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia, Federated States of",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran, Islamic Republic of",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia (Kampuchea)",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros (excluding Mayotte)",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea (Democratic People’s Republic of Korea)",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "Korea, Republic of (South Korea)",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova, Republic of",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands, Republic of",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "Macedonia (Former Yugoslav Republic of)",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia and dependencies",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue Island",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PM",
+            "description": "St Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied palestinian Territory",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RU",
+            "description": "Russian Federation",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles and dependencies",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Swaziland",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "Timor-Leste",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania, United Republic of",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City State",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent and the Grenadines",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "Virgin Islands, British",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "Virgin Islands, United States",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Viet Nam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna Islands",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo (As defined by United Nations Security Council Resolution 1244 of 10 June 1999)",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+        {
+          "code": "03026",
+          "description": "UK VAT zero rate",
+          "formatted_description": "UK VAT zero rate"
+        }
+      ],
+      "order_number": null
+    },
+    {
+      "id": 3717655,
+      "origin": "eu",
+      "effective_start_date": "2019-12-14T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "",
+        "formatted_base": ""
+      },
+      "measure_type": {
+        "description": "Veterinary control",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "410"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2019-12-14T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 312",
+          "officialjournal_page": 1,
+          "published_date": "2019-12-03",
+          "regulation_code": "R2007/19",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D312,YEAR_OJ%3D2019,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "C640",
+          "requirement": "Other certificates: Common Health Entry Document for Animals (CHED-A) (as set out in Part 2, Section A of Annex II to Commission Implementing Regulation (EU) 2019/1715 (OJ L 261))",
+          "action": "Import/export allowed after control",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "",
+          "requirement": null,
+          "action": "Import/export not allowed after control",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        }
+      ],
+      "measure_components": [
+
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1008",
+        "description": "All third countries",
+        "geographical_area_id": "1008",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos Islands (or Keeling Islands)",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo, Democratic Republic of",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo (Republic of)",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia, Federated States of",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran, Islamic Republic of",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia (Kampuchea)",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros (excluding Mayotte)",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea (Democratic People’s Republic of Korea)",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "Korea, Republic of (South Korea)",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova, Republic of",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands, Republic of",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "Macedonia (Former Yugoslav Republic of)",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia and dependencies",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue Island",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PM",
+            "description": "St Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied palestinian Territory",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RU",
+            "description": "Russian Federation",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles and dependencies",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Swaziland",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "Timor-Leste",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania, United Republic of",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City State",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent and the Grenadines",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "Virgin Islands, British",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "Virgin Islands, United States",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Viet Nam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna Islands",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo (As defined by United Nations Security Council Resolution 1244 of 10 June 1999)",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "XU",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "XU"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+        {
+          "id": "AD",
+          "description": "Andorra",
+          "geographical_area_id": "AD"
+        },
+        {
+          "id": "CH",
+          "description": "Switzerland",
+          "geographical_area_id": "CH"
+        },
+        {
+          "id": "LI",
+          "description": "Liechtenstein",
+          "geographical_area_id": "LI"
+        },
+        {
+          "id": "NO",
+          "description": "Norway",
+          "geographical_area_id": "NO"
+        },
+        {
+          "id": "SM",
+          "description": "San Marino",
+          "geographical_area_id": "SM"
+        }
+      ],
+      "footnotes": [
+        {
+          "code": "CD625",
+          "description": "The entry into free circulation of live animals is subject to the presentation of a Common Health Entry Document for live animals (CHED-A) in accordance with the conditions laid down in article 40 of the Commission Implementing Regulation (EU) 2019/1715 of 30 September 2019 laying down rules for the functioning of the information management system for official controls and its system components (‘the IMSOC Regulation’).",
+          "formatted_description": "The entry into free circulation of live animals is subject to the presentation of a Common Health Entry Document for live animals (CHED-A) in accordance with the conditions laid down in article 40 of the Commission Implementing Regulation (EU) 2019/1715 of 30 September 2019 laying down rules for the functioning of the information management system for official controls and its system components (‘the IMSOC Regulation’)."
+        }
+      ],
+      "order_number": null
+    },
+    {
+      "id": 3211138,
+      "origin": "eu",
+      "effective_start_date": "2012-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "10.20 % + 93.10 EUR / 100 kg",
+        "formatted_base": "<span>10.20</span> % + <span>93.10</span> EUR / <abbr title='Hectokilogram'>100 kg</abbr>"
+      },
+      "measure_type": {
+        "description": "Third country duty",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "103"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2012-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 282",
+          "officialjournal_page": 1,
+          "published_date": "2011-10-28",
+          "regulation_code": "R1006/11",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D282,YEAR_OJ%3D2011,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+        },
+        {
+          "validity_start_date": "1988-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 256",
+          "officialjournal_page": 1,
+          "published_date": "1987-09-07",
+          "regulation_code": "R2658/87",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D256,YEAR_OJ%3D1987,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 10.2,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        },
+        {
+          "duty_expression_id": "04",
+          "duty_amount": 93.1,
+          "monetary_unit_code": "EUR",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "+ % or amount",
+          "duty_expression_abbreviation": "+",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos Islands (or Keeling Islands)",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo, Democratic Republic of",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo (Republic of)",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia, Federated States of",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran, Islamic Republic of",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia (Kampuchea)",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros (excluding Mayotte)",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea (Democratic People’s Republic of Korea)",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "Korea, Republic of (South Korea)",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova, Republic of",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands, Republic of",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "Macedonia (Former Yugoslav Republic of)",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia and dependencies",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue Island",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PM",
+            "description": "St Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied palestinian Territory",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RU",
+            "description": "Russian Federation",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles and dependencies",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Swaziland",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "Timor-Leste",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania, United Republic of",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City State",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent and the Grenadines",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "Virgin Islands, British",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "Virgin Islands, United States",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Viet Nam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna Islands",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo (As defined by United Nations Security Council Resolution 1244 of 10 June 1999)",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 2982600,
+      "origin": "eu",
+      "effective_start_date": "2008-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "p/st",
+        "formatted_base": "<abbr title='Number of items'>p/st</abbr>"
+      },
+      "measure_type": {
+        "description": "Supplementary unit",
+        "national": null,
+        "measure_type_series_id": "O",
+        "id": "109"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "1988-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 256",
+          "officialjournal_page": null,
+          "published_date": "1987-09-07",
+          "regulation_code": "R2658/87",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?instInvStatus=ALL&or0=DN%3D31987R2658*,DN-old%3D31987R2658*&DTC=false&type=advanced"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "99",
+          "duty_amount": null,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "NAR",
+          "duty_expression_description": "Supplementary unit",
+          "duty_expression_abbreviation": "UNSUP",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos Islands (or Keeling Islands)",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo, Democratic Republic of",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo (Republic of)",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia, Federated States of",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran, Islamic Republic of",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia (Kampuchea)",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros (excluding Mayotte)",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea (Democratic People’s Republic of Korea)",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "Korea, Republic of (South Korea)",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova, Republic of",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands, Republic of",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "Macedonia (Former Yugoslav Republic of)",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia and dependencies",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue Island",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PM",
+            "description": "St Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied palestinian Territory",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RU",
+            "description": "Russian Federation",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles and dependencies",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Swaziland",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "Timor-Leste",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania, United Republic of",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City State",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent and the Grenadines",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "Virgin Islands, British",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "Virgin Islands, United States",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Viet Nam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna Islands",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo (As defined by United Nations Security Council Resolution 1244 of 10 June 1999)",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 3288801,
+      "origin": "eu",
+      "effective_start_date": "2013-02-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "",
+        "formatted_base": ""
+      },
+      "measure_type": {
+        "description": "Declaration of subheading submitted to restrictions (net weight/supplementary unit)",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "482"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2013-02-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 304",
+          "officialjournal_page": 1,
+          "published_date": "2012-10-31",
+          "regulation_code": "R0927/12",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D304,YEAR_OJ%3D2012,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+        {
+          "condition_code": "R",
+          "condition": "R: Ratio \"net weight/supplementary unit\" is equal to or higher than the condition amount",
+          "document_code": "",
+          "requirement": "<span>80.001</span> <abbr title='Kilogram'>kg</abbr>",
+          "action": "Declaration to be corrected  - box 33, 37, 38, 41 or 46 incorrect",
+          "duty_expression": "",
+          "condition_duty_amount": 80.001,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": "KGM",
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "R",
+          "condition": "R: Ratio \"net weight/supplementary unit\" is equal to or higher than the condition amount",
+          "document_code": "",
+          "requirement": "<span>0.00</span> <abbr title='Kilogram'>kg</abbr>",
+          "action": "Declared subheading allowed",
+          "duty_expression": "",
+          "condition_duty_amount": 0.0,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": "KGM",
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        }
+      ],
+      "measure_components": [
+
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos Islands (or Keeling Islands)",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo, Democratic Republic of",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo (Republic of)",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia, Federated States of",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran, Islamic Republic of",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia (Kampuchea)",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros (excluding Mayotte)",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea (Democratic People’s Republic of Korea)",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "Korea, Republic of (South Korea)",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova, Republic of",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands, Republic of",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "Macedonia (Former Yugoslav Republic of)",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia and dependencies",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue Island",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PM",
+            "description": "St Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied palestinian Territory",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RU",
+            "description": "Russian Federation",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles and dependencies",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Swaziland",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "Timor-Leste",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania, United Republic of",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City State",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent and the Grenadines",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "Virgin Islands, British",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "Virgin Islands, United States",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Viet Nam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna Islands",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo (As defined by United Nations Security Council Resolution 1244 of 10 June 1999)",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+        {
+          "code": "CD651",
+          "description": "Declaration under this goods code is only allowed if the threshold values (net weight/supplementary unit or value/net weight or value/supplementary unit) are respected. If not, check the respective values and correct if necessary. Otherwise, another goods code should be declared.",
+          "formatted_description": "Declaration under this goods code is only allowed if the threshold values (net weight/supplementary unit or value/net weight or value/supplementary unit) are respected. If not, check the respective values and correct if necessary. Otherwise, another goods code should be declared."
+        }
+      ],
+      "order_number": null
+    },
+    {
+      "id": 3522473,
+      "origin": "eu",
+      "effective_start_date": "2017-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "",
+        "formatted_base": ""
+      },
+      "measure_type": {
+        "description": "Import control of organic products",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "750"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2009-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 189",
+          "officialjournal_page": 1,
+          "published_date": "2007-07-20",
+          "regulation_code": "R0834/07",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D189,YEAR_OJ%3D2007,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "C644",
+          "requirement": "Other certificates: Certificate of inspection for organic products",
+          "action": "Import/export allowed after control",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "Y929",
+          "requirement": "Particular provisions: Goods not concerned by Regulation (EC) No 834/2007 (organic products)",
+          "action": "Import/export allowed after control",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "",
+          "requirement": null,
+          "action": "Import/export not allowed after control",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        }
+      ],
+      "measure_components": [
+
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos Islands (or Keeling Islands)",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo, Democratic Republic of",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo (Republic of)",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia, Federated States of",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran, Islamic Republic of",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia (Kampuchea)",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros (excluding Mayotte)",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea (Democratic People’s Republic of Korea)",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "Korea, Republic of (South Korea)",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova, Republic of",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands, Republic of",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "Macedonia (Former Yugoslav Republic of)",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia and dependencies",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue Island",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PM",
+            "description": "St Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied palestinian Territory",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RU",
+            "description": "Russian Federation",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles and dependencies",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Swaziland",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "Timor-Leste",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania, United Republic of",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City State",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent and the Grenadines",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "Virgin Islands, British",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "Virgin Islands, United States",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Viet Nam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna Islands",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo (As defined by United Nations Security Council Resolution 1244 of 10 June 1999)",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+        {
+          "id": "CH",
+          "description": "Switzerland",
+          "geographical_area_id": "CH"
+        },
+        {
+          "id": "IS",
+          "description": "Iceland",
+          "geographical_area_id": "IS"
+        },
+        {
+          "id": "LI",
+          "description": "Liechtenstein",
+          "geographical_area_id": "LI"
+        },
+        {
+          "id": "NO",
+          "description": "Norway",
+          "geographical_area_id": "NO"
+        }
+      ],
+      "footnotes": [
+        {
+          "code": "CD808",
+          "description": "If goods bear a reference to organic production in the labelling, advertising or accompanying documents, the declarant has to present the certificate of inspection C644 as referred to in the Article 33(1)(d) of the Regulation (EC) No 834/2007 (equivalent products). If the goods are not equivalent products, code Y929 must be declared.<br/>Without prejudice to any measures or actions taken in accordance with Article 30 of Regulation (EC) No 834/2007 and/or Article 85 of Regulation (EC) No 889/2008, the release for free circulation in the Community of products not in conformity with the requirements of that Regulation shall be conditional on the removal of references to organic production from the labelling, advertising and accompanying documents.<br/>",
+          "formatted_description": "If goods bear a reference to organic production in the labelling, advertising or accompanying documents, the declarant has to present the certificate of inspection C644 as referred to in the Article 33(1)(d) of the Regulation (EC) No 834/2007 (equivalent products). If the goods are not equivalent products, code Y929 must be declared.<br/>Without prejudice to any measures or actions taken in accordance with Article 30 of Regulation (EC) No 834/2007 and/or Article 85 of Regulation (EC) No 889/2008, the release for free circulation in the Community of products not in conformity with the requirements of that Regulation shall be conditional on the removal of references to organic production from the labelling, advertising and accompanying documents.<br/>"
+        }
+      ],
+      "order_number": null
+    },
+    {
+      "id": 3822121,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 444",
+          "officialjournal_page": 11,
+          "published_date": "2020-12-31",
+          "regulation_code": "D2253/20",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D444,YEAR_OJ%3D2020,PAGE_FIRST%3D0011&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "GB",
+        "description": "United Kingdom (excluding Northern Ireland)",
+        "geographical_area_id": "GB"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    }
+  ],
+  "export_measures": [
+    {
+      "id": 2982600,
+      "origin": "eu",
+      "effective_start_date": "2008-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "p/st",
+        "formatted_base": "<abbr title='Number of items'>p/st</abbr>"
+      },
+      "measure_type": {
+        "description": "Supplementary unit",
+        "national": null,
+        "measure_type_series_id": "O",
+        "id": "109"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "1988-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 256",
+          "officialjournal_page": null,
+          "published_date": "1987-09-07",
+          "regulation_code": "R2658/87",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?instInvStatus=ALL&or0=DN%3D31987R2658*,DN-old%3D31987R2658*&DTC=false&type=advanced"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "99",
+          "duty_amount": null,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "NAR",
+          "duty_expression_description": "Supplementary unit",
+          "duty_expression_abbreviation": "UNSUP",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos Islands (or Keeling Islands)",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo, Democratic Republic of",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo (Republic of)",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia, Federated States of",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran, Islamic Republic of",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia (Kampuchea)",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros (excluding Mayotte)",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea (Democratic People’s Republic of Korea)",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "Korea, Republic of (South Korea)",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova, Republic of",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands, Republic of",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "Macedonia (Former Yugoslav Republic of)",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia and dependencies",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue Island",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PM",
+            "description": "St Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied palestinian Territory",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RU",
+            "description": "Russian Federation",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles and dependencies",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Swaziland",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "Timor-Leste",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania, United Republic of",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City State",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent and the Grenadines",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "Virgin Islands, British",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "Virgin Islands, United States",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Viet Nam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna Islands",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo (As defined by United Nations Security Council Resolution 1244 of 10 June 1999)",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 3288801,
+      "origin": "eu",
+      "effective_start_date": "2013-02-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "",
+        "formatted_base": ""
+      },
+      "measure_type": {
+        "description": "Declaration of subheading submitted to restrictions (net weight/supplementary unit)",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "482"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2013-02-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "L 304",
+          "officialjournal_page": 1,
+          "published_date": "2012-10-31",
+          "regulation_code": "R0927/12",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D304,YEAR_OJ%3D2012,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-l&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+        {
+          "condition_code": "R",
+          "condition": "R: Ratio \"net weight/supplementary unit\" is equal to or higher than the condition amount",
+          "document_code": "",
+          "requirement": "<span>80.001</span> <abbr title='Kilogram'>kg</abbr>",
+          "action": "Declaration to be corrected  - box 33, 37, 38, 41 or 46 incorrect",
+          "duty_expression": "",
+          "condition_duty_amount": 80.001,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": "KGM",
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "R",
+          "condition": "R: Ratio \"net weight/supplementary unit\" is equal to or higher than the condition amount",
+          "document_code": "",
+          "requirement": "<span>0.00</span> <abbr title='Kilogram'>kg</abbr>",
+          "action": "Declared subheading allowed",
+          "duty_expression": "",
+          "condition_duty_amount": 0.0,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": "KGM",
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        }
+      ],
+      "measure_components": [
+
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos Islands (or Keeling Islands)",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo, Democratic Republic of",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo (Republic of)",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia, Federated States of",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom (excluding Northern Ireland)",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran, Islamic Republic of",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia (Kampuchea)",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros (excluding Mayotte)",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea (Democratic People’s Republic of Korea)",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "Korea, Republic of (South Korea)",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova, Republic of",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands, Republic of",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "Macedonia (Former Yugoslav Republic of)",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia and dependencies",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue Island",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PM",
+            "description": "St Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied palestinian Territory",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RU",
+            "description": "Russian Federation",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles and dependencies",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Swaziland",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "Timor-Leste",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania, United Republic of",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City State",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent and the Grenadines",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "Virgin Islands, British",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "Virgin Islands, United States",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Viet Nam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna Islands",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo (As defined by United Nations Security Council Resolution 1244 of 10 June 1999)",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+        {
+          "code": "CD651",
+          "description": "Declaration under this goods code is only allowed if the threshold values (net weight/supplementary unit or value/net weight or value/supplementary unit) are respected. If not, check the respective values and correct if necessary. Otherwise, another goods code should be declared.",
+          "formatted_description": "Declaration under this goods code is only allowed if the threshold values (net weight/supplementary unit or value/net weight or value/supplementary unit) are respected. If not, check the respective values and correct if necessary. Otherwise, another goods code should be declared."
+        }
+      ],
+      "order_number": null
+    }
+  ],
+  "producline_suffix": "80",
+  "number_indents": 5,
+  "description": "Young male bovine animals, intended for fattening",
+  "goods_nomenclature_item_id": "0102291010",
+  "bti_url": "https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code",
+  "formatted_description": "Young male bovine animals, intended for fattening",
+  "description_plain": "Young male bovine animals, intended for fattening",
+  "consigned": false,
+  "consigned_from": null,
+  "basic_duty_rate": null,
+  "meursing_code": false,
+  "declarable": true,
+  "footnotes": [
+    {
+      "code": "TN701",
+      "description": "According to  the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it shall be prohibited to import into European Union goods originating in Crimea or Sevastopol.<br/>The prohibition shall not apply in respect of: <br/>(a) the execution until 26 September 2014, of trade contracts concluded before 25 June 2014, or of ancillary contracts necessary for the execution of such contracts, provided that the natural or legal persons, entity or body seeking to perform the contract have notified, at least 10 working days in advance, the activity or transaction to the competent authority of the Member State in which they are established. <br/>(b) goods originating in Crimea or Sevastopol which have been made available to the Ukrainian authorities for examination, for which compliance with the conditions conferring entitlement to preferential origin has been verified and for which a certificate of origin has been issued in accordance with Regulation (EU) No 978/2012 and Regulation (EU) No 374/2014 or in accordance with the EU-Ukraine Association Agreement.",
+      "formatted_description": "According to  the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it shall be prohibited to import into European Union goods originating in Crimea or Sevastopol.<br/>The prohibition shall not apply in respect of: <br/>(a) the execution until 26 September 2014, of trade contracts concluded before 25 June 2014, or of ancillary contracts necessary for the execution of such contracts, provided that the natural or legal persons, entity or body seeking to perform the contract have notified, at least 10 working days in advance, the activity or transaction to the competent authority of the Member State in which they are established. <br/>(b) goods originating in Crimea or Sevastopol which have been made available to the Ukrainian authorities for examination, for which compliance with the conditions conferring entitlement to preferential origin has been verified and for which a certificate of origin has been issued in accordance with Regulation (EU) No 978/2012 and Regulation (EU) No 374/2014 or in accordance with the EU-Ukraine Association Agreement."
+    }
+  ],
+  "section": {
+    "numeral": "I",
+    "title": "Live animals; animal products",
+    "position": 1,
+    "section_note": "* 1\\. Any reference in this section to a particular genus or species of an animal, except where the context otherwise requires, includes a reference to the young of that genus or species.\r\n* 2\\. Except where the context otherwise requires, throughout the nomenclature any reference to 'dried' products also covers products which have been dehydrated, evaporated or freeze-dried."
+  },
+  "chapter": {
+    "goods_nomenclature_item_id": "0100000000",
+    "description": "LIVE ANIMALS",
+    "formatted_description": "Live animals",
+    "chapter_note": "* 1\\. This chapter covers all live animals except:\r\n  * (a) fish and crustaceans, molluscs and other aquatic invertebrates, of heading 0301, 0306, 0307 or 0308;\r\n  * (b) cultures of micro-organisms and other products of heading 3002; and\r\n  * (c) animals of heading 9508.",
+    "guides": [
+      {
+        "title": "Classification of goods",
+        "url": "https://www.gov.uk/government/collections/classification-of-goods"
+      }
+    ]
+  },
+  "heading": {
+    "goods_nomenclature_item_id": "0102000000",
+    "description": "Live bovine animals",
+    "formatted_description": "Live bovine animals",
+    "description_plain": "Live bovine animals"
+  },
+  "ancestors": [
+    {
+      "producline_suffix": "10",
+      "description": "Cattle",
+      "number_indents": 1,
+      "goods_nomenclature_item_id": "0102210000",
+      "formatted_description": "Cattle",
+      "description_plain": "Cattle"
+    },
+    {
+      "producline_suffix": "80",
+      "description": "Other",
+      "number_indents": 2,
+      "goods_nomenclature_item_id": "0102290000",
+      "formatted_description": "Other",
+      "description_plain": "Other"
+    },
+    {
+      "producline_suffix": "10",
+      "description": "Other",
+      "number_indents": 3,
+      "goods_nomenclature_item_id": "0102291000",
+      "formatted_description": "Other",
+      "description_plain": "Other"
+    },
+    {
+      "producline_suffix": "80",
+      "description": "Of a weight not exceeding 80|kg",
+      "number_indents": 4,
+      "goods_nomenclature_item_id": "0102291000",
+      "formatted_description": "Of a weight not exceeding 80&nbsp;kg",
+      "description_plain": "Of a weight not exceeding 80 kg"
+    }
+  ]
+}

--- a/spec/fixtures/commodities/2401109591.json
+++ b/spec/fixtures/commodities/2401109591.json
@@ -1,0 +1,7515 @@
+{
+  "meta": {
+    "duty_calculator": {
+      "zero_mfn_duty": false,
+      "trade_defence": false,
+      "applicable_measure_units": {
+        "DTN": {
+          "measurement_unit_code": "DTN",
+          "measurement_unit_qualifier_code": "",
+          "abbreviation": "100 kg",
+          "unit_question": "What is the weight of the goods you will be importing?",
+          "unit_hint": "Enter the value in decitonnes (100kg)",
+          "unit": "x 100 kg",
+          "measure_sids": [
+            20002945,
+            20019166,
+            20072018,
+            20105467,
+            20108187
+          ]
+        }
+      },
+      "meursing_code": false
+    }
+  },
+  "import_measures": [
+    {
+      "id": 20118056,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+        {
+          "condition_code": "Q",
+          "condition": "Q: Presentation of an endorsed certificate/licence",
+          "document_code": "U088",
+          "requirement": "Proofs of origin: Origin declaration stating European Union origin, in the context of the Canada-European Union Comprehensive Economic and Trade Agreement (CETA)",
+          "action": "Apply the mentioned duty",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "Q",
+          "condition": "Q: Presentation of an endorsed certificate/licence",
+          "document_code": "",
+          "requirement": null,
+          "action": "Measure not applicable",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        }
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1006",
+        "description": "UK-Canada agreement: re-imported goods",
+        "geographical_area_id": "1006",
+        "children_geographical_areas": [
+          {
+            "id": "GB",
+            "description": "United Kingdom",
+            "geographical_area_id": "GB"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+        {
+          "code": "CD727",
+          "description": "Eligibility to benefit from this preference is subject to the presentation of an origin declaration stating the European Union origin of the goods, in the context of the Canada-European Union Comprehensive Economic and Trade Agreement (CETA).",
+          "formatted_description": "Eligibility to benefit from this preference is subject to the presentation of an origin declaration stating the European Union origin of the goods, in the context of the Canada-European Union Comprehensive Economic and Trade Agreement (CETA)."
+        }
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20002945,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "18.00 GBP / 100 kg",
+        "formatted_base": "<span>18.00</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr>"
+      },
+      "measure_type": {
+        "description": "Third country duty",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "103"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 13.8,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        },
+        {
+          "duty_expression_id": "15",
+          "duty_amount": 13.0,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "Minimum",
+          "duty_expression_abbreviation": "MIN",
+          "measurement_unit_qualifier_code": null
+        },
+        {
+          "duty_expression_id": "17",
+          "duty_amount": 15.0,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "Maximum",
+          "duty_expression_abbreviation": "MAX",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AT",
+            "description": "Austria",
+            "geographical_area_id": "AT"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BE",
+            "description": "Belgium",
+            "geographical_area_id": "BE"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BG",
+            "description": "Bulgaria",
+            "geographical_area_id": "BG"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "The Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos (Keeling) Islands",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo (Democratic Republic)",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "CY",
+            "description": "Cyprus",
+            "geographical_area_id": "CY"
+          },
+          {
+            "id": "CZ",
+            "description": "Czechia",
+            "geographical_area_id": "CZ"
+          },
+          {
+            "id": "DE",
+            "description": "Germany",
+            "geographical_area_id": "DE"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DK",
+            "description": "Denmark",
+            "geographical_area_id": "DK"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EE",
+            "description": "Estonia",
+            "geographical_area_id": "EE"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ES",
+            "description": "Spain",
+            "geographical_area_id": "ES"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FI",
+            "description": "Finland",
+            "geographical_area_id": "FI"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "FR",
+            "description": "France",
+            "geographical_area_id": "FR"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "The Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GR",
+            "description": "Greece",
+            "geographical_area_id": "GR"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HR",
+            "description": "Croatia",
+            "geographical_area_id": "HR"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "HU",
+            "description": "Hungary",
+            "geographical_area_id": "HU"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IE",
+            "description": "Ireland",
+            "geographical_area_id": "IE"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "IT",
+            "description": "Italy",
+            "geographical_area_id": "IT"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "South Korea",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LT",
+            "description": "Lithuania",
+            "geographical_area_id": "LT"
+          },
+          {
+            "id": "LU",
+            "description": "Luxembourg",
+            "geographical_area_id": "LU"
+          },
+          {
+            "id": "LV",
+            "description": "Latvia",
+            "geographical_area_id": "LV"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "North Macedonia",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar (Burma)",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MT",
+            "description": "Malta",
+            "geographical_area_id": "MT"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NL",
+            "description": "Netherlands",
+            "geographical_area_id": "NL"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PL",
+            "description": "Poland",
+            "geographical_area_id": "PL"
+          },
+          {
+            "id": "PM",
+            "description": "Saint Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn, Henderson, Ducie and Oeno Islands",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied Palestinian Territories",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PT",
+            "description": "Portugal",
+            "geographical_area_id": "PT"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RO",
+            "description": "Romania",
+            "geographical_area_id": "RO"
+          },
+          {
+            "id": "RU",
+            "description": "Russia",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SE",
+            "description": "Sweden",
+            "geographical_area_id": "SE"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SI",
+            "description": "Slovenia",
+            "geographical_area_id": "SI"
+          },
+          {
+            "id": "SK",
+            "description": "Slovakia",
+            "geographical_area_id": "SK"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Eswatini",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "East Timor",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "British Virgin Islands",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "United States Virgin Islands",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Vietnam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZB",
+            "description": "Belgian Continental Shelf",
+            "geographical_area_id": "ZB"
+          },
+          {
+            "id": "ZD",
+            "description": "Danish Continental Shelf",
+            "geographical_area_id": "ZD"
+          },
+          {
+            "id": "ZE",
+            "description": "Irish Continental Shelf",
+            "geographical_area_id": "ZE"
+          },
+          {
+            "id": "ZF",
+            "description": "French Continental Shelf",
+            "geographical_area_id": "ZF"
+          },
+          {
+            "id": "ZG",
+            "description": "German Continental Shelf",
+            "geographical_area_id": "ZG"
+          },
+          {
+            "id": "ZH",
+            "description": "Netherlands Continental Shelf",
+            "geographical_area_id": "ZH"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZN",
+            "description": "Norwegian Continental Shelf",
+            "geographical_area_id": "ZN"
+          },
+          {
+            "id": "ZU",
+            "description": "United Kingdom Continental Shelf",
+            "geographical_area_id": "ZU"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20125431,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": "2021-12-31T00:00:00.000Z",
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Autonomous suspension under authorised use",
+        "national": false,
+        "measure_type_series_id": "C",
+        "id": "115"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "N990",
+          "requirement": "UN/EDIFACT certificates: EUS - Authorisation for the use of end use procedure (Column 8c, Annex A of Delegated Regulation (EU) 2015/2446)",
+          "action": "Apply the mentioned duty",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "",
+          "requirement": null,
+          "action": "Declared subheading not allowed",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        }
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AT",
+            "description": "Austria",
+            "geographical_area_id": "AT"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BE",
+            "description": "Belgium",
+            "geographical_area_id": "BE"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BG",
+            "description": "Bulgaria",
+            "geographical_area_id": "BG"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "The Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos (Keeling) Islands",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo (Democratic Republic)",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "CY",
+            "description": "Cyprus",
+            "geographical_area_id": "CY"
+          },
+          {
+            "id": "CZ",
+            "description": "Czechia",
+            "geographical_area_id": "CZ"
+          },
+          {
+            "id": "DE",
+            "description": "Germany",
+            "geographical_area_id": "DE"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DK",
+            "description": "Denmark",
+            "geographical_area_id": "DK"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EE",
+            "description": "Estonia",
+            "geographical_area_id": "EE"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ES",
+            "description": "Spain",
+            "geographical_area_id": "ES"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FI",
+            "description": "Finland",
+            "geographical_area_id": "FI"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "FR",
+            "description": "France",
+            "geographical_area_id": "FR"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "The Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GR",
+            "description": "Greece",
+            "geographical_area_id": "GR"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HR",
+            "description": "Croatia",
+            "geographical_area_id": "HR"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "HU",
+            "description": "Hungary",
+            "geographical_area_id": "HU"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IE",
+            "description": "Ireland",
+            "geographical_area_id": "IE"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "IT",
+            "description": "Italy",
+            "geographical_area_id": "IT"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "South Korea",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LT",
+            "description": "Lithuania",
+            "geographical_area_id": "LT"
+          },
+          {
+            "id": "LU",
+            "description": "Luxembourg",
+            "geographical_area_id": "LU"
+          },
+          {
+            "id": "LV",
+            "description": "Latvia",
+            "geographical_area_id": "LV"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "North Macedonia",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar (Burma)",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MT",
+            "description": "Malta",
+            "geographical_area_id": "MT"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NL",
+            "description": "Netherlands",
+            "geographical_area_id": "NL"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PL",
+            "description": "Poland",
+            "geographical_area_id": "PL"
+          },
+          {
+            "id": "PM",
+            "description": "Saint Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn, Henderson, Ducie and Oeno Islands",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied Palestinian Territories",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PT",
+            "description": "Portugal",
+            "geographical_area_id": "PT"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RO",
+            "description": "Romania",
+            "geographical_area_id": "RO"
+          },
+          {
+            "id": "RU",
+            "description": "Russia",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SE",
+            "description": "Sweden",
+            "geographical_area_id": "SE"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SI",
+            "description": "Slovenia",
+            "geographical_area_id": "SI"
+          },
+          {
+            "id": "SK",
+            "description": "Slovakia",
+            "geographical_area_id": "SK"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Eswatini",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "East Timor",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "British Virgin Islands",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "United States Virgin Islands",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Vietnam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZB",
+            "description": "Belgian Continental Shelf",
+            "geographical_area_id": "ZB"
+          },
+          {
+            "id": "ZD",
+            "description": "Danish Continental Shelf",
+            "geographical_area_id": "ZD"
+          },
+          {
+            "id": "ZE",
+            "description": "Irish Continental Shelf",
+            "geographical_area_id": "ZE"
+          },
+          {
+            "id": "ZF",
+            "description": "French Continental Shelf",
+            "geographical_area_id": "ZF"
+          },
+          {
+            "id": "ZG",
+            "description": "German Continental Shelf",
+            "geographical_area_id": "ZG"
+          },
+          {
+            "id": "ZH",
+            "description": "Netherlands Continental Shelf",
+            "geographical_area_id": "ZH"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZN",
+            "description": "Norwegian Continental Shelf",
+            "geographical_area_id": "ZN"
+          },
+          {
+            "id": "ZU",
+            "description": "United Kingdom Continental Shelf",
+            "geographical_area_id": "ZU"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+        {
+          "code": "EU001",
+          "description": "Suspension of duties is subject to Authorised-Use customs supervision in accordance with Chapter 4 of The Customs (Special Procedures and Outward Processing) (EU Exit) Regulations 2018 (UK Statutory Instruments 2018 No. 1249)",
+          "formatted_description": "Suspension of duties is subject to Authorised-Use customs supervision in accordance with Chapter 4 of The Customs (Special Procedures and Outward Processing) (EU Exit) Regulations 2018 (UK Statutory Instruments 2018 No. 1249)"
+        },
+        {
+          "code": "TM861",
+          "description": "This suspension does not apply to any mixtures, preparations or products made up of different components containing these products.",
+          "formatted_description": "This suspension does not apply to any mixtures, preparations or products made up of different components containing these products."
+        }
+      ],
+      "order_number": null
+    },
+    {
+      "id": -1009487022,
+      "origin": "uk",
+      "effective_start_date": "2019-09-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": true,
+      "duty_expression": {
+        "base": "20.00 %",
+        "formatted_base": "<span>20.00</span> %"
+      },
+      "measure_type": {
+        "description": "Value added tax",
+        "national": null,
+        "measure_type_series_id": "P",
+        "id": "305"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "1970-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": null,
+          "officialjournal_page": null,
+          "published_date": "1970-01-01",
+          "regulation_code": "V70AT/19",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?instInvStatus=ALL&or0=DN%3D32019V70AT*,DN-old%3D32019V70AT*&DTC=false&type=advanced"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 20.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AT",
+            "description": "Austria",
+            "geographical_area_id": "AT"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BE",
+            "description": "Belgium",
+            "geographical_area_id": "BE"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BG",
+            "description": "Bulgaria",
+            "geographical_area_id": "BG"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "The Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos (Keeling) Islands",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo (Democratic Republic)",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "CY",
+            "description": "Cyprus",
+            "geographical_area_id": "CY"
+          },
+          {
+            "id": "CZ",
+            "description": "Czechia",
+            "geographical_area_id": "CZ"
+          },
+          {
+            "id": "DE",
+            "description": "Germany",
+            "geographical_area_id": "DE"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DK",
+            "description": "Denmark",
+            "geographical_area_id": "DK"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EE",
+            "description": "Estonia",
+            "geographical_area_id": "EE"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ES",
+            "description": "Spain",
+            "geographical_area_id": "ES"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FI",
+            "description": "Finland",
+            "geographical_area_id": "FI"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "FR",
+            "description": "France",
+            "geographical_area_id": "FR"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "The Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GR",
+            "description": "Greece",
+            "geographical_area_id": "GR"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HR",
+            "description": "Croatia",
+            "geographical_area_id": "HR"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "HU",
+            "description": "Hungary",
+            "geographical_area_id": "HU"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IE",
+            "description": "Ireland",
+            "geographical_area_id": "IE"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "IT",
+            "description": "Italy",
+            "geographical_area_id": "IT"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "South Korea",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LT",
+            "description": "Lithuania",
+            "geographical_area_id": "LT"
+          },
+          {
+            "id": "LU",
+            "description": "Luxembourg",
+            "geographical_area_id": "LU"
+          },
+          {
+            "id": "LV",
+            "description": "Latvia",
+            "geographical_area_id": "LV"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "North Macedonia",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar (Burma)",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MT",
+            "description": "Malta",
+            "geographical_area_id": "MT"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NL",
+            "description": "Netherlands",
+            "geographical_area_id": "NL"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PL",
+            "description": "Poland",
+            "geographical_area_id": "PL"
+          },
+          {
+            "id": "PM",
+            "description": "Saint Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn, Henderson, Ducie and Oeno Islands",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied Palestinian Territories",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PT",
+            "description": "Portugal",
+            "geographical_area_id": "PT"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RO",
+            "description": "Romania",
+            "geographical_area_id": "RO"
+          },
+          {
+            "id": "RU",
+            "description": "Russia",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SE",
+            "description": "Sweden",
+            "geographical_area_id": "SE"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SI",
+            "description": "Slovenia",
+            "geographical_area_id": "SI"
+          },
+          {
+            "id": "SK",
+            "description": "Slovakia",
+            "geographical_area_id": "SK"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Eswatini",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "East Timor",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "British Virgin Islands",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "United States Virgin Islands",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Vietnam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZB",
+            "description": "Belgian Continental Shelf",
+            "geographical_area_id": "ZB"
+          },
+          {
+            "id": "ZD",
+            "description": "Danish Continental Shelf",
+            "geographical_area_id": "ZD"
+          },
+          {
+            "id": "ZE",
+            "description": "Irish Continental Shelf",
+            "geographical_area_id": "ZE"
+          },
+          {
+            "id": "ZF",
+            "description": "French Continental Shelf",
+            "geographical_area_id": "ZF"
+          },
+          {
+            "id": "ZG",
+            "description": "German Continental Shelf",
+            "geographical_area_id": "ZG"
+          },
+          {
+            "id": "ZH",
+            "description": "Netherlands Continental Shelf",
+            "geographical_area_id": "ZH"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZN",
+            "description": "Norwegian Continental Shelf",
+            "geographical_area_id": "ZN"
+          },
+          {
+            "id": "ZU",
+            "description": "United Kingdom Continental Shelf",
+            "geographical_area_id": "ZU"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+        {
+          "code": "03020",
+          "description": "UK VAT standard rate",
+          "formatted_description": "UK VAT standard rate"
+        }
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20125860,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1013",
+        "description": "European Union",
+        "geographical_area_id": "1013",
+        "children_geographical_areas": [
+          {
+            "id": "AT",
+            "description": "Austria",
+            "geographical_area_id": "AT"
+          },
+          {
+            "id": "BE",
+            "description": "Belgium",
+            "geographical_area_id": "BE"
+          },
+          {
+            "id": "BG",
+            "description": "Bulgaria",
+            "geographical_area_id": "BG"
+          },
+          {
+            "id": "CY",
+            "description": "Cyprus",
+            "geographical_area_id": "CY"
+          },
+          {
+            "id": "CZ",
+            "description": "Czechia",
+            "geographical_area_id": "CZ"
+          },
+          {
+            "id": "DE",
+            "description": "Germany",
+            "geographical_area_id": "DE"
+          },
+          {
+            "id": "DK",
+            "description": "Denmark",
+            "geographical_area_id": "DK"
+          },
+          {
+            "id": "EE",
+            "description": "Estonia",
+            "geographical_area_id": "EE"
+          },
+          {
+            "id": "ES",
+            "description": "Spain",
+            "geographical_area_id": "ES"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FI",
+            "description": "Finland",
+            "geographical_area_id": "FI"
+          },
+          {
+            "id": "FR",
+            "description": "France",
+            "geographical_area_id": "FR"
+          },
+          {
+            "id": "GR",
+            "description": "Greece",
+            "geographical_area_id": "GR"
+          },
+          {
+            "id": "HR",
+            "description": "Croatia",
+            "geographical_area_id": "HR"
+          },
+          {
+            "id": "HU",
+            "description": "Hungary",
+            "geographical_area_id": "HU"
+          },
+          {
+            "id": "IE",
+            "description": "Ireland",
+            "geographical_area_id": "IE"
+          },
+          {
+            "id": "IT",
+            "description": "Italy",
+            "geographical_area_id": "IT"
+          },
+          {
+            "id": "LT",
+            "description": "Lithuania",
+            "geographical_area_id": "LT"
+          },
+          {
+            "id": "LU",
+            "description": "Luxembourg",
+            "geographical_area_id": "LU"
+          },
+          {
+            "id": "LV",
+            "description": "Latvia",
+            "geographical_area_id": "LV"
+          },
+          {
+            "id": "MT",
+            "description": "Malta",
+            "geographical_area_id": "MT"
+          },
+          {
+            "id": "NL",
+            "description": "Netherlands",
+            "geographical_area_id": "NL"
+          },
+          {
+            "id": "PL",
+            "description": "Poland",
+            "geographical_area_id": "PL"
+          },
+          {
+            "id": "PT",
+            "description": "Portugal",
+            "geographical_area_id": "PT"
+          },
+          {
+            "id": "RO",
+            "description": "Romania",
+            "geographical_area_id": "RO"
+          },
+          {
+            "id": "SE",
+            "description": "Sweden",
+            "geographical_area_id": "SE"
+          },
+          {
+            "id": "SI",
+            "description": "Slovenia",
+            "geographical_area_id": "SI"
+          },
+          {
+            "id": "SK",
+            "description": "Slovakia",
+            "geographical_area_id": "SK"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20079787,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1033",
+        "description": "CARIFORUM",
+        "geographical_area_id": "1033",
+        "children_geographical_areas": [
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BS",
+            "description": "The Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent",
+            "geographical_area_id": "VC"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20079882,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1034",
+        "description": "Eastern and Southern Africa States",
+        "geographical_area_id": "1034",
+        "children_geographical_areas": [
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20079977,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1035",
+        "description": "SADC EPA",
+        "geographical_area_id": "1035",
+        "children_geographical_areas": [
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "SZ",
+            "description": "Eswatini",
+            "geographical_area_id": "SZ"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20128817,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "2005",
+        "description": "GSP – Least Developed Countries",
+        "geographical_area_id": "2005",
+        "children_geographical_areas": [
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "CD",
+            "description": "Congo (Democratic Republic)",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "GM",
+            "description": "The Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar (Burma)",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TL",
+            "description": "East Timor",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20019166,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "12.60 GBP / 100 kg",
+        "formatted_base": "<span>12.60</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr>"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 12.6,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "2020",
+        "description": "GSP – General Framework",
+        "geographical_area_id": "2020",
+        "children_geographical_areas": [
+          {
+            "id": "CG",
+            "description": "Congo",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NU",
+            "description": "Niue",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VN",
+            "description": "Vietnam",
+            "geographical_area_id": "VN"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20019168,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "2027",
+        "description": "GSP – Enhanced Framework",
+        "geographical_area_id": "2027",
+        "children_geographical_areas": [
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20091283,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "2080",
+        "description": "OCTs (Overseas Countries and Territories)",
+        "geographical_area_id": "2080",
+        "children_geographical_areas": [
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn, Henderson, Ducie and Oeno Islands",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "VG",
+            "description": "British Virgin Islands",
+            "geographical_area_id": "VG"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20055453,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "2200",
+        "description": "Central America",
+        "geographical_area_id": "2200",
+        "children_geographical_areas": [
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20115303,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "CA",
+        "description": "Canada",
+        "geographical_area_id": "CA"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20079692,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "CI",
+        "description": "Ivory Coast",
+        "geographical_area_id": "CI"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20072018,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "3.90 % MAX 18.00 GBP / 100 kg",
+        "formatted_base": "<span>3.90</span> % MAX <span>18.00</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr>"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 3.9,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        },
+        {
+          "duty_expression_id": "17",
+          "duty_amount": 18.0,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "Maximum",
+          "duty_expression_abbreviation": "MAX",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "CL",
+        "description": "Chile",
+        "geographical_area_id": "CL"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20120654,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "CM",
+        "description": "Cameroon",
+        "geographical_area_id": "CM"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20049791,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "CO",
+        "description": "Colombia",
+        "geographical_area_id": "CO"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20051183,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "EC",
+        "description": "Ecuador",
+        "geographical_area_id": "EC"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20091811,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "EG",
+        "description": "Egypt",
+        "geographical_area_id": "EG"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20080072,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "FJ",
+        "description": "Fiji",
+        "geographical_area_id": "FJ"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20057026,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "GE",
+        "description": "Georgia",
+        "geographical_area_id": "GE"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20133264,
+      "origin": "eu",
+      "effective_start_date": "2021-03-05T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-03-05T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-03-03",
+          "regulation_code": "P0241/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "GH",
+        "description": "Ghana",
+        "geographical_area_id": "GH"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20073209,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "IL",
+        "description": "Israel",
+        "geographical_area_id": "IL"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20091109,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "IS",
+        "description": "Iceland",
+        "geographical_area_id": "IS"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20110209,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "JP",
+        "description": "Japan",
+        "geographical_area_id": "JP"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20079597,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "KE",
+        "description": "Kenya",
+        "geographical_area_id": "KE"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20078361,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "KR",
+        "description": "South Korea",
+        "geographical_area_id": "KR"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20076658,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "LB",
+        "description": "Lebanon",
+        "geographical_area_id": "LB"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20097551,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "MA",
+        "description": "Morocco",
+        "geographical_area_id": "MA"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20111210,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "MD",
+        "description": "Moldova",
+        "geographical_area_id": "MD"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20093100,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "MK",
+        "description": "North Macedonia",
+        "geographical_area_id": "MK"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20120423,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "MX",
+        "description": "Mexico",
+        "geographical_area_id": "MX"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20053066,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "PE",
+        "description": "Peru",
+        "geographical_area_id": "PE"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20080357,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "PG",
+        "description": "Papua New Guinea",
+        "geographical_area_id": "PG"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20079389,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "PS",
+        "description": "Occupied Palestinian Territories",
+        "geographical_area_id": "PS"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20105467,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "6.60 % + 12.00 GBP / 100 kg MAX 18.00 GBP / 100 kg",
+        "formatted_base": "<span>6.60</span> % + <span>12.00</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr> MAX <span>18.00</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr>"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 6.6,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        },
+        {
+          "duty_expression_id": "04",
+          "duty_amount": 12.0,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "+ % or amount",
+          "duty_expression_abbreviation": "+",
+          "measurement_unit_qualifier_code": null
+        },
+        {
+          "duty_expression_id": "17",
+          "duty_amount": 18.0,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "Maximum",
+          "duty_expression_abbreviation": "MAX",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "SG",
+        "description": "Singapore",
+        "geographical_area_id": "SG"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20125972,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "SM",
+        "description": "San Marino",
+        "geographical_area_id": "SM"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20102882,
+      "origin": "eu",
+      "effective_start_date": "2021-01-20T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "TR",
+        "description": "Turkey",
+        "geographical_area_id": "TR"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20081734,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "UA",
+        "description": "Ukraine",
+        "geographical_area_id": "UA"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20108187,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "13.80 % MIN 13.00 GBP / 100 kg MAX 15.00 GBP / 100 kg",
+        "formatted_base": "<span>13.80</span> % MIN <span>13.00</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr> MAX <span>15.00</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr>"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 13.8,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        },
+        {
+          "duty_expression_id": "15",
+          "duty_amount": 13.0,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "Minimum",
+          "duty_expression_abbreviation": "MIN",
+          "measurement_unit_qualifier_code": null
+        },
+        {
+          "duty_expression_id": "17",
+          "duty_amount": 15.0,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "DTN",
+          "duty_expression_description": "Maximum",
+          "duty_expression_abbreviation": "MAX",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "VN",
+        "description": "Vietnam",
+        "geographical_area_id": "VN"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20080262,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "WS",
+        "description": "Samoa",
+        "geographical_area_id": "WS"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20126170,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "XC",
+        "description": "Ceuta",
+        "geographical_area_id": "XC"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20074692,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "XK",
+        "description": "Kosovo",
+        "geographical_area_id": "XK"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20126282,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "XL",
+        "description": "Melilla",
+        "geographical_area_id": "XL"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    },
+    {
+      "id": 20084888,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "0.00 %",
+        "formatted_base": "<span>0.00</span> %"
+      },
+      "measure_type": {
+        "description": "Tariff preference",
+        "national": null,
+        "measure_type_series_id": "C",
+        "id": "142"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2021,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "duty_expression_id": "01",
+          "duty_amount": 0.0,
+          "monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": null,
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit_qualifier_code": null
+        }
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "ZA",
+        "description": "South Africa",
+        "geographical_area_id": "ZA"
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+
+      ],
+      "order_number": null
+    }
+  ],
+  "export_measures": [
+
+  ],
+  "producline_suffix": "80",
+  "number_indents": 4,
+  "description": "whether or not cut in regular size, having a custom value of not less than Euro 450 per 100 kg net weight, for use as binder or wrapper for the manufacture of goods falling within subheading 2402 10 00",
+  "goods_nomenclature_item_id": "2401109591",
+  "bti_url": "https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code",
+  "formatted_description": "whether or not cut in regular size, having a custom value of not less than Euro 450 per 100 kg net weight, for use as binder or wrapper for the manufacture of goods falling within subheading 2402 10 00",
+  "description_plain": "whether or not cut in regular size, having a custom value of not less than Euro 450 per 100 kg net weight, for use as binder or wrapper for the manufacture of goods falling within subheading 2402 10 00",
+  "consigned": false,
+  "consigned_from": null,
+  "basic_duty_rate": "<span>18.00</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr>",
+  "meursing_code": false,
+  "declarable": true,
+  "footnotes": [
+    {
+      "code": "TN701",
+      "description": "According to the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it shall be prohibited to import into European Union goods originating in Crimea or Sevastopol.<br>The prohibition shall not apply in respect of: <br>(a) the execution until 26 September 2014, of trade contracts concluded before 25 June 2014, or of ancillary contracts necessary for the execution of such contracts, provided that the natural or legal persons, entity or body seeking to perform the contract have notified, at least 10 working days in advance, the activity or transaction to the competent authority of the Member State in which they are established. <br>(b) goods originating in Crimea or Sevastopol which have been made available to the Ukrainian authorities for examination, for which compliance with the conditions conferring entitlement to preferential origin has been verified and for which a certificate of origin has been issued in accordance with Regulation (EU) No 978/2012 and Regulation (EU) No 374/2014 or in accordance with the EU-Ukraine Association Agreement.",
+      "formatted_description": "According to the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it shall be prohibited to import into European Union goods originating in Crimea or Sevastopol.<br>The prohibition shall not apply in respect of: <br>(a) the execution until 26 September 2014, of trade contracts concluded before 25 June 2014, or of ancillary contracts necessary for the execution of such contracts, provided that the natural or legal persons, entity or body seeking to perform the contract have notified, at least 10 working days in advance, the activity or transaction to the competent authority of the Member State in which they are established. <br>(b) goods originating in Crimea or Sevastopol which have been made available to the Ukrainian authorities for examination, for which compliance with the conditions conferring entitlement to preferential origin has been verified and for which a certificate of origin has been issued in accordance with Regulation (EU) No 978/2012 and Regulation (EU) No 374/2014 or in accordance with the EU-Ukraine Association Agreement."
+    }
+  ],
+  "section": {
+    "numeral": "IV",
+    "title": "Prepared foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes",
+    "position": 4,
+    "section_note": "In this section the term “pellets` means products which have been agglomerated either directly by compression or by the addition of a binder in a proportion not exceeding 3% by weight."
+  },
+  "chapter": {
+    "goods_nomenclature_item_id": "2400000000",
+    "description": "TOBACCO AND MANUFACTURED TOBACCO SUBSTITUTES",
+    "formatted_description": "Tobacco and manufactured tobacco substitutes",
+    "chapter_note": "* 1\\. This chapter does not cover medicinal cigarettes (Chapter 30).\r\n\r\n## Subheading note ##\r\n\r\n* 1\\. For the purposes of subheading 2403 11, the expression ‘water-pipe tobacco’ means tobacco intended for smoking in a water pipe and which consists of a mixture of tobacco and glycerol, whether or not containing aromatic oils and extracts, molasses or sugar, and whether or not flavoured with fruit. However, tobacco-free products intended for smoking in a water pipe are excluded from this subheading.",
+    "guides": [
+      {
+        "title": "Tobacco and manufactured tobacco substitutes",
+        "url": "https://www.gov.uk/guidance/classifying-tobacco"
+      }
+    ]
+  },
+  "heading": {
+    "goods_nomenclature_item_id": "2401000000",
+    "description": "Unmanufactured tobacco; tobacco refuse",
+    "formatted_description": "Unmanufactured tobacco; tobacco refuse",
+    "description_plain": "Unmanufactured tobacco; tobacco refuse"
+  },
+  "ancestors": [
+    {
+      "producline_suffix": "80",
+      "description": "Tobacco, not stemmed/stripped",
+      "number_indents": 1,
+      "goods_nomenclature_item_id": "2401100000",
+      "formatted_description": "Tobacco, not stemmed/stripped",
+      "description_plain": "Tobacco, not stemmed/stripped"
+    },
+    {
+      "producline_suffix": "80",
+      "description": "Other",
+      "number_indents": 2,
+      "goods_nomenclature_item_id": "2401109500",
+      "formatted_description": "Other",
+      "description_plain": "Other"
+    },
+    {
+      "producline_suffix": "10",
+      "description": "Other tobacco",
+      "number_indents": 3,
+      "goods_nomenclature_item_id": "2401109591",
+      "formatted_description": "Other tobacco",
+      "description_plain": "Other tobacco"
+    }
+  ]
+}

--- a/spec/models/api/measure_component_spec.rb
+++ b/spec/models/api/measure_component_spec.rb
@@ -1,4 +1,17 @@
 RSpec.describe Api::MeasureComponent do
+  subject(:component) do
+    described_class.new(
+      'duty_expression_id' => '01',
+      'duty_amount' => 10.0,
+      'monetary_unit_code' => nil,
+      'monetary_unit_abbreviation' => nil,
+      'measurement_unit_code' => nil,
+      'duty_expression_description' => '% or amount',
+      'duty_expression_abbreviation' => '%',
+      'measurement_unit_qualifier_code' => nil,
+    )
+  end
+
   it_behaves_like 'a resource that has attributes', duty_expression_id: '01',
                                                     duty_amount: 0.0,
                                                     monetary_unit_code: nil,
@@ -7,4 +20,129 @@ RSpec.describe Api::MeasureComponent do
                                                     duty_expression_description: '% or amount',
                                                     duty_expression_abbreviation: '%',
                                                     measurement_unit_qualifier_code: nil
+
+  describe '#ad_valorem?' do
+    context 'when it is ad_valorem' do
+      it 'returns true' do
+        expect(component).to be_ad_valorem
+      end
+    end
+
+    context 'when it is not ad_valorem' do
+      subject(:component) do
+        described_class.new(
+          'duty_expression_id' => '01',
+          'duty_amount' => 10.0,
+          'monetary_unit_code' => 'GBP',
+          'monetary_unit_abbreviation' => nil,
+          'measurement_unit_code' => 'DTN',
+          'duty_expression_description' => '% or amount',
+          'duty_expression_abbreviation' => '%',
+          'measurement_unit_qualifier_code' => nil,
+        )
+      end
+
+      it 'returns false' do
+        expect(component).not_to be_ad_valorem
+      end
+    end
+  end
+
+  describe '#specific_duty?' do
+    subject(:component) do
+      described_class.new(
+        'duty_expression_id' => '01',
+        'duty_amount' => 10.0,
+        'monetary_unit_code' => 'GBP',
+        'monetary_unit_abbreviation' => nil,
+        'measurement_unit_code' => nil,
+        'duty_expression_description' => '% or amount',
+        'duty_expression_abbreviation' => '%',
+        'measurement_unit_qualifier_code' => nil,
+      )
+    end
+
+    context 'when monetary_unit_code is present' do
+      it 'returns true' do
+        expect(component).to be_specific_duty
+      end
+    end
+
+    context 'when measurement_unit_code is present' do
+      subject(:component) do
+        described_class.new(
+          'duty_expression_id' => '01',
+          'duty_amount' => 10.0,
+          'monetary_unit_code' => nil,
+          'monetary_unit_abbreviation' => nil,
+          'measurement_unit_code' => 'DTN',
+          'duty_expression_description' => '% or amount',
+          'duty_expression_abbreviation' => '%',
+          'measurement_unit_qualifier_code' => nil,
+        )
+      end
+
+      it 'returns true' do
+        expect(component).to be_specific_duty
+      end
+    end
+  end
+
+  describe '#no_specific_duty?' do
+    subject(:component) do
+      described_class.new(
+        'duty_expression_id' => '01',
+        'duty_amount' => 10.0,
+        'monetary_unit_code' => nil,
+        'monetary_unit_abbreviation' => nil,
+        'measurement_unit_code' => nil,
+        'duty_expression_description' => '% or amount',
+        'duty_expression_abbreviation' => '%',
+        'measurement_unit_qualifier_code' => nil,
+      )
+    end
+
+    context 'when not a specific duty' do
+      it 'returns true' do
+        expect(component).to be_no_specific_duty
+      end
+    end
+  end
+
+  describe '#conjunction_operator?' do
+    subject(:component) do
+      described_class.new(
+        'duty_expression_id' => '01',
+        'duty_amount' => 10.0,
+        'monetary_unit_code' => nil,
+        'monetary_unit_abbreviation' => nil,
+        'measurement_unit_code' => nil,
+        'duty_expression_description' => '% or amount',
+        'duty_expression_abbreviation' => duty_expression_abbreviation,
+        'measurement_unit_qualifier_code' => nil,
+      )
+    end
+
+    let(:duty_expression_abbreviation) { '%' }
+
+    context 'when it is a conjunction operator' do
+      let(:duty_expression_abbreviation) { 'MAX' }
+
+      it 'returns true' do
+        expect(component).to be_conjunction_operator
+      end
+    end
+
+    context 'when it is not a conjunction operator' do
+      it 'returns false' do
+        expect(component).not_to be_conjunction_operator
+      end
+    end
+  end
+
+  describe '#operator' do
+    it 'returns %' do
+      expect(component.operator).to eq '%'
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ if ENV['COVERAGE']
   SimpleCov.start do
     minimum_coverage 90
     maximum_coverage_drop 0.25
+    add_filter '/spec/'
   end
 end
 

--- a/spec/services/expression_evaluators/compound_spec.rb
+++ b/spec/services/expression_evaluators/compound_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe ExpressionEvaluators::Compound do
+  subject(:evaluator) do
+    described_class.new(measure, user_session)
+  end
+
+  let(:measure) do
+    Api::Measure.new(
+      'id' => 3_211_138,
+      'duty_expression' => {
+        'base' => '10.20 % + 93.10 EUR / 100 kg',
+        'formatted_base' => "<span>10.20</span> % + <span>93.10</span> EUR / <abbr title='Hectokilogram'>100 kg</abbr>",
+      },
+      'measure_components' => [
+        {
+          'duty_expression_id' => '01',
+          'duty_amount' => 13.8,
+          'monetary_unit_code' => nil,
+          'monetary_unit_abbreviation' => nil,
+          'measurement_unit_code' => nil,
+          'duty_expression_description' => '% or amount',
+          'duty_expression_abbreviation' => '%',
+          'measurement_unit_qualifier_code' => nil,
+        },
+        {
+          'duty_expression_id' => '15',
+          'duty_amount' => 13.0,
+          'monetary_unit_code' => 'GBP',
+          'monetary_unit_abbreviation' => nil,
+          'measurement_unit_code' => 'DTN',
+          'duty_expression_description' => 'Minimum',
+          'duty_expression_abbreviation' => 'MIN',
+          'measurement_unit_qualifier_code' => nil,
+        },
+        {
+          'duty_expression_id' => '17',
+          'duty_amount' => 15.0,
+          'monetary_unit_code' => 'GBP',
+          'monetary_unit_abbreviation' => nil,
+          'measurement_unit_code' => 'DTN',
+          'duty_expression_description' => 'Maximum',
+          'duty_expression_abbreviation' => 'MAX',
+          'measurement_unit_qualifier_code' => nil,
+        },
+        {
+          'duty_expression_id' => '36',
+          'duty_amount' => 7.0,
+          'monetary_unit_code' => 'GBP',
+          'monetary_unit_abbreviation' => nil,
+          'measurement_unit_code' => 'DTN',
+          'duty_expression_description' => '-',
+          'duty_expression_abbreviation' => '-',
+          'measurement_unit_qualifier_code' => nil,
+        },
+      ],
+    )
+  end
+
+  let(:expected_evaluation) do
+    {
+      value: 8.0,
+      formatted_value: '£8.00',
+      calculation: '10.20 % + 93.10 EUR / 100 kg',
+    }
+  end
+
+  let(:session) do
+    {
+      'answers' => {
+        'customs_value' => {
+          'insurance_cost' => '1000',
+          'monetary_value' => '',
+          'shipping_cost' => '',
+        },
+        'measure_amount' => {
+          'dtn' => '1',
+        },
+      },
+      'commodity_source' => 'xi',
+      'commodity_code' => '0102291010',
+    }
+  end
+
+  let(:user_session) { UserSession.new(session) }
+
+  it 'returns a properly calculated evaluation' do
+    expect(evaluator.call).to eq(expected_evaluation)
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds compound evaluations for third country duty option

### Why?

I am doing this because:

- These are needed when we have measures that are expressed in either percentage or measure unit terms that are combined with an operator
