### PR TITLE
HOTT-709: Cosmetic fix to "Trade Remedies apply" page

### DIFF
--- a/app/views/pages/trade_remedies.html.erb
+++ b/app/views/pages/trade_remedies.html.erb
@@ -1,13 +1,9 @@
 <%= link_to('Back', country_of_origin_path, class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-caption-xl">Calculate import duties</span>
-      <h1 class="govuk-heading-xl">Duties apply to this import</h1>
-      <p class="govuk-body">As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk' under all circumstances.</p>
-      <p class="govuk-body">Click on the 'Continue' button to enter the customs value of your import, to help to calculate the applicable import duties.</p>
-    </div>
-  </div>
+  <span class="govuk-caption-xl">Calculate import duties</span>
+  <h1 class="govuk-heading-xl">Duties apply to this import</h1>
+  <p class="govuk-body">As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk' under all circumstances.</p>
+  <p class="govuk-body">Click on the 'Continue' button to enter the customs value of your import, to help to calculate the applicable import duties.</p>
   <%= link_to('Continue', customs_value_path, class: 'govuk-button') %>
 </main>

--- a/app/views/pages/trade_remedies.html.erb
+++ b/app/views/pages/trade_remedies.html.erb
@@ -1,9 +1,9 @@
-<%= link_to('Back', country_of_origin_path, class: "govuk-back-link") %>
+<div class="govuk-!-margin-bottom-5">
+  <%= link_to('Back', country_of_origin_path, class: "govuk-back-link") %>
+</div>
 
-<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-  <span class="govuk-caption-xl">Calculate import duties</span>
-  <h1 class="govuk-heading-xl">Duties apply to this import</h1>
-  <p class="govuk-body">As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk' under all circumstances.</p>
-  <p class="govuk-body">Click on the 'Continue' button to enter the customs value of your import, to help to calculate the applicable import duties.</p>
-  <%= link_to('Continue', customs_value_path, class: 'govuk-button') %>
-</main>
+<span class="govuk-caption-xl">Calculate import duties</span>
+<h1 class="govuk-heading-xl">Duties apply to this import</h1>
+<p class="govuk-body">As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk' under all circumstances.</p>
+<p class="govuk-body">Click on the 'Continue' button to enter the customs value of your import, to help to calculate the applicable import duties.</p>
+<%= link_to('Continue', customs_value_path, class: 'govuk-button') %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-709

### What?

I have added/removed/altered:

- [ ] Remove the three-quarters row/column that was further reducing the area occupied by the content on the page

### Why?

The ticket asks to remove the two-thirds section and leave the three-quarters, however the two-thirds section is part of the layout and removing that would have required one of two options:

1. Change the layout for all pages so that they would all be changed from using a two-thirds width to three-quarters
2. Add a new layout file for this page specifically, with no guarantee that it would be used for other content

After a chat with Matt Lavis, the decision was that it was acceptable to remove the three-quarters instead.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
