### PR TITLE
Plumb trade remedies step to RoW to NI journey when there is a trade defence

### DIFF
--- a/app/controllers/wizard/steps/trade_remedies_controller.rb
+++ b/app/controllers/wizard/steps/trade_remedies_controller.rb
@@ -1,0 +1,9 @@
+module Wizard
+  module Steps
+    class TradeRemediesController < BaseController
+      def show
+        @step = Wizard::Steps::TradeRemedy.new(user_session)
+      end
+    end
+  end
+end

--- a/app/helpers/commodity_helper.rb
+++ b/app/helpers/commodity_helper.rb
@@ -28,12 +28,18 @@ module CommodityHelper
   end
 
   def default_filter
-    { 'filter[geographical_area_id]' => user_session.country_of_origin }
+    { 'filter[geographical_area_id]' => country_of_origin_code }
   end
 
   def as_of
     return user_session.import_date.iso8601 if user_session.import_date.present?
 
     Time.zone.today.iso8601
+  end
+
+  def country_of_origin_code
+    return user_session.other_country_of_origin if user_session.country_of_origin == 'OTHER'
+
+    user_session.country_of_origin
   end
 end

--- a/app/models/wizard/steps/trade_remedy.rb
+++ b/app/models/wizard/steps/trade_remedy.rb
@@ -1,0 +1,23 @@
+module Wizard
+  module Steps
+    class TradeRemedy < Wizard::Steps::Base
+      STEPS_TO_REMOVE_FROM_SESSION = %w[].freeze
+
+      def next_step_path
+        customs_value_path
+      end
+
+      def previous_step_path
+        return country_of_origin_path if user_session.gb_to_ni_route?
+
+        previous_step_for_row_to_ni
+      end
+
+      private
+
+      def previous_step_for_row_to_ni
+        return country_of_origin_path if user_session.trade_defence
+      end
+    end
+  end
+end

--- a/app/views/pages/trade_remedies.html.erb
+++ b/app/views/pages/trade_remedies.html.erb
@@ -1,9 +1,0 @@
-<div class="govuk-!-margin-bottom-5">
-  <%= link_to('Back', country_of_origin_path, class: "govuk-back-link") %>
-</div>
-
-<span class="govuk-caption-xl">Calculate import duties</span>
-<h1 class="govuk-heading-xl">Duties apply to this import</h1>
-<p class="govuk-body">As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk' under all circumstances.</p>
-<p class="govuk-body">Click on the 'Continue' button to enter the customs value of your import, to help to calculate the applicable import duties.</p>
-<%= link_to('Continue', customs_value_path, class: 'govuk-button') %>

--- a/app/views/wizard/steps/trade_remedies/shared/_context.html.erb
+++ b/app/views/wizard/steps/trade_remedies/shared/_context.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-xl"><%= heading %></h1>
+<p class="govuk-body"><%= body %></p>
+<p class="govuk-body">Click on the 'Continue' button to enter the customs value of your import, to help to calculate the applicable import duties.</p>

--- a/app/views/wizard/steps/trade_remedies/show.html.erb
+++ b/app/views/wizard/steps/trade_remedies/show.html.erb
@@ -1,0 +1,14 @@
+<%= render 'wizard/steps/shared/back_link' %>
+
+<span class="govuk-caption-xl">Calculate import duties</span>
+
+<% if user_session.gb_to_ni_route? %>
+  <%= render partial: 'wizard/steps/trade_remedies/shared/context', locals: { heading: t('trade_remedies.gb_to_ni.heading'), body: t('trade_remedies.gb_to_ni.body') } %>
+<% elsif user_session.row_to_ni_route? %>
+  <% if user_session.trade_defence %>
+    <%= render partial: 'wizard/steps/trade_remedies/shared/context', locals: { heading: t('trade_remedies.row_to_ni.trade_defence.heading'), body: t('trade_remedies.row_to_ni.trade_defence.body') } %>
+  <% end %>
+<% end %>
+
+<%= link_to('Continue', @step.next_step_path, class: 'govuk-button') %>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,14 @@ en:
         waiver: 'Option %{option_no}: Claiming a waiver – Exchange rate'
 
 
-
+  trade_remedies:
+    gb_to_ni:
+      heading: Duties apply to this import
+      body: As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk' under all circumstances.
+    row_to_ni:
+      trade_defence:
+        heading: EU duties apply to this import
+        body: As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk'.
   confirmation_page:
     import_date: Date of import
     import_destination: Destination

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
 
     get 'confirm', to: 'wizard/steps/confirmation#show'
 
-    get 'trade-remedies', to: 'pages#trade_remedies'
+    get 'trade-remedies', to: 'wizard/steps/trade_remedies#show'
 
     get 'duty', to: 'wizard/steps/duty#show'
 

