### PR TITLE
Handle expired/empty sessions

### DIFF
--- a/app/controllers/wizard/steps/base_controller.rb
+++ b/app/controllers/wizard/steps/base_controller.rb
@@ -2,9 +2,11 @@ module Wizard
   module Steps
     class BaseController < ::ApplicationController
       include CommodityHelper
+      include ServiceHelper
 
       default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
       after_action :track_session
+      before_action :ensure_session_integrity
 
       helper_method :commodity_code,
                     :commodity_source,
@@ -57,6 +59,10 @@ module Wizard
           commodity_source: user_session.commodity_source,
           referred_service: user_session.referred_service,
         })
+      end
+
+      def ensure_session_integrity
+        return redirect_to trade_tariff_url if commodity_code.blank?
       end
     end
   end

--- a/spec/requests/session_integrity_spec.rb
+++ b/spec/requests/session_integrity_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe 'Session integrity', type: :request do
+  context 'when the session expires or is empty for any reason' do
+    context 'when deep linking to any question but import_date question' do
+      let(:trade_tariff_host) { 'https://dev.trade-tariff.service.gov.uk' }
+
+      it 'redirects to the trade tariff platform ' do
+        allow(Rails.configuration).to receive(:trade_tariff_frontend_url).and_return(trade_tariff_host)
+
+        get import_destination_path
+
+        expect(response).to redirect_to('https://dev.trade-tariff.service.gov.uk/sections')
+      end
+    end
+
+    context 'when landing on import_date question' do
+      let(:commodity_code) { '0702000007' }
+      let(:referred_service) { 'uk' }
+      let(:import_into) { 'UK' }
+
+      it 'does not redirect to the trade tariff platform' do
+        get import_date_path(commodity_code: commodity_code, referred_service: referred_service)
+
+        expect(response.body).to include('When will the goods be imported?')
+      end
+    end
+  end
+end


### PR DESCRIPTION
If the session expires or is wiped out, then redirect
to /sections on the trade tariff platform.

### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [ ] If the session expires or is wiped out, then redirect
to /sections on the trade tariff platform.

### Why?

I am doing this because:

- Avoid bad user experience (seeing a 500 error) for users when their session expires during their progress.