### PR TITLE
Guard against missing key on params

### DIFF
--- a/app/controllers/wizard/steps/country_of_origin_controller.rb
+++ b/app/controllers/wizard/steps/country_of_origin_controller.rb
@@ -14,6 +14,8 @@ module Wizard
       private
 
       def permitted_params
+        return {} unless params.key?(:wizard_steps_country_of_origin)
+
         params.require(:wizard_steps_country_of_origin).permit(
           :country_of_origin,
           :other_country_of_origin,


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

The form builder we use will not submit the expected key
if neither option is selected on the country of origin step.
We need to guard against that.