### PR TITLE
Add RAILS_SERVE_STATIC_FILES to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY . /app/
 # Compile assets and run webpack
 # Run in rails test environment to avoid loading development gems
 RUN RAILS_ENV=test bundle exec rails assets:precompile
+ENV RAILS_SERVE_STATIC_FILES=true
 
 # Cleanup to save space in the production image
 RUN rm -rf node_modules log tmp && \


### PR DESCRIPTION
### Jira link

HOTT-743
### What?

I have added/removed/altered:

- [ ] Add the RAILS_SERVE_STATIC_FILES setting in the docker image, so that we don't need to set it on the PaaS environement

### Why?

I am doing this because:
- With build packs assets are served in a different way, and it set's some environment variables automatically. Since we are running the whole thing in docker we need to setup our own.

