### PR TITLE
Fetch the MFN and trade defence for RoW to NI

### DIFF
--- a/app/controllers/wizard/steps/country_of_origin_controller.rb
+++ b/app/controllers/wizard/steps/country_of_origin_controller.rb
@@ -23,7 +23,7 @@ module Wizard
       end
 
       def opts
-        return opts_for_ni_to_gb_route if answer == 'GB' && user_session.import_destination == 'XI'
+        return trade_defence_mfn_opts if %w[GB OTHER].include?(answer) && user_session.import_destination == 'XI'
 
         {}
       end
@@ -36,7 +36,7 @@ module Wizard
         { 'filter[geographical_area_id]' => answer }
       end
 
-      def opts_for_ni_to_gb_route
+      def trade_defence_mfn_opts
         {
           trade_defence: commodity.trade_defence,
           zero_mfn_duty: filtered_commodity(filter: geographical_area_id_filter).zero_mfn_duty,

--- a/app/models/wizard/steps/customs_value.rb
+++ b/app/models/wizard/steps/customs_value.rb
@@ -47,6 +47,8 @@ module Wizard
       def previous_step_path
         return previous_step_for_gb_to_ni if user_session.gb_to_ni_route?
         return country_of_origin_path if user_session.row_to_gb_route?
+
+        previous_step_for_row_to_ni
       end
 
       private
@@ -55,6 +57,10 @@ module Wizard
         return trade_remedies_path if user_session.trade_defence
 
         certificate_of_origin_path
+      end
+
+      def previous_step_for_row_to_ni
+        return country_of_origin_path if user_session.zero_mfn_duty
       end
     end
   end

--- a/spec/models/wizard/steps/customs_value_spec.rb
+++ b/spec/models/wizard/steps/customs_value_spec.rb
@@ -219,12 +219,30 @@ RSpec.describe Wizard::Steps::CustomsValue do
         allow(user_session).to receive(:row_to_gb_route?).and_return(true)
       end
 
-      it 'returns certificate_of_origin_path' do
+      it 'returns country_of_origin_path' do
         expect(
           step.previous_step_path,
         ).to eq(
           country_of_origin_path,
         )
+      end
+    end
+
+    context 'when on RoW to NI route' do
+      before do
+        allow(user_session).to receive(:row_to_ni_route?).and_return(true)
+      end
+
+      context 'when there is a zero mfn duty' do
+        it 'returns country_of_origin_path' do
+          allow(user_session).to receive(:zero_mfn_duty).and_return(true)
+
+          expect(
+            step.previous_step_path,
+          ).to eq(
+            country_of_origin_path,
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
We need to fetch both MFN duty and trade defence
answers for RoW to NI route now in addition to RoW
to GB.

Also update the previous step path for customs value
question for RoW to NI route.

### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Fetch the mfn duty + trade defence for RoW to NI
- [x] Update the previous step path for customs value

### Why?

I am doing this because:

- We need to fetch both MFN duty and trade defence
answers for RoW to NI route now in addition to RoW
to GB.
- We also need to allow users to go back to the previous question from the customs value page