### PR TITLE
Adds the CommodityContextService

### DIFF
--- a/app/helpers/commodity_helper.rb
+++ b/app/helpers/commodity_helper.rb
@@ -10,9 +10,8 @@ module CommodityHelper
   def commodity
     commodity_source = user_session.commodity_source
     commodity_code = user_session.commodity_code
-    query = default_query
 
-    commodity_context_service.call(commodity_source, commodity_code, query)
+    commodity_context_service.call(commodity_source, commodity_code, default_query)
   end
 
   def applicable_additional_codes

--- a/app/helpers/commodity_helper.rb
+++ b/app/helpers/commodity_helper.rb
@@ -1,20 +1,18 @@
 module CommodityHelper
   def filtered_commodity(filter: default_filter, source: user_session.commodity_source)
+    commodity_source = source || user_session.commodity_source
+    commodity_code = user_session.commodity_code
     query = default_query.merge(filter)
 
-    Api::Commodity.build(
-      source,
-      user_session.commodity_code,
-      query,
-    )
+    commodity_context_service.call(commodity_source, commodity_code, query)
   end
 
   def commodity
-    @commodity ||= Api::Commodity.build(
-      user_session.commodity_source,
-      user_session.commodity_code,
-      default_query,
-    )
+    commodity_source = user_session.commodity_source
+    commodity_code = user_session.commodity_code
+    query = default_query
+
+    commodity_context_service.call(commodity_source, commodity_code, query)
   end
 
   def applicable_additional_codes
@@ -27,18 +25,16 @@ module CommodityHelper
 
   private
 
-  def default_query
-    { 'as_of' => as_of }
+  def commodity_context_service
+    Thread.current[:commodity_context_service]
   end
 
   def default_filter
     { 'filter[geographical_area_id]' => country_of_origin_code }
   end
 
-  def as_of
-    return user_session.import_date.iso8601 if user_session.import_date.present?
-
-    Time.zone.today.iso8601
+  def default_query
+    { 'as_of' => (user_session.import_date || Time.zone.today).iso8601 }
   end
 
   def country_of_origin_code

--- a/app/services/commodity_context_service.rb
+++ b/app/services/commodity_context_service.rb
@@ -1,0 +1,16 @@
+class CommodityContextService
+  def initialize
+    @cache = {}
+  end
+
+  def call(commodity_source, commodity_code, query)
+    digest = Digest::SHA2.hexdigest(query.to_json)
+    key = "commodity-#{commodity_code}-#{commodity_source}-#{digest}"
+
+    @cache[key] ||= Api::Commodity.build(
+      commodity_source,
+      commodity_code,
+      query,
+    )
+  end
+end

--- a/app/services/expression_evaluators/measure_unit.rb
+++ b/app/services/expression_evaluators/measure_unit.rb
@@ -36,7 +36,7 @@ module ExpressionEvaluators
     end
 
     def measure_applicable_units
-      commodity.applicable_measure_units.select do |_unit, values|
+      filtered_commodity.applicable_measure_units.select do |_unit, values|
         values['measure_sids'].include?(measure.id)
       end
     end

--- a/spec/controllers/wizard/steps/base_controller_spec.rb
+++ b/spec/controllers/wizard/steps/base_controller_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe Wizard::Steps::BaseController do
       response
       expect(NewRelic::Agent).to have_received(:add_custom_attributes).with(expected_tracked_attributes)
     end
+
+    it 'initializes the CommodityContextService' do
+      response
+      expect(Thread.current[:commodity_context_service]).to be_a(CommodityContextService)
+    end
   end
 
   describe 'GET #error' do

--- a/spec/helpers/commodity_helper_spec.rb
+++ b/spec/helpers/commodity_helper_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe CommodityHelper do
   before do
     allow(helper).to receive(:user_session).and_return(user_session)
     allow(Api::Commodity).to receive(:build).and_call_original
+    allow(Thread.current[:commodity_context_service]).to receive(:call).and_call_original
   end
 
   let(:commodity_source) { 'xi' }
