### PR TITLE
HOTT-858 Added missing govuk-link to error pages

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,9 +1,9 @@
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">We could not proceed with calculating your duty.</p>
-      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code)) %>.</p>
+      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code, class: 'govuk-link')) %>.</p>
     </div>
   </div>
 </main>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,9 +1,9 @@
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
       <p class="govuk-body">You may have mistyped the address or the page may have moved.</p>
-      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code)) %>.</p>
+      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code), class: 'govuk-link') %>.</p>
     </div>
   </div>
 </main>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,9 +1,9 @@
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
       <p class="govuk-body">Maybe you tried to change something you didn't have access to.</p>
-      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code)) %>.</p>
+      <p class="govuk-body">Click here to <%= link_to('start again', import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code), class: 'govuk-link') %>.</p>
     </div>
   </div>
 </main>


### PR DESCRIPTION
Also corrected column width of error title/content. It was already inside a two thirds width
container so a second two thirds makes it only use 50% of the page width.

### Jira link

https://transformuk.atlassian.net/jira/software/projects/HOTT/boards/96?selectedIssue=HOTT-858

### What?

I have added/removed/altered:

- [ ] Added the `govuk-link` class to the links on the 500, 422 and 404 pages
- [ ] Changed the container to use 2/3rds of the page width instead of 50%

### Why?

I am doing this because:

- We want our pages to look correct

### Have you? (optional)

- [x] Validated mobile responsive behaviour of view changes

