### PR TITLE
Enable production docker releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
 
   checking:
     docker:
-      - image: 'cimg/ruby:2.7.3-node'
+      - image: 'cimg/ruby:2.7.4-node'
     steps:
       - checkout
       - ruby/install-deps
@@ -136,7 +136,7 @@ jobs:
         default: false
         type: boolean
     docker:
-      - image: cimg/ruby:2.7.3-node
+      - image: cimg/ruby:2.7.4-node
     steps:
       - checkout
       - setup_remote_docker:
@@ -156,7 +156,7 @@ jobs:
 
   test:
     docker:
-      - image: cimg/ruby:2.7.3-node
+      - image: cimg/ruby:2.7.4-node
         environment:
           BUNDLE_JOBS: "3"
           BUNDLE_RETRY: "3"
@@ -189,7 +189,7 @@ jobs:
 
   deploy_dev:
     docker:
-      - image: cimg/ruby:2.7.3
+      - image: cimg/ruby:2.7.4
     environment:
       SENTRY_ENVIRONMENT: "development"
     steps:
@@ -202,7 +202,7 @@ jobs:
 
   deploy_staging:
     docker:
-      - image: cimg/ruby:2.7.3
+      - image: cimg/ruby:2.7.4
     environment:
       SENTRY_ENVIRONMENT: "staging"
     steps:
@@ -214,7 +214,7 @@ jobs:
 
   deploy_production:
     docker:
-      - image: cimg/ruby:2.7.3
+      - image: cimg/ruby:2.7.4
     environment:
       SENTRY_ENVIRONMENT: "production"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,8 @@ commands:
             sentry-cli releases finalize $SENTRY_RELEASE
             sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
 
-
 jobs:
+
   checking:
     docker:
       - image: 'cimg/ruby:2.7.3-node'
@@ -262,6 +262,8 @@ workflows:
             branches:
               only:
                 - master
+          requires:
+            - build_live
       - cypress:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,98 +9,17 @@ orbs:
   slack: circleci/slack@4.3.0
 
 commands:
