### PR TITLE
Switch commodity source to UK

### DIFF
--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -75,9 +75,11 @@ module Wizard
 
       def next_step_for_row_to_ni
         return trade_remedies_path if trade_defence
-        return customs_value_path if zero_mfn_duty
+        return trader_scheme_path unless zero_mfn_duty
 
-        trader_scheme_path
+        user_session.commodity_source = 'uk'
+
+        customs_value_path
       end
 
       def next_step_for_row_to_gb

--- a/spec/models/wizard/steps/country_of_origin_spec.rb
+++ b/spec/models/wizard/steps/country_of_origin_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
           'import_destination' => 'XI',
           'country_of_origin' => 'OTHER',
           'other_country_of_origin' => 'AR',
+          'commodity_source' => 'xi',
         }
       end
 
@@ -250,6 +251,12 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
             ).to eq(
               customs_value_path,
             )
+          end
+
+          it 'sets the commodity source to UK' do
+            expect {
+              step.next_step_path
+            }.to change(user_session, :commodity_source).from('xi').to('uk')
           end
         end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] If there is a commodity that has zero mfn duties, then
we need to switch its source to UK in this case, since
originally the source would be set up to XI on this
route.

### Why?

I am doing this because:

- Originally the source for this commodity would be set up to XI on this route.