--- a/spec/helpers/commodity_helper_spec.rb
+++ b/spec/helpers/commodity_helper_spec.rb
@@ -1,0 +1,107 @@
+RSpec.describe CommodityHelper do
+  before do
+    allow(helper).to receive(:user_session).and_return(user_session)
+  end
+
+  let(:commodity_source) { 'xi' }
+  let(:commodity_code) { '0102291010' }
+  let(:import_destination) { 'XI' }
+  let(:as_of) { Time.zone.today.iso8601 }
+
+  describe '#filtered_commodity' do
+    before do
+      allow(Api::Commodity).to receive(:build)
+    end
+
+    context 'when not on RoW to NI route' do
+      let(:user_session) do
+        build(
+          :user_session,
+          import_destination: import_destination,
+          country_of_origin: 'GB',
+          commodity_source: commodity_source,
+          commodity_code: commodity_code,
+          other_country_of_origin: '',
+        )
+      end
+
+      let(:expected_filter) do
+        {
+          'as_of' => Time.zone.today.iso8601,
+          'filter[geographical_area_id]' => 'GB',
+        }
+      end
+
+      it 'returns a correctly filtered commodity' do
+        helper.filtered_commodity
+
+        expect(Api::Commodity).to have_received(:build).with(
+          commodity_source,
+          commodity_code,
+          expected_filter,
+        )
+      end
+    end
+
+    context 'when on RoW to NI route' do
+      let(:user_session) do
+        build(
+          :user_session,
+          import_destination: import_destination,
+          country_of_origin: 'OTHER',
+          commodity_source: commodity_source,
+          commodity_code: commodity_code,
+          other_country_of_origin: 'AR',
+        )
+      end
+
+      let(:expected_filter) do
+        {
+          'as_of' => Time.zone.today.iso8601,
+          'filter[geographical_area_id]' => 'AR',
+        }
+      end
+
+      it 'returns a correctly filtered commodity' do
+        helper.filtered_commodity
+
+        expect(Api::Commodity).to have_received(:build).with(
+          commodity_source,
+          commodity_code,
+          expected_filter,
+        )
+      end
+    end
+  end
+
+  describe '#commodity' do
+    before do
+      allow(Api::Commodity).to receive(:build)
+    end
+
+    let(:user_session) do
+      build(
+        :user_session,
+        import_destination: import_destination,
+        commodity_source: commodity_source,
+        commodity_code: commodity_code,
+      )
+    end
+
+    let(:expected_filter) do
+      {
+        'as_of' => Time.zone.today.iso8601,
+      }
+    end
+
+    it 'returns an unfiltered commodity' do
+      helper.commodity
+
+      expect(Api::Commodity).to have_received(:build).with(
+        commodity_source,
+        commodity_code,
+        expected_filter,
+      )
+    end
+  end
+end

--- a/spec/models/wizard/steps/trade_remedy_spec.rb
+++ b/spec/models/wizard/steps/trade_remedy_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe Wizard::Steps::TradeRemedy do
+  subject(:step) { described_class.new(user_session) }
+
+  let(:user_session) do
+    build(
+      :user_session,
+      import_destination: import_destination,
+      country_of_origin: country_of_origin,
+      other_country_of_origin: other_country_of_origin,
+      trade_defence: trade_defence,
+    )
+  end
+
+  let(:session) { user_session.session }
+
+  let(:import_destination) { 'XI' }
+  let(:country_of_origin) { 'GB' }
+  let(:other_country_of_origin) { '' }
+  let(:trade_defence) { false }
+
+  describe 'STEPS_TO_REMOVE_FROM_SESSION' do
+    it 'returns the correct list of steps' do
+      expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to be_empty
+    end
+  end
+
+  describe '#next_step_path' do
+    include Rails.application.routes.url_helpers
+
+    it 'returns customs_value_path' do
+      expect(
+        step.next_step_path,
+      ).to eq(
+        customs_value_path,
+      )
+    end
+  end
+
+  describe '#previous_step_path' do
+    include Rails.application.routes.url_helpers
+
+    context 'when on GB to NI route' do
+      it 'returns country_of_origin_path' do
+        expect(
+          step.previous_step_path,
+        ).to eq(
+          country_of_origin_path,
+        )
+      end
+    end
+
+    context 'when on RoW to NI route' do
+      let(:import_destination) { 'XI' }
+      let(:country_of_origin) { 'OTHER' }
+      let(:other_country_of_origin) { 'AR' }
+
+      context 'when there is a trade defence in place' do
+        let(:trade_defence) { true }
+
+        it 'returns customs_value_path' do
+          expect(
+            step.previous_step_path,
+          ).to eq(
+            country_of_origin_path,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] trade remedies become a pseudo step
- [x] plumb trade remedies page to RoW journey when there is a trade defence in place

### Why?

I am doing this because:

- Because the trade remedies page now has logic in place
and we need to know which step to go back to depending
on the journey we are at, it needs to become a step.