### PR TITLE
Allow duty-calculator to reach the internal backends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,10 @@ commands:
 
             # Map dark route
             cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
+
+            # Enable routing from this service to the backend applications which are private
+            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" --protocol tcp --port 8080
+            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_UK-<< parameters.environment_key >>"  --protocol tcp --port 8080
       - run:
           name: "Verify new version is working on dark URL."
           command: |


### PR DESCRIPTION
### Jira link

n/a 

### What?

I have added/removed/altered:

- [ ] Allows duty-calculator to talk with the backends via internal network 

### Why?

I am doing this because:

- We don't want to go out and in via the internet to reach a neighbour app 
-


### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Makes changes to our complex routing setup that may affect apis to proxying to backend
