### PR TITLE
Add start again button for no duty pages

### DIFF
--- a/app/views/wizard/steps/duty/_no_duty.html.erb
+++ b/app/views/wizard/steps/duty/_no_duty.html.erb
@@ -6,3 +6,5 @@
 <% elsif @user_session.gb_to_ni_route? %>
   <%= render 'wizard/steps/duty/gb_to_ni/no_duty' %>
 <% end %>
+
+<%= link_to('Start again', import_date_path, class: 'govuk-button') %>

--- a/app/views/wizard/steps/duty/gb_to_ni/_no_duty.html.erb
+++ b/app/views/wizard/steps/duty/gb_to_ni/_no_duty.html.erb
@@ -29,5 +29,3 @@
   </ul>
   <%= render('wizard/steps/duty/gb_to_ni/shared/note') %>
 <% end %>
-
-<%= link_to('Start again', import_date_path, class: 'govuk-button') %>


### PR DESCRIPTION
### Jira link

HOTT-551

### What?

I have added/removed/altered:

- [x] Add start again button for no duty pages

### Why?

I am doing this because:

- Users need to be able to start the process again.