### PR TITLE
Show chosen document codes on confirmation page

### DIFF
--- a/app/decorators/confirmation_decorator.rb
+++ b/app/decorators/confirmation_decorator.rb
@@ -58,7 +58,7 @@ class ConfirmationDecorator < SimpleDelegator
     return format_measure_amount(value) if key == 'measure_amount'
     return country_name_for(value, key) if %w[import_destination country_of_origin].include?(key)
     return additional_codes_for(value) if key == 'additional_code'
-    return document_code_for(value) if key == 'document_code'
+    return selected_document_codes_from(value) if key == 'document_code'
     return excise_for(value) if key == 'excise'
     return vat_label(value) if key == 'vat'
 
@@ -113,14 +113,10 @@ class ConfirmationDecorator < SimpleDelegator
     user_session.excise_additional_code.values.join(', ')
   end
 
-  def additional_codes
-    (user_session.additional_code_uk.values + user_session.additional_code_xi.values).compact.join(', ')
-  end
+  def selected_document_codes_from(session_answers)
+    return document_codes if session_answers.values.map(&:values).flatten.any?(&:present?)
 
-  def document_code_for(value)
-    return nil unless value.values.reject(&:empty?).any?
-
-    document_codes
+    nil
   end
 
   def document_codes

--- a/app/decorators/confirmation_decorator.rb
+++ b/app/decorators/confirmation_decorator.rb
@@ -4,6 +4,7 @@ class ConfirmationDecorator < SimpleDelegator
 
   ORDERED_STEPS = %w[
     additional_code
+    document_code
     import_date
     import_destination
     country_of_origin
@@ -27,6 +28,7 @@ class ConfirmationDecorator < SimpleDelegator
     return import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code) if key == 'import_date'
 
     return additional_codes_path(applicable_measure_type_ids.first) if key == 'additional_code'
+    return document_codes_path(document_codes_applicable_measure_type_ids.first) if key == 'document_code' && Rails.application.config.document_codes_enabled
     return excise_path(applicable_excise_measure_type_ids.first) if key == 'excise' && Rails.application.config.excise_step_enabled
 
     send("#{key}_path")
@@ -56,6 +58,7 @@ class ConfirmationDecorator < SimpleDelegator
     return format_measure_amount(value) if key == 'measure_amount'
     return country_name_for(value, key) if %w[import_destination country_of_origin].include?(key)
     return additional_codes_for(value) if key == 'additional_code'
+    return document_code_for(value) if key == 'document_code'
     return excise_for(value) if key == 'excise'
     return vat_label(value) if key == 'vat'
 
@@ -108,6 +111,20 @@ class ConfirmationDecorator < SimpleDelegator
 
   def excise_additional_codes
     user_session.excise_additional_code.values.join(', ')
+  end
+
+  def additional_codes
+    (user_session.additional_code_uk.values + user_session.additional_code_xi.values).compact.join(', ')
+  end
+
+  def document_code_for(value)
+    return nil unless value.values.reject(&:empty?).any?
+
+    document_codes
+  end
+
+  def document_codes
+    (user_session.document_code_uk.values.flatten.reject(&:empty?) + user_session.document_code_xi.values.flatten.reject(&:empty?)).uniq.join(', ')
   end
 
   def user_session

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
     customs_value: Customs value
     measure_amount: Import quantity
     additional_code: Additional code(s)
+    document_code: Document(s)
     vat: Applicable VAT rate
     excise: Excise additional code
   activemodel:

--- a/spec/decorators/confirmation_decorator_spec.rb
+++ b/spec/decorators/confirmation_decorator_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ConfirmationDecorator, :user_session do
       :with_additional_codes,
       :with_excise_additional_codes,
       :with_vat,
+      :with_document_codes,
     )
   end
 
@@ -35,6 +36,7 @@ RSpec.describe ConfirmationDecorator, :user_session do
       expect(described_class::ORDERED_STEPS).to eq(
         %w[
           additional_code
+          document_code
           import_date
           import_destination
           country_of_origin
@@ -55,6 +57,7 @@ RSpec.describe ConfirmationDecorator, :user_session do
     let(:expected) do
       [
         { key: 'additional_code', label: 'Additional code(s)', value: '2340, 2600, 2340, 2600' },
+        { key: 'document_code', label: 'Document(s)', value: 'N851, C644, Y929' },
         { key: 'import_date', label: 'Date of import', value: '01 January 2025' },
         { key: 'import_destination', label: 'Destination', value: 'Northern Ireland' },
         { key: 'country_of_origin', label: 'Coming from', value: 'United Kingdom' },


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-676

### What?

I have added/removed/altered:

- [x] Show chosen document codes on the confirmation page

### Why?

I am doing this because:

- users need to be able to change their selection
- users need to see a summary of their selection

![Screen Shot 2021-07-26 at 11 06 25](https://user-images.githubusercontent.com/1955084/126972430-a5324656-1d40-494f-a529-59fa91e54d6d.png)
