### PR TITLE
HOTT-858 Enabled global styles

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -8,6 +8,7 @@
 
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
+$govuk-global-styles: true;
 
 @import "~govuk-frontend/govuk/all";
 @import "accessible-autocomplete";


### PR DESCRIPTION
Sets govuk-body-m on all <p> tags and govuk-link on all <a> tags

### Jira link

https://transformuk.atlassian.net/browse/HOTT-858

### What?

I have added/removed/altered:

- [x] set the govuk-global-styles env var

### Why?

I am doing this because:

- This will automatically set `govuk-body-m` on all <p> tags and `govuk-link` on all <a> tags
- This avoids pages rendering incorrectly because of css classes missed on 'generic' parts of the page

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

