### PR TITLE
Move back additional_codes to user_session

### DIFF
--- a/app/decorators/confirmation_decorator.rb
+++ b/app/decorators/confirmation_decorator.rb
@@ -97,7 +97,7 @@ class ConfirmationDecorator < SimpleDelegator
   def additional_codes_for(value)
     return nil unless value.values.any? { |v| v.values.compact.present? }
 
-    additional_codes
+    user_session.additional_codes
   end
 
   def excise_for(value)
@@ -108,10 +108,6 @@ class ConfirmationDecorator < SimpleDelegator
 
   def excise_additional_codes
     user_session.excise_additional_code.values.join(', ')
-  end
-
-  def additional_codes
-    (user_session.additional_code_uk.values + user_session.additional_code_xi.values).compact.join(', ')
   end
 
   def user_session

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -247,6 +247,10 @@ class UserSession
     no_duty_route? || possible_duty_route? && no_duty_applies?
   end
 
+  def additional_codes
+    (additional_code_uk.values + additional_code_xi.values).compact.join(', ')
+  end
+
   def self.build(session)
     Thread.current[:user_session] = new(session)
   end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -869,4 +869,20 @@ RSpec.describe UserSession do
       expect(described_class.get).to eq(user_session)
     end
   end
+
+  describe '#additional_codes' do
+    context 'when additional code answers have been stored' do
+      subject(:user_session) do
+        build(:user_session, :with_additional_codes, :with_commodity_information)
+      end
+
+      it { expect(user_session.additional_codes).to eq('2340, 2600, 2340, 2600') }
+    end
+
+    context 'when additional code answers have not been stored' do
+      subject(:user_session) { build(:user_session, :with_commodity_information) }
+
+      it { expect(user_session.additional_codes).to eq('') }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] We need this method on the user_session 

### Why?

I am doing this because:

- It is used on the duty/show section and having an instance of the ConfirmationDecorator on duty feels wrong, so it can't stay on that class.