### PR TITLE
Add better copy on the error pages

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,8 +1,9 @@
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+      <p class="govuk-body">We could not proceed with calculating your duty.</p>
+      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path) %>.</p>
     </div>
   </div>
 </main>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
       <p class="govuk-body">You may have mistyped the address or the page may have moved.</p>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
+      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path) %>.</p>
     </div>
   </div>
 </main>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
       <p class="govuk-body">Maybe you tried to change something you didn't have access to.</p>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
+      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path) %>.</p>
     </div>
   </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root to: proc { [404, {}, ['Not found.']] }
+
   scope path: '/duty-calculator/' do
     get 'import-date', to: 'wizard/steps/import_date#show'
     post 'import-date', to: 'wizard/steps/import_date#create'


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Add better copy on the error pages
- [x] Also return 404 for the root path as we don't have a page for that

### Why?

I am doing this because:

- Users should be able to navigate their way around a 500 or similar error and keep being able to use the service