### PR TITLE
Updates copy for country-of-origin step

### DIFF
--- a/app/views/wizard/steps/country_of_origin/_gb_options.html.erb
+++ b/app/views/wizard/steps/country_of_origin/_gb_options.html.erb
@@ -14,6 +14,7 @@
 
       <p class="govuk-!-margin-top-3 govuk-hint">When autocomplete results are available, use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.</p>
     </div>
+
     <%= f.govuk_submit %>
   </fieldset>
 <% end %>

--- a/app/views/wizard/steps/country_of_origin/_xi_options.html.erb
+++ b/app/views/wizard/steps/country_of_origin/_xi_options.html.erb
@@ -3,5 +3,10 @@
   <%= f.govuk_collection_radio_buttons :country_of_origin, Wizard::Steps::CountryOfOrigin::XI_OPTIONS, :id, :name,
                                        legend: { text: 'Which country are the goods dispatched from?', size: 'xl', tag: 'h1' }, hint: { text: 'The duty you are charged may be dependent on the country of dispatch of the goods being imported.' }, include_hidden: true %>
 
+  <p class="govuk-body">
+  The functionality to display duties applicable to imports
+  from countries outside of GB and the European Union is currently
+  under construction and will be delivered shortly.
+  </p>
   <%= f.govuk_submit %>
 <% end %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-563
### What?

I have added/removed/altered:

- [x] Updates copy for country of origin step

![Screenshot from 2021-04-12 08-35-26](https://user-images.githubusercontent.com/8156884/114357769-0d7bfc00-9b6a-11eb-9831-5a9f8a551cb9.png)

### Why?

I am doing this because:

- This was missed during implementation
