### PR TITLE
Convert XI to EUR when presenting options

### DIFF
--- a/app/services/duty_options/base.rb
+++ b/app/services/duty_options/base.rb
@@ -43,7 +43,7 @@ module DutyOptions
       presented_rows = []
       presented_rows << I18n.t(
         'duty_calculations.options.import_duty_html',
-        commodity_source: user_session.commodity_source.upcase,
+        commodity_source: presented_commodity_source,
         option_type: option_type,
         additional_code: formatted_additional_code,
       ).html_safe
@@ -124,6 +124,10 @@ module DutyOptions
 
     def additional_code
       measure.additional_code&.code
+    end
+
+    def presented_commodity_source
+      user_session.commodity_source.upcase == 'XI' ? 'EU' : 'UK'
     end
   end
 end

--- a/spec/services/duty_options/additional_duty/provisional_anti_dumping_spec.rb
+++ b/spec/services/duty_options/additional_duty/provisional_anti_dumping_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DutyOptions::AdditionalDuty::ProvisionalAntiDumping do
       let(:duty_html) do
         I18n.t(
           'duty_calculations.options.import_duty_html',
-          commodity_source: commodity_source.upcase,
+          commodity_source: 'EU',
           option_type: 'Provisional anti-dumping duty',
           additional_code: nil,
         )

--- a/spec/services/duty_options/tariff_preference_spec.rb
+++ b/spec/services/duty_options/tariff_preference_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DutyOptions::TariffPreference do
           footnote: I18n.t('measure_type_footnotes.142'),
           values: [
             [I18n.t('duty_calculations.options.import_valuation'), I18n.t('duty_calculations.options.customs_value'), '£1,050.00'],
-            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: commodity_source.upcase, option_type: 'Tariff preference', additional_code: nil), '5.00% * £1,050.00', '£52.50'],
+            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: 'EU', option_type: 'Tariff preference', additional_code: nil), '5.00% * £1,050.00', '£52.50'],
             [I18n.t('duty_calculations.options.duty_total_html'), nil, '<strong>£52.50</strong>'],
           ],
           geographical_area_description: 'GSP – General Framework',
@@ -126,7 +126,7 @@ RSpec.describe DutyOptions::TariffPreference do
           values: [
             [I18n.t('duty_calculations.options.import_valuation'), I18n.t('duty_calculations.options.customs_value'), '£1,050.00'],
             [I18n.t('duty_calculations.options.import_quantity'), nil, '120.0 x 100 kg'],
-            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: commodity_source.upcase, option_type: 'Tariff preference', additional_code: nil), '35.10 EUR / 100 kg * 120.0', '£3,596.12'],
+            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: 'EU', option_type: 'Tariff preference', additional_code: nil), '35.10 EUR / 100 kg * 120.0', '£3,596.12'],
             [I18n.t('duty_calculations.options.duty_total_html'), nil, '<strong>£3,596.12</strong>'],
           ],
           geographical_area_description: 'GSP – General Framework',
@@ -213,7 +213,7 @@ RSpec.describe DutyOptions::TariffPreference do
           footnote: I18n.t('measure_type_footnotes.142'),
           values: [
             [I18n.t('duty_calculations.options.import_valuation'), I18n.t('duty_calculations.options.customs_value'), '£1,050.00'],
-            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: commodity_source.upcase, option_type: 'Tariff preference', additional_code: nil), 'foo', '£15.00'],
+            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: 'EU', option_type: 'Tariff preference', additional_code: nil), 'foo', '£15.00'],
             [I18n.t('duty_calculations.options.duty_total_html'), nil, '<strong>£15.00</strong>'],
           ],
           geographical_area_description: 'GSP – General Framework',

--- a/spec/services/duty_options/third_country_tariff_spec.rb
+++ b/spec/services/duty_options/third_country_tariff_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe DutyOptions::ThirdCountryTariff do
           footnote: I18n.t('measure_type_footnotes.103'),
           values: [
             [I18n.t('duty_calculations.options.import_valuation'), I18n.t('duty_calculations.options.customs_value'), '£1,050.00'],
-            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: commodity_source, option_type: 'Third-country duty', additional_code: nil), '5.00% * £1,050.00', '£52.50'],
+            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: 'EU', option_type: 'Third-country duty', additional_code: nil), '5.00% * £1,050.00', '£52.50'],
             [I18n.t('duty_calculations.options.duty_total_html'), nil, '<strong>£52.50</strong>'],
           ],
         }
@@ -112,7 +112,7 @@ RSpec.describe DutyOptions::ThirdCountryTariff do
           values: [
             [I18n.t('duty_calculations.options.import_valuation'), I18n.t('duty_calculations.options.customs_value'), '£1,050.00'],
             [I18n.t('duty_calculations.options.import_quantity'), nil, '120.0 x 100 kg'],
-            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: commodity_source, option_type: 'Third-country duty', additional_code: nil), '35.10 EUR / 100 kg * 120.0', '£3,596.12'],
+            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: 'EU', option_type: 'Third-country duty', additional_code: nil), '35.10 EUR / 100 kg * 120.0', '£3,596.12'],
             [I18n.t('duty_calculations.options.duty_total_html'), nil, '<strong>£3,596.12</strong>'],
           ],
         }
@@ -195,7 +195,7 @@ RSpec.describe DutyOptions::ThirdCountryTariff do
           footnote: I18n.t('measure_type_footnotes.103'),
           values: [
             [I18n.t('duty_calculations.options.import_valuation'), I18n.t('duty_calculations.options.customs_value'), '£1,050.00'],
-            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: commodity_source, option_type: 'Third-country duty', additional_code: nil), 'foo', '£15.00'],
+            [I18n.t('duty_calculations.options.import_duty_html', commodity_source: 'EU', option_type: 'Third-country duty', additional_code: nil), 'foo', '£15.00'],
             [I18n.t('duty_calculations.options.duty_total_html'), nil, '<strong>£15.00</strong>'],
           ],
         }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-759

### What?

I have added/removed/altered:

- [x] Make it so that XI is EUR for the XI commodity source in duty options
- [x] Updates tests that were using the XI commodity source

**UK**

![image](https://user-images.githubusercontent.com/8156884/122403091-fbf20e80-cf75-11eb-9912-b52897dc4d23.png)

**XI**

![image](https://user-images.githubusercontent.com/8156884/122403341-352a7e80-cf76-11eb-9b1b-3693c9c77264.png)

### Why?

I am doing this because:

- Business requirement