@@ -27,6 +28,12 @@ RSpec.describe CommodityHelper do
   end
 
   describe '#filtered_commodity' do
+    it 'retrieves commodities via the CommodityContextService' do
+      helper.filtered_commodity
+
+      expect(Thread.current[:commodity_context_service]).to have_received(:call).with(commodity_source, commodity_code, expected_filter)
+    end
+
     context 'when the commodity source is passed' do
       it 'uses the passed commodity source' do
         helper.filtered_commodity(source: 'uk')
@@ -107,6 +114,12 @@ RSpec.describe CommodityHelper do
       {
         'as_of' => Time.zone.today.iso8601,
       }
+    end
+
+    it 'retrieves commodities via the CommodityContextService' do
+      helper.commodity
+
+      expect(Thread.current[:commodity_context_service]).to have_received(:call).with(commodity_source, commodity_code, expected_filter)
     end
 
     it 'returns an unfiltered commodity' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   config.example_status_persistence_file_path = 'rspec.txt'
   config.include FactoryBot::Syntax::Methods
+  config.before do
+    Thread.current[:commodity_context_service] = CommodityContextService.new
+  end
 
   config.before do
     Rails.application.config.http_client_uk = FakeUkttHttp.new(nil, nil, nil, nil)

--- a/spec/services/commodity_context_service_spec.rb
+++ b/spec/services/commodity_context_service_spec.rb
@@ -1,0 +1,44 @@
+describe CommodityContextService do
+  subject(:service) { described_class.new }
+
+  let(:commodity_source) { 'uk' }
+  let(:commodity_code) { '0702000007' }
+  let(:query) { { 'as_of' => '2021-01-01', 'filter[geographical_area_id]' => 'AR' } }
+
+  it 'generates a sha of the query' do
+    allow(Digest::SHA2).to receive(:hexdigest).with(query.to_json)
+  end
+
+  context 'when a commodity has not already been fetched' do
+    before do
+      allow(Api::Commodity).to receive(:build).and_call_original
+    end
+
+    it 'returns a commodity' do
+      expect(service.call(commodity_source, commodity_code, query)).to be_a(Api::Commodity)
+    end
+
+    it 'calls the api builder with the passed arguments' do
+      service.call(commodity_source, commodity_code, query)
+
+      expect(Api::Commodity).to have_received(:build).with(commodity_source, commodity_code, query)
+    end
+  end
+
+  context 'when a commodity has already been fetched' do
+    before do
+      service.call(commodity_source, commodity_code, query)
+      allow(Api::Commodity).to receive(:build)
+    end
+
+    it 'returns the commodity' do
+      expect(service.call(commodity_source, commodity_code, query)).to be_a(Api::Commodity)
+    end
+
+    it 'does not call the api builder' do
+      service.call(commodity_source, commodity_code, query)
+
+      expect(Api::Commodity).not_to have_received(:build)
+    end
+  end
+end

--- a/spec/services/commodity_context_service_spec.rb
+++ b/spec/services/commodity_context_service_spec.rb
@@ -6,7 +6,9 @@ describe CommodityContextService do
   let(:query) { { 'as_of' => '2021-01-01', 'filter[geographical_area_id]' => 'AR' } }
 
   it 'generates a sha of the query' do
-    allow(Digest::SHA2).to receive(:hexdigest).with(query.to_json)
+    allow(Digest::SHA2).to receive(:hexdigest)
+    service.call(commodity_source, commodity_code, query)
+    expect(Digest::SHA2).to have_received(:hexdigest).with(query.to_json)
   end
 
   context 'when a commodity has not already been fetched' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-770

### What?

I have added/removed/altered:

- [x] Adds a CommodityContextService
- [x] Adds specs for the new service
- [x] Updates the existing CommodityHelper specs to indicate we're now using the CommodityContextService to fetch commodities

### Why?

- We noticed that the commodities were getting fetched for every measure unit evaluator we were
  instantiating (quite a few of these).
- We don't want to make additional network requests if we can help it and we don't want to create a burden on the
  running application by adding more and more commodities on a colocated cache.
- We can avoid handling TTL functionality this way.
