### PR TITLE
Allow users to now input past import dates

### DIFF
--- a/app/models/wizard/steps/import_date.rb
+++ b/app/models/wizard/steps/import_date.rb
@@ -18,7 +18,7 @@ module Wizard
       attribute 'import_date(2i)', :string
       attribute 'import_date(1i)', :string
 
-      validate :import_date_in_future
+      validate :import_date_validation
 
       def initialize(user_session, attributes = {})
         check_attributes_validity(attributes)
@@ -40,8 +40,8 @@ module Wizard
 
     private
 
-      def import_date_in_future
-        return if input_date.present? && input_date >= Time.zone.today
+      def import_date_validation
+        return if input_date.present? && input_date >= Date.new(2021, 1, 1)
 
         errors.add(:import_date, :invalid_date)
       end

--- a/app/views/wizard/steps/import_date/show.html.erb
+++ b/app/views/wizard/steps/import_date/show.html.erb
@@ -6,7 +6,7 @@
       <%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: import_date_path, html: { novalidate: true } do |f| %>
         <%= f.govuk_error_summary %>
         <span class="govuk-caption-xl">Calculate import duties</span>
-        <%= f.govuk_date_field :import_date, legend: { text: 'When will the goods be imported?', size: 'xl', tag: 'h1' }, hint: { text: 'As duties and quotas change over time, it may be important to enter the proposed import date. For example, 27  3  2021' } %>
+        <%= f.govuk_date_field :import_date, legend: { text: 'When will the goods be imported?', size: 'xl', tag: 'h1' }, hint: { text: 'As duties and quotas change over time, it may be important to enter the proposed import date. Enter a date from 1st January 2021 or later in the format 27 3 2021.' } %>
         <%= f.govuk_submit %>
       <% end %>
       <%= render 'shared/commodity_details' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
         wizard/steps/import_date:
           attributes:
             import_date:
-              invalid_date: Enter a valid future date
+              invalid_date: Enter a valid date, no earlier than 1st January 2021
         wizard/steps/import_destination:
           attributes:
             import_destination:

--- a/spec/models/wizard/steps/import_date_spec.rb
+++ b/spec/models/wizard/steps/import_date_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Wizard::Steps::ImportDate do
       it 'adds the correct validation error message' do
         step.valid?
 
-        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid date, no earlier than 1st January 2021'])
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe Wizard::Steps::ImportDate do
       it 'adds the correct validation error message' do
         step.valid?
 
-        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid date, no earlier than 1st January 2021'])
       end
     end
 
@@ -99,11 +99,11 @@ RSpec.describe Wizard::Steps::ImportDate do
       it 'adds the correct validation error message' do
         step.valid?
 
-        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid date, no earlier than 1st January 2021'])
       end
     end
 
-    context 'when import date is in the past' do
+    context 'when import date is in the past, earlier than 1st Jan 2021' do
       let(:attributes) do
         ActionController::Parameters.new(
           'import_date(3i)' => '12',
@@ -123,7 +123,31 @@ RSpec.describe Wizard::Steps::ImportDate do
       it 'adds the correct validation error message' do
         step.valid?
 
-        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid date, no earlier than 1st January 2021'])
+      end
+    end
+
+    context 'when import date is in the past, but not earlier than 1st Jan 2021' do
+      let(:attributes) do
+        ActionController::Parameters.new(
+          'import_date(3i)' => '1',
+          'import_date(2i)' => '1',
+          'import_date(1i)' => '2021',
+        ).permit(
+          'import_date(3i)',
+          'import_date(2i)',
+          'import_date(1i)',
+        )
+      end
+
+      it 'is a valid object' do
+        expect(step.valid?).to be true
+      end
+
+      it 'has no validation errors' do
+        step.valid?
+
+        expect(step.errors.messages[:import_date]).to be_empty
       end
     end
 
@@ -147,7 +171,7 @@ RSpec.describe Wizard::Steps::ImportDate do
       it 'adds the correct validation error message' do
         step.valid?
 
-        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid date, no earlier than 1st January 2021'])
       end
     end
 


### PR DESCRIPTION
### Jira link

HOTT-593

### What?

I have added/removed/altered:

- [ ] Allow users to now input past import dates, but not earlier than 1st Jan 2021

### Why?

I am doing this because:

- Business request