### PR TITLE
Ignore duty expression id which is only interesting for sequencing

### DIFF
--- a/app/models/api/measure_component.rb
+++ b/app/models/api/measure_component.rb
@@ -13,7 +13,7 @@ module Api
                :measurement_unit_qualifier_code
 
     def ad_valorem?
-      no_specific_duty? && duty_expression_id == '01'
+      no_specific_duty?
     end
 
     def specific_duty?


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Ignore duty expression id when working out whether a component is ad valorem
