### PR TITLE
Updates uktt gem

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
-API_SERVICE_BACKEND_URL_OPTIONS={"uk":"https://dev.trade-tariff.service.gov.uk","xi":"https://dev.trade-tariff.service.gov.uk/xi"}
+API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000/","xi":"http://localhost:3000/"}
 DUTY_CALCULATOR_HOST=http://test.host
 TRADE_TARIFF_FRONTEND_URL="https://dev.trade-tariff.service.gov.uk"
+PORT=3002

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'logstash-event'
 gem 'govuk_design_system_formbuilder'
 
 # API client for the trade tariff api
-gem 'uktt', '~> 1.2.0', git: 'https://github.com/trade-tariff/uktt.git'
+gem 'uktt', '~> 2.0.0', git: 'https://github.com/trade-tariff/uktt.git'
 
 # Sentry for errors tracking
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/trade-tariff/uktt.git
-  revision: 93e87eb0940958093724eea40d57e1403d967697
+  revision: 7413ec76e41b7e62f2daa618887a71343cb77da5
   specs:
-    uktt (1.2.0)
+    uktt (2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -325,7 +325,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
-  uktt (~> 1.2.0)!
+  uktt (~> 2.0.0)!
   web-console (>= 3.3.0)
   webdrivers (~> 4.5)
   webpacker


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Bumps uktt gem to 2.0.0

### Why?

I am doing this because:

- Use internal routes to speak directly with the backend apis
