### PR TITLE
Add stop page for RoW to NI case

### DIFF
--- a/app/models/wizard/steps/planned_processing.rb
+++ b/app/models/wizard/steps/planned_processing.rb
@@ -38,7 +38,7 @@ module Wizard
       def next_step_for_row_to_ni
         return trade_remedies_path unless user_session.planned_processing == 'commercial_purposes'
 
-        # TODO: We need to add the link to a stop page here - that will come in soon
+        row_to_ni_duty_path
       end
     end
   end

--- a/app/views/pages/row_to_ni_duty.html.erb
+++ b/app/views/pages/row_to_ni_duty.html.erb
@@ -1,0 +1,16 @@
+<%= link_to('Back', planned_processing_path, class: "govuk-back-link") %>
+
+<span class="govuk-caption-xl">Calculate import duties</span>
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <h1 class="govuk-fieldset__heading">Duties cannot currently be calculated</h1>
+  </legend>
+</fieldset>
+
+<p class="govuk-body govuk-!-margin-top-5">We're currently unable to calculate the duties applicable to your import.</p>
+<p class="govuk-body">The functionality to calculate the duties applicable to your circumstances is under construction.</p>
+
+<p class="govuk-body">Find out more about <%= link_to('trading and moving goods in and out of Northern Ireland', 'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland', target: '_blank') %>.</p>
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
 
     get 'additional-codes/:measure_type_id', to: 'wizard/steps/additional_codes#show', as: 'additional_codes'
     post 'additional-codes/:measure_type_id', to: 'wizard/steps/additional_codes#create'
+
+    get 'row-to-ni-duty', to: 'pages#row_to_ni_duty'
   end
 
   get '404', to: 'errors#not_found', via: :all

--- a/spec/models/wizard/steps/planned_processing_spec.rb
+++ b/spec/models/wizard/steps/planned_processing_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Wizard::Steps::PlannedProcessing do
           expect(
             step.next_step_path,
           ).to eq(
-            nil,
+            row_to_ni_duty_path,
           )
         end
       end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added a stoppage for the case when the trader picks planned_processing option as not commercial processing 

### Why?

I am doing this because:

- This route is more complicated and we don't yet have a way to calculate the duty