### PR TITLE
Refactor evaluator api

### DIFF
--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -36,6 +36,7 @@ module Api
       end
     end
 
+    # Compound components (where there are more than one) need to be evaluated by each individual component and have slightly different logic
     def evaluator_for_compound_component(component, user_session)
       if component.ad_valorem?
         ExpressionEvaluators::AdValorem.new(self, component, user_session)

--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -28,11 +28,19 @@ module Api
 
     def evaluator_for(user_session)
       if ad_valorem?
-        ExpressionEvaluators::AdValorem.new(self, user_session)
+        ExpressionEvaluators::AdValorem.new(self, component, user_session)
       elsif specific_duty?
-        ExpressionEvaluators::MeasureUnit.new(self, user_session)
+        ExpressionEvaluators::MeasureUnit.new(self, component, user_session)
       else
-        ExpressionEvaluators::Compound.new(self, user_session)
+        ExpressionEvaluators::Compound.new(self, nil, user_session)
+      end
+    end
+
+    def evaluator_for_compound_component(component, user_session)
+      if component.ad_valorem?
+        ExpressionEvaluators::AdValorem.new(self, component, user_session)
+      elsif component.specific_duty?
+        ExpressionEvaluators::MeasureUnit.new(self, component, user_session)
       end
     end
 

--- a/app/services/expression_evaluators/base.rb
+++ b/app/services/expression_evaluators/base.rb
@@ -2,18 +2,14 @@ module ExpressionEvaluators
   class Base
     include ActionView::Helpers::NumberHelper
 
-    def initialize(measure, user_session)
+    def initialize(measure, component, user_session)
       @measure = measure
+      @component = component
       @user_session = user_session
     end
 
     protected
 
-    def component
-      @component || measure.component
-    end
-
-    attr_reader :measure, :user_session
-    attr_writer :component
+    attr_reader :measure, :component, :user_session
   end
 end

--- a/app/services/expression_evaluators/compound.rb
+++ b/app/services/expression_evaluators/compound.rb
@@ -31,21 +31,8 @@ module ExpressionEvaluators
       end
     end
 
-    # TODO: This needs to be refactored. Ticket: HOTT-547
-    def evaluator_for(component)
-      evaluator = if component.ad_valorem?
-                    ExpressionEvaluators::AdValorem.new(measure, user_session)
-                  elsif component.specific_duty?
-                    ExpressionEvaluators::MeasureUnit.new(measure, user_session)
-                  end
-
-      evaluator.component = component
-
-      evaluator
-    end
-
     def value_for(component)
-      evaluator = evaluator_for(component)
+      evaluator = measure.evaluator_for_compound_component(component, user_session)
 
       evaluator.call[:value]
     end

--- a/spec/models/api/measure_spec.rb
+++ b/spec/models/api/measure_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Api::Measure do
 
         measure.evaluator_for(user_session)
 
-        expect(ExpressionEvaluators::AdValorem).to have_received(:new).with(measure, user_session)
+        expect(ExpressionEvaluators::AdValorem).to have_received(:new).with(measure, measure.component, user_session)
       end
     end
 
@@ -125,7 +125,7 @@ RSpec.describe Api::Measure do
 
         measure.evaluator_for(user_session)
 
-        expect(ExpressionEvaluators::MeasureUnit).to have_received(:new).with(measure, user_session)
+        expect(ExpressionEvaluators::MeasureUnit).to have_received(:new).with(measure, measure.component, user_session)
       end
     end
 
@@ -201,7 +201,45 @@ RSpec.describe Api::Measure do
 
         measure.evaluator_for(user_session)
 
-        expect(ExpressionEvaluators::Compound).to have_received(:new).with(measure, user_session)
+        expect(ExpressionEvaluators::Compound).to have_received(:new).with(measure, nil, user_session)
+      end
+    end
+  end
+
+  describe '#evaluator_for_compound_component' do
+    subject(:measure) { described_class.new({}) }
+
+    let(:component) { instance_double('Api::MeasureComponent') }
+    let(:ad_valorem) { false }
+    let(:specific_duty) { false }
+    let(:session_attributes) { {} }
+
+    before do
+      allow(component).to receive(:ad_valorem?).and_return(ad_valorem)
+      allow(component).to receive(:specific_duty?).and_return(specific_duty)
+    end
+
+    context 'when an ad_valorem component' do
+      let(:ad_valorem) { true }
+
+      it 'instantiates the correct evaluator' do
+        allow(ExpressionEvaluators::AdValorem).to receive(:new)
+
+        measure.evaluator_for_compound_component(component, user_session)
+
+        expect(ExpressionEvaluators::AdValorem).to have_received(:new).with(measure, component, user_session)
+      end
+    end
+
+    context 'when a specific duty component' do
+      let(:specific_duty) { true }
+
+      it 'instantiates the correct evaluator' do
+        allow(ExpressionEvaluators::MeasureUnit).to receive(:new)
+
+        measure.evaluator_for_compound_component(component, user_session)
+
+        expect(ExpressionEvaluators::MeasureUnit).to have_received(:new).with(measure, component, user_session)
       end
     end
   end

