### PR TITLE
Customs value page succeeds the country of origin

### DIFF
--- a/app/models/wizard/steps/customs_value.rb
+++ b/app/models/wizard/steps/customs_value.rb
@@ -38,6 +38,7 @@ module Wizard
 
       def previous_step_path
         return previous_step_for_gb_to_ni if user_session.gb_to_ni_route?
+        return country_of_origin_path if user_session.row_to_gb_route?
       end
 
       private

--- a/spec/models/wizard/steps/customs_value_spec.rb
+++ b/spec/models/wizard/steps/customs_value_spec.rb
@@ -280,6 +280,20 @@ RSpec.describe Wizard::Steps::CustomsValue do
         end
       end
     end
+
+    context 'when on RoW to GB route' do
+      before do
+        allow(user_session).to receive(:row_to_gb_route?).and_return(true)
+      end
+
+      it 'returns certificate_of_origin_path' do
+        expect(
+          step.previous_step_path,
+        ).to eq(
+          country_of_origin_path,
+        )
+      end
+    end
   end
 
   describe '#next_step_path' do


### PR DESCRIPTION
### Jira link

HOTT-553

### What?

I have added/removed/altered:

- [ ] Allow users to navigate back to the country of origin page from customs value while on RoW to GB

### Why?

I am doing this because:

- Currently, they are stuck on the customs value page while being on RoW to GB and can't go back to country of origin