### PR TITLE
HOTT-744: Put in GTM / GA tagging on the DC

### DIFF
--- a/app/helpers/cookies_helper.rb
+++ b/app/helpers/cookies_helper.rb
@@ -1,0 +1,11 @@
+module CookiesHelper
+  def policy_cookie
+    cookie = cookies['cookies_policy']
+
+    cookie.present? ? JSON.parse(cookie) : {}
+  end
+
+  def usage_enabled?
+    policy_cookie['usage'] == 'true'
+  end
+end

--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,9 @@
+<% if usage_enabled? -%>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-MNNT6SX');</script>
+  <!-- End Google Tag Manager -->
+<%- end %>

--- a/app/views/layouts/_google_tag_manager_no_script.html.erb
+++ b/app/views/layouts/_google_tag_manager_no_script.html.erb
@@ -1,0 +1,6 @@
+<% if usage_enabled? -%>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MNNT6SX"
+                    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<%- end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
     <%= tag :meta, name: 'robots', content: 'noindex,nofollow' %>
+    <%= render partial: 'layouts/google_tag_manager' %>
     <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
@@ -20,6 +21,7 @@
   </head>
 
   <body class="govuk-template__body ">
+    <%= render partial: 'layouts/google_tag_manager_no_script' %>
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-744

### What?

I have added/removed/altered:

- [ ] Add GTM tagging in the layout
- [ ] Add helper methods to determine the cookies, so that the tagging can be removed if the user opted out

### Why?

I am doing this because we need to track usage on the Duty Calculator

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
