### PR TITLE
Skip measure amount page if no applicable units

### DIFF
--- a/app/models/wizard/steps/confirmation.rb
+++ b/app/models/wizard/steps/confirmation.rb
@@ -8,7 +8,9 @@ module Wizard
       end
 
       def previous_step_path
-        return measure_amount_path if user_session.gb_to_ni_route?
+        return measure_amount_path unless user_session.measure_amount.empty?
+
+        customs_value_path
       end
     end
   end

--- a/app/models/wizard/steps/customs_value.rb
+++ b/app/models/wizard/steps/customs_value.rb
@@ -33,7 +33,11 @@ module Wizard
       end
 
       def next_step_path
-        measure_amount_path
+        return measure_amount_path if filtered_commodity.applicable_measure_units.present?
+
+        user_session.measure_amount = {}
+
+        confirm_path
       end
 
       def previous_step_path
@@ -47,6 +51,18 @@ module Wizard
         return trade_remedies_path if user_session.trade_defence
 
         certificate_of_origin_path
+      end
+
+      def filtered_commodity(filter: default_filter)
+        Api::Commodity.build(
+          user_session.commodity_source,
+          user_session.commodity_code,
+          filter,
+        )
+      end
+
+      def default_filter
+        { 'filter[geographical_area_id]' => user_session.country_of_origin }
       end
     end
   end

--- a/spec/models/wizard/steps/confirmation_spec.rb
+++ b/spec/models/wizard/steps/confirmation_spec.rb
@@ -13,16 +13,27 @@ RSpec.describe Wizard::Steps::Confirmation do
   describe '#next_step_path' do
     include Rails.application.routes.url_helpers
 
-    xit 'to be added' do
+    it 'return duty path' do
+      expect(
+        step.next_step_path,
+      ).to eq(
+        duty_path,
+      )
     end
   end
 
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
 
-    context 'when on GB to NI route' do
+    context 'when there are measure amounts on the session' do
+      let(:measure_amount) do
+        {
+          'dtn' => 1,
+        }
+      end
+
       before do
-        allow(user_session).to receive(:gb_to_ni_route?).and_return(true)
+        allow(user_session).to receive(:measure_amount).and_return(measure_amount)
       end
 
       it 'returns measure_amount_path' do
@@ -30,6 +41,20 @@ RSpec.describe Wizard::Steps::Confirmation do
           step.previous_step_path,
         ).to eq(
           measure_amount_path,
+        )
+      end
+    end
+
+    context 'when there are no measure amounts on the session' do
+      before do
+        allow(user_session).to receive(:measure_amount).and_return({})
+      end
+
+      it 'returns measure_amount_path' do
+        expect(
+          step.previous_step_path,
+        ).to eq(
+          customs_value_path,
         )
       end
     end


### PR DESCRIPTION
### Jira link

HOTT-530

### What?

I have added/removed/altered:

- [x] Skip measure amount page if no applicable units

### Why?

I am doing this because:

- There are cases when a commodity does not have
applicable measure units available. In this case, users
should jump straight to the confirmation page.