### PR TITLE
Always fetch VAT options from the UK source

### DIFF
--- a/app/helpers/commodity_helper.rb
+++ b/app/helpers/commodity_helper.rb
@@ -1,9 +1,9 @@
 module CommodityHelper
-  def filtered_commodity(filter: default_filter)
+  def filtered_commodity(filter: default_filter, source: user_session.commodity_source)
     query = default_query.merge(filter)
 
     Api::Commodity.build(
-      user_session.commodity_source,
+      source,
       user_session.commodity_code,
       query,
     )
@@ -22,7 +22,7 @@ module CommodityHelper
   end
 
   def applicable_vat_options
-    @applicable_vat_options ||= filtered_commodity.applicable_vat_options
+    @applicable_vat_options ||= filtered_commodity(source: 'uk').applicable_vat_options
   end
 
   private

--- a/app/models/duty_calculator.rb
+++ b/app/models/duty_calculator.rb
@@ -1,4 +1,6 @@
 class DutyCalculator
+  include CommodityHelper
+
   def initialize(user_session, commodity)
     @user_session = user_session
     @commodity = commodity
@@ -83,12 +85,14 @@ class DutyCalculator
   end
 
   def vat_measures
-    commodity.import_measures.each_with_object([]) do |measure, acc|
+    uk_filtered_commodity = filtered_commodity(source: 'uk')
+
+    uk_filtered_commodity.import_measures.each_with_object([]) do |measure, acc|
       vat_type = measure.vat_type
 
       next if vat_type.nil?
 
-      acc << measure if commodity.applicable_vat_options.keys.size == 1 || user_session.vat == vat_type
+      acc << measure if uk_filtered_commodity.applicable_vat_options.keys.size == 1 || user_session.vat == vat_type
     end
   end
 

--- a/spec/support/shared_examples/gb_to_ni.rb
+++ b/spec/support/shared_examples/gb_to_ni.rb
@@ -64,7 +64,7 @@ RSpec.shared_context 'GB to NI' do # rubocop: disable RSpec/ContextWording, RSpe
     allow(commodity).to receive(:import_measures).and_return([])
     allow(commodity).to receive(:applicable_additional_codes).and_return(applicable_additional_codes)
     allow(commodity).to receive(:applicable_vat_options).and_return(applicable_vat_options)
-    allow(Api::Commodity).to receive(:build).with('xi', commodity_code, default_query).and_return(commodity)
+    allow(Api::Commodity).to receive(:build).with('uk', commodity_code, filtered_query).and_return(commodity)
     allow(Api::Commodity).to receive(:build).with('xi', commodity_code, filtered_query).and_return(commodity)
 
     visit import_date_url(referred_service: referred_service, commodity_code: commodity_code)


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] We always need to fetch the VAT options from the UK source, even when on the XI service

### Why?

I am doing this because:

- On the XI service we will need to use the UK source