### PR TITLE
HOTT-718: Filter out GB and EU member states

### DIFF
--- a/app/models/api/geographical_area.rb
+++ b/app/models/api/geographical_area.rb
@@ -1,6 +1,7 @@
 module Api
   class GeographicalArea < Api::Base
     EU = '1013'.freeze
+    UK = %w[GB].freeze
 
     has_many :children_geographical_areas, GeographicalArea
 
@@ -24,6 +25,12 @@ module Api
       countries = build_collection(service, 'Country')
       countries << northern_ireland if service == :uk
       countries
+    end
+
+    def self.other_countries(service = :xi)
+      eu_ids = european_union_members(service).map(&:geographical_area_id).concat(UK)
+      build_collection(service, 'Country')
+        .reject { |country| eu_ids.include?(country.geographical_area_id) }
     end
 
     def self.european_union_members(service = :xi)

--- a/app/models/api/geographical_area.rb
+++ b/app/models/api/geographical_area.rb
@@ -27,7 +27,7 @@ module Api
       countries
     end
 
-    def self.other_countries(service = :xi)
+    def self.non_eu_countries(service = :xi)
       eu_ids = european_union_members(service).map(&:geographical_area_id).concat(UK)
       build_collection(service, 'Country')
         .reject { |country| eu_ids.include?(country.geographical_area_id) }

--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -34,7 +34,9 @@ module Wizard
         user_session.zero_mfn_duty = zero_mfn_duty
       end
 
-      def self.options_for(service)
+      def self.options_for(service, other = false)
+        return Api::GeographicalArea.other_countries(service.to_sym) if other
+
         Api::GeographicalArea.list_countries(service.to_sym)
       end
 

--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -34,8 +34,8 @@ module Wizard
         user_session.zero_mfn_duty = zero_mfn_duty
       end
 
-      def self.options_for(service, other = false)
-        return Api::GeographicalArea.other_countries(service.to_sym) if other
+      def self.options_for(service, include_eu_members = true)
+        return Api::GeographicalArea.non_eu_countries(service.to_sym) unless include_eu_members
 
         Api::GeographicalArea.list_countries(service.to_sym)
       end

--- a/app/views/wizard/steps/country_of_origin/_xi_options.html.erb
+++ b/app/views/wizard/steps/country_of_origin/_xi_options.html.erb
@@ -6,7 +6,7 @@
     <%= f.govuk_radio_button :country_of_origin, 'EU', label: { text: 'Ireland or other EU member states' } %>
     <% if Rails.configuration.row_to_ni == 'true' %>
       <%= f.govuk_radio_button :country_of_origin, 'OTHER', label: { text: 'Countries outside of GB and European Union' } do %>
-        <%= f.govuk_collection_select :other_country_of_origin, Wizard::Steps::CountryOfOrigin.options_for(commodity_source, true), :id, :name, options: { prompt: true }, label: { text: 'Where are the goods coming from?' } %>
+        <%= f.govuk_collection_select :other_country_of_origin, Wizard::Steps::CountryOfOrigin.options_for(commodity_source, false), :id, :name, options: { prompt: true }, label: { text: 'Where are the goods coming from?' } %>
         <span class="govuk-hint govuk-!-margin-top-3">
           When autocomplete results are available, use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.
         </span>

--- a/app/views/wizard/steps/country_of_origin/_xi_options.html.erb
+++ b/app/views/wizard/steps/country_of_origin/_xi_options.html.erb
@@ -6,7 +6,7 @@
     <%= f.govuk_radio_button :country_of_origin, 'EU', label: { text: 'Ireland or other EU member states' } %>
     <% if Rails.configuration.row_to_ni == 'true' %>
       <%= f.govuk_radio_button :country_of_origin, 'OTHER', label: { text: 'Countries outside of GB and European Union' } do %>
-        <%= f.govuk_collection_select :other_country_of_origin, Wizard::Steps::CountryOfOrigin.options_for(commodity_source), :id, :name, options: { prompt: true }, label: { text: 'Where are the goods coming from?' } %>
+        <%= f.govuk_collection_select :other_country_of_origin, Wizard::Steps::CountryOfOrigin.options_for(commodity_source, true), :id, :name, options: { prompt: true }, label: { text: 'Where are the goods coming from?' } %>
         <span class="govuk-hint govuk-!-margin-top-3">
           When autocomplete results are available, use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.
         </span>

--- a/spec/models/api/geographical_area_spec.rb
+++ b/spec/models/api/geographical_area_spec.rb
@@ -85,6 +85,29 @@ RSpec.describe Api::GeographicalArea do
     end
   end
 
+  describe '.other_countries' do
+    let(:expected_members) do
+      %w[AT BE BG CY CZ DE DK EE ES EU FI FR GR HR HU IE IT LT LU LV MT NL PL PT RO SE SI SK]
+    end
+    let(:members) { described_class.other_countries.map(&:id) }
+
+    it 'returns non-eu results' do
+      expect(members.length).to be_positive
+    end
+
+    it 'returns none of the member countries of the EU' do
+      expect(members).not_to include(expected_members)
+    end
+
+    it 'doesn\'t return UK' do
+      expect(members).not_to include('UK')
+    end
+
+    it 'doesn\'t return XI' do
+      expect(members).not_to include('XI')
+    end
+  end
+
   describe '.find' do
     it 'returns the country found by id' do
       country = described_class.find(id)

--- a/spec/models/api/geographical_area_spec.rb
+++ b/spec/models/api/geographical_area_spec.rb
@@ -85,26 +85,26 @@ RSpec.describe Api::GeographicalArea do
     end
   end
 
-  describe '.other_countries' do
-    let(:expected_members) do
+  describe '.non_eu_countries' do
+    let(:eu_member_states_ids) do
       %w[AT BE BG CY CZ DE DK EE ES EU FI FR GR HR HU IE IT LT LU LV MT NL PL PT RO SE SI SK]
     end
-    let(:members) { described_class.other_countries.map(&:id) }
+    let(:members) { described_class.non_eu_countries.map(&:id) }
 
     it 'returns non-eu results' do
       expect(members.length).to be_positive
     end
 
+    it 'returns a non-EU country' do
+      expect(members).to include('US')
+    end
+
     it 'returns none of the member countries of the EU' do
-      expect(members).not_to include(expected_members)
+      expect(members).not_to include(eu_member_states_ids)
     end
 
-    it 'doesn\'t return UK' do
-      expect(members).not_to include('UK')
-    end
-
-    it 'doesn\'t return XI' do
-      expect(members).not_to include('XI')
+    it 'doesn\'t return GB' do
+      expect(members).not_to include('GB')
     end
   end
 

--- a/spec/models/api/geographical_area_spec.rb
+++ b/spec/models/api/geographical_area_spec.rb
@@ -91,10 +91,6 @@ RSpec.describe Api::GeographicalArea do
     end
     let(:members) { described_class.non_eu_countries.map(&:id) }
 
-    it 'returns non-eu results' do
-      expect(members.length).to be_positive
-    end
-
     it 'returns a non-EU country' do
       expect(members).to include('US')
     end


### PR DESCRIPTION
Filter out GB and EU member states from the 'other' country of origin
step.

### Jira link

https://transformuk.atlassian.net/browse/HOTT-718

### What?

I have added/removed/altered:

- [ ] Added a new method to return only non-eu, non-GB countries in the geographical area model
- [ ] Use the new method to fill in the "other countries" select in the country of origin page 

### Why?

I am doing this because it's pointless to let the user select GB or any EU country from the select when those are covered by the first two radio buttons.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
