### PR TITLE
Header must not break if referred_service is nil

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -44,6 +44,6 @@ module ServiceHelper
   end
 
   def referred_service
-    params[:referred_service] || session['referred_service']
+    params[:referred_service] || session['referred_service'] || 'uk'
   end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe ServiceHelper do
 
       it { expect(helper.header).to eq('UK Global Online Tariff') }
     end
+
+    context 'when referred_service is not set at all' do
+      let(:service) { nil }
+
+      it { expect(helper.header).to eq('UK Global Online Tariff') }
+    end
   end
 
   describe '#trade_tariff_url' do


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Default to UK if the referred_service is nil


### Why?

I am doing this because:

- There are cases where a referred_service might be missing
from the session or url (e.g 500 error). We want to default
to UK if that happens so the localised header in the
main navbar does not break.


![image](https://user-images.githubusercontent.com/1955084/114567283-fec93e00-9c6a-11eb-8cb6-5be0e7e50530.png)

