### PR TITLE
Remove Turbolinks

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -2,9 +2,7 @@ require.context('govuk-frontend/govuk/assets');
 
 import '../styles/application.scss';
 import Rails from 'rails-ujs';
-import Turbolinks from 'turbolinks';
 import { initAll } from 'govuk-frontend';
 
 Rails.start();
-Turbolinks.start();
 initAll();


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Remove Turbolinks 

### Why?

I am doing this because:

- Turbolinks is causing issues with JS reloading when
navigating back to a previous page, causing the Menu
nav bar on mobile view to break. Removing Turbolinks solves the issue.