### PR TITLE
Add the 3 remaining pipes for trade remedies

### DIFF
--- a/app/models/wizard/steps/trade_remedy.rb
+++ b/app/models/wizard/steps/trade_remedy.rb
@@ -17,6 +17,10 @@ module Wizard
 
       def previous_step_for_row_to_ni
         return country_of_origin_path if user_session.trade_defence
+        return planned_processing_path if user_session.planned_processing == 'commercial_processing'
+        return final_use_path if user_session.final_use == 'no'
+
+        trader_scheme_path
       end
     end
   end

--- a/app/views/wizard/steps/trade_remedies/show.html.erb
+++ b/app/views/wizard/steps/trade_remedies/show.html.erb
@@ -7,6 +7,12 @@
 <% elsif user_session.row_to_ni_route? %>
   <% if user_session.trade_defence %>
     <%= render partial: 'wizard/steps/trade_remedies/shared/context', locals: { heading: t('trade_remedies.row_to_ni.trade_defence.heading'), body: t('trade_remedies.row_to_ni.trade_defence.body') } %>
+  <% elsif user_session.trader_scheme == 'no' %>
+    <%= render partial: 'wizard/steps/trade_remedies/shared/context', locals: { heading: t('trade_remedies.row_to_ni.trader_scheme.heading'), body: t('trade_remedies.row_to_ni.trader_scheme.body_html') } %>
+  <% elsif user_session.final_use == 'no' %>
+    <%= render partial: 'wizard/steps/trade_remedies/shared/context', locals: { heading: t('trade_remedies.row_to_ni.final_use.heading'), body: t('trade_remedies.row_to_ni.final_use.body') } %>
+  <% elsif user_session.planned_processing == 'commercial_processing' %>
+    <%= render partial: 'wizard/steps/trade_remedies/shared/context', locals: { heading: t('trade_remedies.row_to_ni.commercial_processing.heading'), body: t('trade_remedies.row_to_ni.commercial_processing.body') } %>
   <% end %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,15 @@ en:
       trade_defence:
         heading: EU duties apply to this import
         body: As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk'.
+      trader_scheme:
+        heading: EU duties apply to this import
+        body_html: As you are not authorised under the UK Trader Scheme, imports of this commodity are treated as 'at risk'. <a href='https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-trader-scheme-if-you-bring-goods-into-northern-ireland' class='govuk-link' target='_blank'>Find out more about applying for authorisation for the UK Trader Scheme</a>.
+      final_use:
+        heading: EU duties apply to this import
+        body: As your goods are not for final use in Northern Ireland, imports of this commodity are treated as 'at risk'.
+      commercial_processing:
+        heading: EU duties apply to this import
+        body: As your goods are subject to commercial processing, imports of this commodity are treated as 'at risk'.
   confirmation_page:
     import_date: Date of import
     import_destination: Destination

--- a/spec/models/wizard/steps/trade_remedy_spec.rb
+++ b/spec/models/wizard/steps/trade_remedy_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Wizard::Steps::TradeRemedy do
       country_of_origin: country_of_origin,
       other_country_of_origin: other_country_of_origin,
       trade_defence: trade_defence,
+      planned_processing: planned_processing,
+      final_use: final_use,
+      trader_scheme: trader_scheme,
     )
   end
 
@@ -17,6 +20,9 @@ RSpec.describe Wizard::Steps::TradeRemedy do
   let(:country_of_origin) { 'GB' }
   let(:other_country_of_origin) { '' }
   let(:trade_defence) { false }
+  let(:planned_processing) { 'without_any_processing' }
+  let(:final_use) { 'yes' }
+  let(:trader_scheme) { 'yes' }
 
   describe 'STEPS_TO_REMOVE_FROM_SESSION' do
     it 'returns the correct list of steps' do
@@ -62,6 +68,42 @@ RSpec.describe Wizard::Steps::TradeRemedy do
             step.previous_step_path,
           ).to eq(
             country_of_origin_path,
+          )
+        end
+      end
+
+      context 'when goods are for commercial processing' do
+        let(:planned_processing) { 'commercial_processing' }
+
+        it 'returns planned_processing_path' do
+          expect(
+            step.previous_step_path,
+          ).to eq(
+            planned_processing_path,
+          )
+        end
+      end
+
+      context 'when goods are not for final use' do
+        let(:final_use) { 'no' }
+
+        it 'returns final_use_path' do
+          expect(
+            step.previous_step_path,
+          ).to eq(
+            final_use_path,
+          )
+        end
+      end
+
+      context 'when the trader is not part of the trader scheme' do
+        let(:trader_scheme) { 'no' }
+
+        it 'returns trader_scheme_path' do
+          expect(
+            step.previous_step_path,
+          ).to eq(
+            trader_scheme_path,
           )
         end
       end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] This PR handles the logic for the other
3 possible routes that could lead to the
trade remedies step:
- belongs to the trader scheme?
OR
- goods are for final use?
OR
- goods are for commercial processing?

### Why?

I am doing this because:

- Part of the RoW to NI journey