### PR TITLE
Disable CircleCI DLC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.2
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run:
           name: "Build Docker image"
           command: |


### PR DESCRIPTION
### Jira link

n/a
### What?

I have added/removed/altered:

- [x] Disabled Docker Layer Caching in CircleCI (https://circleci.com/docs/2.0/docker-layer-caching/)

### Why?

I am doing this because:
- DLC is charged at 200 credits per run, unlikely cost effective for the time it saves us currently.
- 200 credits it's equivalent to 20 minutes of a Docker Medium instance, per job (https://circleci.com/pricing/) 
