### PR TITLE
Hott 743 ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 
 orbs:
@@ -40,20 +41,96 @@ commands:
           name: "Push new app in dark mode"
           command: |
             export BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#<< parameters.buildpack_version >>"
-
             # Enables /healthcheck to show the current deployed git sha
             export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
             echo $GIT_NEW_REVISION >REVISION
-
             # Push as "dark" instance
             cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --buildpack $BUILDPACK
-
             # Map dark route
             cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
-
             # Enable routing from this service to the backend applications which are private
             cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" --protocol tcp --port 8080
             cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_UK-<< parameters.environment_key >>"  --protocol tcp --port 8080
+      - run:
+          name: "Verify new version is working on dark URL."
+          command: |
+            sleep 15
+            # Verify new version is working on dark URL.
+            HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-<< parameters.environment_key >>-dark.london.cloudapps.digital/duty-calculator/ping`
+            if [ "$HTTPCODE" -ne 200 ];then
+              echo "dark route not available, failing deploy ($HTTPCODE)"
+              cf logs "$CF_APP-<< parameters.environment_key >>-dark" --recent
+              cf delete -f  "$CF_APP-<< parameters.environment_key >>-dark"
+              exit 1
+            fi
+      - run:
+          name: "Switch dark app to live"
+          command: |
+            # Send "real" url to new version
+            cf unmap-route "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
+            # Start sending traffic to new version
+            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
+            # TODO: Update when we remove referring service from the path
+            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk --path "/duty-calculator"
+            # Stop sending traffic to previous version
+            cf unmap-route  "$CF_APP-<< parameters.environment_key >>" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
+            cf unmap-route  "$CF_APP-<< parameters.environment_key >>" "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk --path "/duty-calculator"
+            # stop previous version
+            cf stop "$CF_APP-<< parameters.environment_key >>"
+            # delete previous version
+            cf delete "$CF_APP-<< parameters.environment_key >>" -f
+            # Switch name of "dark" version to claim correct name
+            cf rename "$CF_APP-<< parameters.environment_key >>-dark" "$CF_APP-<< parameters.environment_key >>"
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: deployments
+          event: pass
+          template: basic_success_1
+
+  cf_deploy_docker:
+    parameters:
+      space:
+        type: string
+      environment_key:
+        type: string
+      app_domain_prefix:
+        type: string
+      buildpack_version:
+        type: string
+        default: "v1.8.39"
+    steps:
+      - checkout
+      - run:
+          name: "Setup CF CLI"
+          command: |
+            curl -L -o cf.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.2.0&source=github-rel'
+            sudo dpkg -i cf.deb
+            cf -v
+            cf api "$CF_ENDPOINT"
+            cf auth "$CF_USER" "$CF_PASSWORD"
+            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+            cf install-plugin app-autoscaler-plugin -r CF-Community -f
+            cf target -o "$CF_ORG" -s "<< parameters.space >>"
+      - run:
+          name: "Fetch existing manifest"
+          command: |
+            cf create-app-manifest "$CF_APP-<< parameters.environment_key >>" -p deploy_manifest.yml
+      - run:
+          name: "Push new app in dark mode"
+          command: |
+            export IMAGE=enginetransformation/tariff-dutycalculator
+            export DOCKER_IMAGE=${IMAGE}:dev-${CIRCLE_SHA1}
+
+            # Push as "dark" instance
+            cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$DOCKER_IMAGE"
+            # Map dark route
+            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
+            # Enable routing from this service to the backend applications which are private
+            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" --protocol tcp --port 8080
+            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_UK-<< parameters.environment_key >>" --protocol tcp --port 8080
       - run:
           name: "Verify new version is working on dark URL."
           command: |
@@ -131,9 +208,14 @@ jobs:
           command:  bundle exec brakeman -o brakeman_results.html
       - store_artifacts:
           path: brakeman_results.html
+
   build:
     environment:
       IMAGE_NAME: enginetransformation/tariff-dutycalculator
+    parameters:
+      dev-build:
+        default: false
+        type: boolean
     docker:
       - image: cimg/ruby:2.7.3-node
     steps:
@@ -144,12 +226,12 @@ jobs:
       - run:
           name: "Build Docker image"
           command: |
-            docker build -t $IMAGE_NAME:${CIRCLE_SHA1} .
+            docker build -t $IMAGE_NAME:<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1} .
       - run:
           name: "Push image"
           command: |
             echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push $IMAGE_NAME:${CIRCLE_SHA1}
+            docker push $IMAGE_NAME:<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1}
 
   test:
     docker:
@@ -190,7 +272,7 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "development"
     steps:
-      - cf_deploy:
+      - cf_deploy_docker:
           space: "development"
           environment_key: "dev"
           app_domain_prefix: "dev"
@@ -233,6 +315,7 @@ workflows:
                 - master
       - build:
           context: trade-tariff
+          dev-build: true
           requires:
             - test
       - deploy_dev:
@@ -242,7 +325,7 @@ workflows:
               ignore:
                 - master
           requires:
-            - test
+            - build
       - deploy_staging:
           context: trade-tariff
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,7 @@ workflows:
               ignore:
                 - master
       - build:
+          name: build_dev
           context: trade-tariff
           dev-build: true
           requires:
@@ -325,7 +326,14 @@ workflows:
               ignore:
                 - master
           requires:
-            - build
+            - build_dev
+      - build:
+          name: build_live
+          context: trade-tariff
+          filters:
+            branches:
+              only:
+                - master
       - deploy_staging:
           context: trade-tariff
           filters:

--- a/README.md
+++ b/README.md
@@ -63,3 +63,20 @@ bundle exec scss-lint app/webpacker/styles
 
 Check the file `manifest.yml` for customisation of name (you may need to change it as there could be a conflict on that name), buildpacks and eventual services (PostgreSQL needs to be [set up](https://docs.cloud.service.gov.uk/deploying_services/postgresql/)).
 
+
+## Running locally in docker-compose
+
+### Prerequisites
+
+* You have working Docker environment
+* You have docker-compose installed 
+
+
+### Run
+
+  1. Clone this repo and change to it's root directory
+  2. Run ``docker-compose up ``
+  3. Open your browser to `http://0.0.0.0:3000/duty-calculator/ping` to verify it's running.
+  4. Start the journey with the commodity ID you want to test (It uses the dev environment API by default)
+     e.g `http://0.0.0.0:3000/duty-calculator/uk/9620001000/import-date`
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ services:
   web:
     build: .
     ports:
-      - 3002:3000
+      - 3000:8080
     environment:
+      - PORT=8080
       - RAILS_ENV=production
       - SECRET_KEY_BASE=abcd1234
       - RAILS_SERVE_STATIC_FILES=true
@@ -14,5 +15,3 @@ services:
       - TRADE_TARIFF_FRONTEND_URL=http://localhost:3000
       - ROW_TO_NI=true
       - ROUTE_THROUGH_FRONTEND=true
-    extra_hosts:
-      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
### Jira link

HOTT-743-CI

### What?

I have added/removed/altered:

- [ ] Adds a Dockerfile to build a Docker image of Duty-calculator
- [ ] Adds a local use docker-compose to run the local version of code against the DEV api
- [ ] Adds docker deployment to development in CI

### Why?

I am doing this because:
- We want to have a portable docker image of the application that we can run both locally and on the live infrastructure 
