### PR TITLE
Use consistent formatting for trade details

### DIFF
--- a/app/views/wizard/steps/duty/calculations/_trade_details.html.erb
+++ b/app/views/wizard/steps/duty/calculations/_trade_details.html.erb
@@ -38,7 +38,7 @@
           Valuation of import:
         </dt>
         <dd class="govuk-summary-list__value govuk-body-s">
-          £<%= user_session.total_amount %>
+          <%= number_to_currency(user_session.total_amount) %>
         </dd>
       </div>
     </dl>


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [ ] Format the value of import under the trade details section

### Why?

I am doing this because:

- Keep the formatting consistent