### PR TITLE
Adds extra session information to the user context in sentry

### DIFF
--- a/app/controllers/wizard/steps/base_controller.rb
+++ b/app/controllers/wizard/steps/base_controller.rb
@@ -4,6 +4,8 @@ module Wizard
       include CommodityHelper
       include ServiceHelper
 
+      rescue_from StandardError, with: :handle_exception
+
       default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
       after_action :track_session
       before_action :ensure_session_integrity
@@ -59,6 +61,12 @@ module Wizard
           commodity_source: user_session.commodity_source,
           referred_service: user_session.referred_service,
         })
+      end
+
+      def handle_exception(exception)
+        Raven.user_context(session.to_h.except('_csrf_token'))
+
+        raise exception
       end
 
       def ensure_session_integrity


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-734

### What?

I have added/removed/altered:

- [x] Enrich sentry errors with more session information

### Why?

I am doing this because:

- We have no way of debugging issues with new relic since it rotates stack traces and cookie information every 7 days
