### PR TITLE
Do not redirect to vat path from confirmation page

### DIFF
--- a/app/models/wizard/steps/confirmation.rb
+++ b/app/models/wizard/steps/confirmation.rb
@@ -1,6 +1,8 @@
 module Wizard
   module Steps
     class Confirmation < Wizard::Steps::Base
+      include CommodityHelper
+
       STEPS_TO_REMOVE_FROM_SESSION = %w[].freeze
 
       def next_step_path
@@ -8,7 +10,7 @@ module Wizard
       end
 
       def previous_step_path
-        return vat_path if user_session.vat.present?
+        return vat_path if filtered_commodity(source: 'uk').applicable_vat_options.keys.size > 1
         return additional_codes_path(user_session.measure_type_ids.last) unless user_session.additional_code.empty?
         return measure_amount_path unless user_session.measure_amount.empty?
 

--- a/spec/fixtures/commodities/0102291010.json
+++ b/spec/fixtures/commodities/0102291010.json
@@ -17,6 +17,7 @@
         }
       },
       "applicable_vat_options": {
+        "VATR": "VAT reduced rate 5% (5.0)"
       },
       "meursing_code": false
     }

--- a/spec/models/wizard/steps/confirmation_spec.rb
+++ b/spec/models/wizard/steps/confirmation_spec.rb
@@ -24,10 +24,8 @@ RSpec.describe Wizard::Steps::Confirmation do
   describe '#previous_step_path' do
     include Rails.application.routes.url_helpers
 
-    context 'when there is a VAT code on the session' do
-      before do
-        allow(user_session).to receive(:vat).and_return('VATZ')
-      end
+    context 'when there are more than one applicable vat options' do
+      let(:user_session) { build(:user_session, :with_commodity_information) }
 
       it 'returns vat_path' do
         expect(
@@ -38,10 +36,23 @@ RSpec.describe Wizard::Steps::Confirmation do
       end
     end
 
+    context 'when there us just one  applicable vat option available' do
+      let(:user_session) { build(:user_session, commodity_code: '0102291010') }
+
+      it 'returns vat_path' do
+        expect(
+          step.previous_step_path,
+        ).to eq(
+          customs_value_path,
+        )
+      end
+    end
+
     context 'when there are additional codes on the session' do
       let(:user_session) do
         build(
           :user_session,
+          commodity_code: '0103921100',
           additional_code: accumulated_codes,
         )
       end
@@ -69,6 +80,13 @@ RSpec.describe Wizard::Steps::Confirmation do
         }
       end
 
+      let(:user_session) do
+        build(
+          :user_session,
+          commodity_code: '0103921100',
+        )
+      end
+
       before do
         allow(user_session).to receive(:measure_amount).and_return(measure_amount)
       end
@@ -83,6 +101,13 @@ RSpec.describe Wizard::Steps::Confirmation do
     end
 
     context 'when there are no measure amounts on the session' do
+      let(:user_session) do
+        build(
+          :user_session,
+          commodity_code: '0103921100',
+        )
+      end
+
       before do
         allow(user_session).to receive(:measure_amount).and_return({})
       end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [ ] In case there is just one vat option available,
do not go back to vat page from the confirmation
page.

### Why?

I am doing this because:

- Part of the RoW to NI journey logic