### PR TITLE
Use other_country_of_origin value from the session

### DIFF
--- a/app/controllers/wizard/steps/base_controller.rb
+++ b/app/controllers/wizard/steps/base_controller.rb
@@ -19,7 +19,7 @@ module Wizard
 
       def country_of_origin_description
         Api::GeographicalArea.find(
-          user_session.country_of_origin,
+          country_of_origin_code,
           user_session.import_destination.downcase.to_sym,
         ).description
       end
@@ -45,7 +45,7 @@ module Wizard
       end
 
       def default_filter
-        { 'filter[geographical_area_id]' => user_session.country_of_origin }
+        { 'filter[geographical_area_id]' => country_of_origin_code }
       end
 
       def default_query
@@ -63,6 +63,12 @@ module Wizard
 
       def ensure_session_integrity
         return redirect_to trade_tariff_url if commodity_code.blank?
+      end
+
+      def country_of_origin_code
+        return user_session.other_country_of_origin if user_session.country_of_origin == 'OTHER'
+
+        user_session.country_of_origin
       end
     end
   end

--- a/app/decorators/confirmation_decorator.rb
+++ b/app/decorators/confirmation_decorator.rb
@@ -79,6 +79,8 @@ class ConfirmationDecorator < SimpleDelegator
   def country_name_for(value, key)
     return Wizard::Steps::ImportDestination::OPTIONS.find { |c| c.id == value }.name if key == 'import_destination'
 
+    value = user_session.other_country_of_origin if value == 'OTHER'
+
     Api::GeographicalArea.find(value, user_session.import_destination.downcase.to_sym).description
   end
 

--- a/app/models/duty_calculator.rb
+++ b/app/models/duty_calculator.rb
@@ -5,9 +5,9 @@ class DutyCalculator
   end
 
   def result
-    return nil if user_session.ni_to_gb_route? || user_session.eu_to_ni_route?
+    return nil if user_session.ni_to_gb_route? || user_session.eu_to_ni_route? || no_duty_applies?
 
-    calculate_duty if user_session.gb_to_ni_route? || user_session.row_to_gb_route?
+    calculate_duty
   end
 
   private
@@ -15,8 +15,6 @@ class DutyCalculator
   attr_reader :user_session, :commodity
 
   def calculate_duty
-    return nil if zero_mfn_duty_no_trade_defence? || strict_processing? || certificate_of_origin?
-
     options = applicable_measures.each_with_object(default_options) do |measure, acc|
       option_klass = measure.measure_type.option
 
@@ -86,5 +84,13 @@ class DutyCalculator
 
   def no_additional_code_measures
     commodity.import_measures.reject(&:additional_code)
+  end
+
+  def no_duty_applies?
+    relevant_route? && (zero_mfn_duty_no_trade_defence? || strict_processing? || certificate_of_origin?)
+  end
+
+  def relevant_route?
+    user_session.gb_to_ni_route? || user_session.row_to_gb_route?
   end
 end


### PR DESCRIPTION
Whenever session.country_of_origin is set to OTHER,
we need to use the session.other_country_of_origin value
for our duty calculation.

### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Whenever session.country_of_origin is set to OTHER,
we need to use the session.other_country_of_origin value
for our duty calculation.


### Why?

I am doing this because:

- So that we can filter by the correct country and compute the duty