--- a/spec/services/expression_evaluators/ad_valorem_spec.rb
+++ b/spec/services/expression_evaluators/ad_valorem_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ExpressionEvaluators::AdValorem do
   subject(:evaluator) do
-    described_class.new(measure, user_session)
+    described_class.new(measure, component, user_session)
   end
 
   let(:measure) do
@@ -16,19 +16,20 @@ RSpec.describe ExpressionEvaluators::AdValorem do
         'measure_type_series_id' => 'C',
         'id' => '103',
       },
-      'measure_conditions' => [],
-      'measure_components' => [
-        {
-          'duty_expression_id' => '01',
-          'duty_amount' => 8.0,
-          'monetary_unit_code' => nil,
-          'monetary_unit_abbreviation' => nil,
-          'measurement_unit_code' => nil,
-          'duty_expression_description' => '% or amount',
-          'duty_expression_abbreviation' => '%',
-          'measurement_unit_qualifier_code' => nil,
-        },
-      ],
+    )
+  end
+  let(:component) do
+    Api::MeasureComponent.new(
+      {
+        'duty_expression_id' => '01',
+        'duty_amount' => 8.0,
+        'monetary_unit_code' => nil,
+        'monetary_unit_abbreviation' => nil,
+        'measurement_unit_code' => nil,
+        'duty_expression_description' => '% or amount',
+        'duty_expression_abbreviation' => '%',
+        'measurement_unit_qualifier_code' => nil,
+      },
     )
   end
 

--- a/spec/services/expression_evaluators/compound_spec.rb
+++ b/spec/services/expression_evaluators/compound_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ExpressionEvaluators::Compound do
   subject(:evaluator) do
-    described_class.new(measure, user_session)
+    described_class.new(measure, nil, user_session)
   end
 
   let(:measure) do

--- a/spec/services/expression_evaluators/measure_unit_spec.rb
+++ b/spec/services/expression_evaluators/measure_unit_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ExpressionEvaluators::MeasureUnit do
   subject(:evaluator) do
-    described_class.new(measure, user_session)
+    described_class.new(measure, component, user_session)
   end
 
   let(:measure) do
@@ -16,19 +16,19 @@ RSpec.describe ExpressionEvaluators::MeasureUnit do
         'measure_type_series_id' => 'C',
         'id' => '103',
       },
-      'measure_conditions' => [],
-      'measure_components' => [
-        {
-          'duty_expression_id' => '01',
-          'duty_amount' => 35.1,
-          'monetary_unit_code' => 'EUR',
-          'monetary_unit_abbreviation' => nil,
-          'measurement_unit_code' => 'DTN',
-          'duty_expression_description' => '% or amount',
-          'duty_expression_abbreviation' => '%',
-          'measurement_unit_qualifier_code' => nil,
-        },
-      ],
+    )
+  end
+
+  let(:component) do
+    Api::MeasureComponent.new(
+      'duty_expression_id' => '01',
+      'duty_amount' => 35.1,
+      'monetary_unit_code' => 'EUR',
+      'monetary_unit_abbreviation' => nil,
+      'measurement_unit_code' => 'DTN',
+      'duty_expression_description' => '% or amount',
+      'duty_expression_abbreviation' => '%',
+      'measurement_unit_qualifier_code' => nil,
     )
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-547

### What?

I have added/removed/altered:

- [x] Consolidate evaluator_for implementations under the Api::Measure class
- [x] Separate concern for picking the component from the evaluator implementation

### Why?

I am doing this because:

- This interface grew organically and didn't sufficiently separate the concerns of the evaluator and the components choice
- This led to a need to arbitrarily write the component instance to the member scope of the evaluator when dealing with compound evaluators
