### PR TITLE
Adds more tariff preference measure types

### DIFF
--- a/app/models/api/measure_type.rb
+++ b/app/models/api/measure_type.rb
@@ -8,6 +8,8 @@ module Api
       '117' => ::DutyOptions::Suspension::CertainCategoryGoods,
       '119' => ::DutyOptions::Suspension::Airworthiness,
       '142' => ::DutyOptions::TariffPreference,
+      '145' => ::DutyOptions::TariffPreference,
+      '106' => ::DutyOptions::TariffPreference,
       '122' => ::DutyOptions::Quota::NonPreferential,
       '123' => ::DutyOptions::Quota::NonPreferentialEndUse,
       '143' => ::DutyOptions::Quota::Preferential,


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added 145, 106 measure types

### Why?

I am doing this because:

- These are needed for go live of the DC
