### PR TITLE
Suppress exchange rate for imports into GB

### DIFF
--- a/app/controllers/wizard/steps/duty_controller.rb
+++ b/app/controllers/wizard/steps/duty_controller.rb
@@ -3,7 +3,13 @@ module Wizard
     class DutyController < BaseController
       def show
         @duty_options = DutyCalculator.new(user_session, filtered_commodity).result
-        @gbp_to_eur_exchange_rate = Api::ExchangeRate.for('GBP').rate.round(4)
+        @gbp_to_eur_exchange_rate = Api::ExchangeRate.for('GBP').rate.round(4) unless import_into_gb?
+      end
+
+      private
+
+      def import_into_gb?
+        user_session.import_destination == 'UK'
       end
     end
   end

--- a/app/views/wizard/steps/duty/calculations/_exchange_rate_details.html.erb
+++ b/app/views/wizard/steps/duty/calculations/_exchange_rate_details.html.erb
@@ -1,4 +1,4 @@
- <p class="govuk-body-s">Please note - the current page uses an exchange rate of <strong><%= @gbp_to_eur_exchange_rate %> GBP to EUR</strong>.</p>
+<p class="govuk-body-s">Please note - the current page uses an exchange rate of <strong><%= @gbp_to_eur_exchange_rate %> GBP to EUR</strong>.</p>
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">

--- a/app/views/wizard/steps/duty/show.html.erb
+++ b/app/views/wizard/steps/duty/show.html.erb
@@ -17,7 +17,9 @@
         <p class="govuk-body">You are importing commodity <%= link_to(commodity.formatted_commodity_code,commodity_url(commodity.code), class: 'govuk-link') %> from <strong><%= country_of_origin_description %> </strong> on <strong><%= l user_session.import_date %></strong>.</p>
         <%= render 'wizard/steps/duty/calculations/trade_details' %>
         <%= render 'wizard/steps/duty/calculations/options' %>
-        <%= render 'wizard/steps/duty/calculations/exchange_rate_details' %>
+        <% if @gbp_to_eur_exchange_rate.present? %>
+          <%= render 'wizard/steps/duty/calculations/exchange_rate_details' %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/spec/features/confirmation_page_spec.rb
+++ b/spec/features/confirmation_page_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe 'Confirmation Page', type: :feature do
+  include_context 'GB to NI' do
+    let(:attributes) do
+      ActionController::Parameters.new(
+        'measure_amount' => measure_amount,
+        'applicable_measure_units' => {
+          'DTN' => {
+            'measurement_unit_code' => 'DTN',
+            'measurement_unit_qualifier_code' => '',
+            'abbreviation' => '100 kg',
+            'unit_question' => 'What is the weight of the goods you will be importing?',
+            'unit_hint' => 'Enter the value in decitonnes (100kg)',
+            'unit' => 'x 100 kg',
+            'measure_sids' => [
+              20_005_920,
+              20_056_507,
+              20_073_335,
+              20_076_779,
+              20_090_066,
+              20_105_690,
+              20_078_066,
+              20_102_998,
+              20_108_866,
+              20_085_014,
+            ],
+          },
+        },
+      ).permit!
+    end
+
+    let(:measure_amount) { { 'dtn' => 500.42 } }
+
+    let(:expected_content) do
+      "Check your answers\nCommodity code 7202 11 80 00 Change\nDate of import 12 December 2030 Change\nDestination Northern Ireland Change\nCountry of dispatch United Kingdom Change\nTrader scheme No Change\nCertificate of origin No Change\nCustoms value £1,200.00 Change\nImport quantity 1_200 x 100 kg Change\n"
+    end
+
+    let(:expected_links) do
+      [
+        'https://dev.trade-tariff.service.gov.uk/sections',
+        '/duty-calculator/import-date',
+        '/duty-calculator/import-destination',
+        '/duty-calculator/country-of-origin',
+        '/duty-calculator/trader-scheme',
+        '/duty-calculator/certificate-of-origin',
+        '/duty-calculator/customs-value',
+        '/duty-calculator/measure-amount',
+      ]
+    end
+
+    before do
+      # trader scheme question
+      choose(option: 'no')
+      click_on('Continue')
+
+      # certificate of origin question
+      choose(option: 'no')
+      click_on('Continue')
+
+      fill_in('wizard_steps_customs_value[monetary_value]', with: '1_200')
+
+      click_on('Continue')
+
+      fill_in('wizard_steps_measure_amount[dtn]', with: '1_200')
+
+      click_on('Continue')
+    end
+
+    it 'contains the summary of all the previously given answers' do
+      expect(page).to have_content(expected_content)
+    end
+
+    it 'contains the links that allow users to go back and change their answers' do
+      expected_links.each do |link|
+        expect(page).to have_link('Change', href: link)
+      end
+    end
+  end
+end

--- a/spec/features/duty_page_spec.rb
+++ b/spec/features/duty_page_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe 'Measure Amount Page', type: :feature do
+  include_context 'GB to NI' do
+    let(:attributes) do
+      ActionController::Parameters.new(
+        'measure_amount' => measure_amount,
+        'applicable_measure_units' => {
+          'DTN' => {
+            'measurement_unit_code' => 'DTN',
+            'measurement_unit_qualifier_code' => '',
+            'abbreviation' => '100 kg',
+            'unit_question' => 'What is the weight of the goods you will be importing?',
+            'unit_hint' => 'Enter the value in decitonnes (100kg)',
+            'unit' => 'x 100 kg',
+            'measure_sids' => [
+              20_005_920,
+              20_056_507,
+              20_073_335,
+              20_076_779,
+              20_090_066,
+              20_105_690,
+              20_078_066,
+              20_102_998,
+              20_108_866,
+              20_085_014,
+            ],
+          },
+        },
+      ).permit!
+    end
+
+    let(:measure_amount) { { 'dtn' => 500.42 } }
+    let(:exchange_rate) { instance_double(Api::ExchangeRate) }
+    let(:rate) { 0.0034567 }
+
+    before do
+      allow(Api::ExchangeRate).to receive(:for).with('GBP').and_return(exchange_rate)
+      allow(exchange_rate).to receive(:rate).and_return(rate)
+
+      # trader scheme question
+      choose(option: 'no')
+      click_on('Continue')
+
+      # certificate of origin question
+      choose(option: 'no')
+      click_on('Continue')
+
+      fill_in('wizard_steps_customs_value[monetary_value]', with: '1_200')
+
+      click_on('Continue')
+
+      fill_in('wizard_steps_measure_amount[dtn]', with: '1_200')
+
+      click_on('Continue')
+
+      click_on('Calculate import duties')
+    end
+
+    it 'displays a rounded exchange rate' do
+      expect(page).to have_content('0.0035 GBP to EUR')
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-589

### What?

I have added/removed/altered:

- [x] Suppress exchange rate for imports into GB
- [x] Also add missing test coverage for:
        - confirmation page
        - duty calculation page


### Why?

I am doing this because:

- Business request