### PR TITLE
Fix incorrect copy on country of origin

### DIFF
--- a/app/views/wizard/steps/country_of_origin/_xi_options.html.erb
+++ b/app/views/wizard/steps/country_of_origin/_xi_options.html.erb
@@ -1,7 +1,7 @@
 <%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: country_of_origin_path do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_collection_radio_buttons :country_of_origin, Wizard::Steps::CountryOfOrigin::XI_OPTIONS, :id, :name,
-                                       legend: { text: 'Which country are the goods dispatched from?', size: 'xl', tag: 'h1' }, hint: { text: 'The duty you are charged may be dependent on the part of the UK to which you are importing.' }, include_hidden: true %>
+                                       legend: { text: 'Which country are the goods dispatched from?', size: 'xl', tag: 'h1' }, hint: { text: 'The duty you are charged may be dependent on the country of dispatch of the goods being imported.' }, include_hidden: true %>
 
   <%= f.govuk_submit %>
 <% end %>


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [ ] Fix incorrect copy on the country of origin

### Why?

I am doing this because:

- The country of origin page had the wrong message