-  cf_deploy:
-    parameters:
-      space:
-        type: string
-      environment_key:
-        type: string
-      app_domain_prefix:
-        type: string
-      buildpack_version:
-        type: string
-        default: "v1.8.43"
-    steps:
-      - checkout
-      - run:
-          name: "Setup CF CLI"
-          command: |
-            curl -L -o cf.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.2.0&source=github-rel'
-            sudo dpkg -i cf.deb
-            cf -v
-            cf api "$CF_ENDPOINT"
-            cf auth "$CF_USER" "$CF_PASSWORD"
-            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-            cf install-plugin app-autoscaler-plugin -r CF-Community -f
-            cf target -o "$CF_ORG" -s "<< parameters.space >>"
-      - run:
-          name: "Fetch existing manifest"
-          command: |
-            cf create-app-manifest "$CF_APP-<< parameters.environment_key >>" -p deploy_manifest.yml
-      - run:
-          name: "Push new app in dark mode"
-          command: |
-            export BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#<< parameters.buildpack_version >>"
-            # Enables /healthcheck to show the current deployed git sha
-            export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
-            echo $GIT_NEW_REVISION >REVISION
-            # Push as "dark" instance
-            cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --buildpack $BUILDPACK
-            # Map dark route
-            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
-            # Enable routing from this service to the backend applications which are private
-            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" --protocol tcp --port 8080
-            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_UK-<< parameters.environment_key >>"  --protocol tcp --port 8080
-      - run:
-          name: "Verify new version is working on dark URL."
-          command: |
-            sleep 15
-            # Verify new version is working on dark URL.
-            HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-<< parameters.environment_key >>-dark.london.cloudapps.digital/duty-calculator/ping`
-            if [ "$HTTPCODE" -ne 200 ];then
-              echo "dark route not available, failing deploy ($HTTPCODE)"
-              cf logs "$CF_APP-<< parameters.environment_key >>-dark" --recent
-              cf delete -f  "$CF_APP-<< parameters.environment_key >>-dark"
-              exit 1
-            fi
-      - run:
-          name: "Switch dark app to live"
-          command: |
-            # Send "real" url to new version
-            cf unmap-route "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
-            # Start sending traffic to new version
-            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
-            # TODO: Update when we remove referring service from the path
-            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk --path "/duty-calculator"
-            # Stop sending traffic to previous version
-            cf unmap-route  "$CF_APP-<< parameters.environment_key >>" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
-            cf unmap-route  "$CF_APP-<< parameters.environment_key >>" "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk --path "/duty-calculator"
-            # stop previous version
-            cf stop "$CF_APP-<< parameters.environment_key >>"
-            # delete previous version
-            cf delete "$CF_APP-<< parameters.environment_key >>" -f
-            # Switch name of "dark" version to claim correct name
-            cf rename "$CF_APP-<< parameters.environment_key >>-dark" "$CF_APP-<< parameters.environment_key >>"
-      - slack/notify:
-          channel: deployments
-          event: fail
-          template: basic_fail_1
-      - slack/notify:
-          channel: deployments
-          event: pass
-          template: basic_success_1
-
   cf_deploy_docker:
     parameters:
+      dev-release:
+        default: false
+        type: boolean
       space:
         type: string
       environment_key:
         type: string
       app_domain_prefix:
         type: string
-      buildpack_version:
-        type: string
-        default: "v1.8.39"
     steps:
       - checkout
       - run:
@@ -122,7 +41,7 @@ commands:
           name: "Push new app in dark mode"
           command: |
             export IMAGE=enginetransformation/tariff-dutycalculator
-            export DOCKER_IMAGE=${IMAGE}:dev-${CIRCLE_SHA1}
+            export DOCKER_IMAGE=${IMAGE}:<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
 
             # Push as "dark" instance
             cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$DOCKER_IMAGE"
@@ -193,7 +112,7 @@ commands:
 jobs:
   checking:
     docker:
-      - image: 'cimg/ruby:2.7.4-node'
+      - image: 'cimg/ruby:2.7.3-node'
     steps:
       - checkout
       - ruby/install-deps
@@ -217,7 +136,7 @@ jobs:
         default: false
         type: boolean
     docker:
-      - image: cimg/ruby:2.7.4-node
+      - image: cimg/ruby:2.7.3-node
     steps:
       - checkout
       - setup_remote_docker:
@@ -237,7 +156,7 @@ jobs:
 
   test:
     docker:
-      - image: cimg/ruby:2.7.4-node
+      - image: cimg/ruby:2.7.3-node
         environment:
           BUNDLE_JOBS: "3"
           BUNDLE_RETRY: "3"
@@ -270,11 +189,12 @@ jobs:
 
   deploy_dev:
     docker:
-      - image: cimg/ruby:2.7.4
+      - image: cimg/ruby:2.7.3
     environment:
       SENTRY_ENVIRONMENT: "development"
     steps:
       - cf_deploy_docker:
+          dev-release: true
           space: "development"
           environment_key: "dev"
           app_domain_prefix: "dev"
@@ -282,11 +202,11 @@ jobs:
 
   deploy_staging:
     docker:
-      - image: cimg/ruby:2.7.4
+      - image: cimg/ruby:2.7.3
     environment:
       SENTRY_ENVIRONMENT: "staging"
     steps:
-      - cf_deploy:
+      - cf_deploy_docker:
           space: "staging"
           environment_key: "staging"
           app_domain_prefix: "staging"
@@ -294,11 +214,11 @@ jobs:
 
   deploy_production:
     docker:
-      - image: cimg/ruby:2.7.4
+      - image: cimg/ruby:2.7.3
     environment:
       SENTRY_ENVIRONMENT: "production"
     steps:
-      - cf_deploy:
+      - cf_deploy_docker:
           space: "production"
           environment_key: "production"
           app_domain_prefix: "www"


### PR DESCRIPTION
### Jira link

HOTT-743

### What?

I have added/removed/altered:

- [ ] Enables docker releases on staging and production environments

### Why?

I am doing this because:

- We staged this change in the dev environment for over a week, during which multiple releases were done without any issues.
- This PR removes the dual logic docker/buildpack and enables docker releases across all environments


