### PR TITLE
Remove Latest News link

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -15,6 +15,10 @@ module ServiceHelper
     service_url_for("/commodities/#{commodity_code}")
   end
 
+  def feedback_url
+    service_url_for('/feedback')
+  end
+
   private
 
   def service_url_for(relative_path)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
             beta
             </strong>
             <span class="govuk-phase-banner__text">
-            This is a Beta service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
+            This is a Beta service - your <%= link_to('feedback', feedback_url, class:'govuk-link') %> will help us to improve it.
             </span>
           </p>
         </div>

--- a/app/views/navbar/_main.html.erb
+++ b/app/views/navbar/_main.html.erb
@@ -14,9 +14,6 @@
       <li class="govuk-header__navigation-item">
         <%= link_to "Tools", tools_url, class: "govuk-header__link" %>
       </li>
-      <li class="govuk-header__navigation-item">
-        <%= link_to "Latest News", '#', class: "govuk-header__link" %>
-      </li>
     </ul>
   </nav>
 </div>

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -98,4 +98,22 @@ RSpec.describe ServiceHelper do
       end
     end
   end
+
+  describe '#feedback_url' do
+    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
+      it 'returns the dev trade tariff tools url' do
+        expect(helper.feedback_url).to eq(
+          'https://dev.trade-tariff.service.gov.uk/feedback',
+        )
+      end
+    end
+
+    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
+      let(:frontend_url) { nil }
+
+      it 'returns the dev trade tariff tools url' do
+        expect(helper.feedback_url).to eq('#')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Remove Latest News link
- [x] Also link to the correct feedback page.

### Why?

I am doing this because:

- The Lates News page does not exist anymore
- We were not linking to the feedback location