### PR TITLE
Wipe out stale excise keys from session

### DIFF
--- a/app/models/steps/additional_code.rb
+++ b/app/models/steps/additional_code.rb
@@ -2,7 +2,7 @@ module Steps
   class AdditionalCode < Steps::Base
     include CommodityHelper
 
-    STEPS_TO_REMOVE_FROM_SESSION = %w[].freeze
+    STEPS_TO_REMOVE_FROM_SESSION = %w[document_code excise].freeze
 
     attribute :measure_type_id, :string
     attribute :additional_code_uk, :string

--- a/app/models/steps/certificate_of_origin.rb
+++ b/app/models/steps/certificate_of_origin.rb
@@ -5,7 +5,7 @@ module Steps
       OpenStruct.new(id: 'no', name: 'No, I do not have a valid Certificate of Origin'),
     ].freeze
 
-    STEPS_TO_REMOVE_FROM_SESSION = %w[document_code].freeze
+    STEPS_TO_REMOVE_FROM_SESSION = %w[document_code excise].freeze
 
     attribute :certificate_of_origin, :string
 

--- a/app/models/steps/country_of_origin.rb
+++ b/app/models/steps/country_of_origin.rb
@@ -6,6 +6,7 @@ module Steps
       certificate_of_origin
       planned_processing
       document_code
+      excise
     ].freeze
 
     attr_reader :zero_mfn_duty, :trade_defence

--- a/app/models/steps/customs_value.rb
+++ b/app/models/steps/customs_value.rb
@@ -2,7 +2,7 @@ module Steps
   class CustomsValue < Steps::Base
     include CommodityHelper
 
-    STEPS_TO_REMOVE_FROM_SESSION = %w[additional_code document_code].freeze
+    STEPS_TO_REMOVE_FROM_SESSION = %w[additional_code document_code excise].freeze
 
     attribute :monetary_value, :string
     attribute :shipping_cost, :string

--- a/app/models/steps/final_use.rb
+++ b/app/models/steps/final_use.rb
@@ -4,6 +4,7 @@ module Steps
       certificate_of_origin
       planned_processing
       document_code
+      excise
     ].freeze
 
     attribute :final_use, :string

--- a/app/models/steps/import_date.rb
+++ b/app/models/steps/import_date.rb
@@ -10,6 +10,7 @@ module Steps
       certificate_of_origin
       planned_processing
       document_code
+      excise
     ].freeze
 
     attribute :import_date, :date

--- a/app/models/steps/import_destination.rb
+++ b/app/models/steps/import_destination.rb
@@ -13,6 +13,7 @@ module Steps
       certificate_of_origin
       planned_processing
       document_code
+      excise
     ].freeze
 
     attribute :import_destination, :string

--- a/app/models/steps/measure_amount.rb
+++ b/app/models/steps/measure_amount.rb
@@ -1,6 +1,6 @@
 module Steps
   class MeasureAmount
-    STEPS_TO_REMOVE_FROM_SESSION = %w[additional_code document_code].freeze
+    STEPS_TO_REMOVE_FROM_SESSION = %w[additional_code document_code excise].freeze
 
     include ActiveModel::Model
     include CommodityHelper

--- a/app/models/steps/planned_processing.rb
+++ b/app/models/steps/planned_processing.rb
@@ -3,6 +3,7 @@ module Steps
     STEPS_TO_REMOVE_FROM_SESSION = %w[
       certificate_of_origin
       document_code
+      excise
     ].freeze
 
     attribute :planned_processing, :string

--- a/app/models/steps/trader_scheme.rb
+++ b/app/models/steps/trader_scheme.rb
@@ -10,6 +10,7 @@ module Steps
       certificate_of_origin
       planned_processing
       document_code
+      excise
     ].freeze
 
     attribute :trader_scheme, :string

--- a/spec/models/steps/additional_code_spec.rb
+++ b/spec/models/steps/additional_code_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
   describe 'STEPS_TO_REMOVE_FROM_SESSION' do
     it 'returns the correct list of steps' do
       expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(
-        %w[],
+        %w[document_code excise],
       )
     end
   end

--- a/spec/models/steps/certificate_of_origin_spec.rb
+++ b/spec/models/steps/certificate_of_origin_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Steps::CertificateOfOrigin, :step, :user_session do
   describe 'STEPS_TO_REMOVE_FROM_SESSION' do
     it 'returns the correct list of steps' do
       expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(
-        %w[document_code],
+        %w[document_code excise],
       )
     end
   end

--- a/spec/models/steps/country_of_origin_spec.rb
+++ b/spec/models/steps/country_of_origin_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Steps::CountryOfOrigin, :step, :user_session do
           certificate_of_origin
           planned_processing
           document_code
+          excise
         ],
       )
     end

--- a/spec/models/steps/customs_value_spec.rb
+++ b/spec/models/steps/customs_value_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Steps::CustomsValue, :step, :user_session do
   describe 'STEPS_TO_REMOVE_FROM_SESSION' do
     it 'returns the correct list of steps' do
       expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(
-        %w[additional_code document_code],
+        %w[additional_code document_code excise],
       )
     end
   end

--- a/spec/models/steps/final_use_spec.rb
+++ b/spec/models/steps/final_use_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Steps::FinalUse, :step, :user_session do
           certificate_of_origin
           planned_processing
           document_code
+          excise
         ],
       )
     end

--- a/spec/models/steps/import_date_spec.rb
+++ b/spec/models/steps/import_date_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Steps::ImportDate, :step, :user_session do
           certificate_of_origin
           planned_processing
           document_code
+          excise
         ],
       )
     end

--- a/spec/models/steps/import_destination_spec.rb
+++ b/spec/models/steps/import_destination_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Steps::ImportDestination, :step, :user_session do
           certificate_of_origin
           planned_processing
           document_code
+          excise
         ],
       )
     end

--- a/spec/models/steps/measure_amount_spec.rb
+++ b/spec/models/steps/measure_amount_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Steps::MeasureAmount, :step, :user_session do
 
   describe 'STEPS_TO_REMOVE_FROM_SESSION' do
     it 'returns the correct list of steps' do
-      expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(%w[additional_code document_code])
+      expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(%w[additional_code document_code excise])
     end
   end
 

--- a/spec/models/steps/trader_scheme_spec.rb
+++ b/spec/models/steps/trader_scheme_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Steps::TraderScheme, :step, :user_session do
           certificate_of_origin
           planned_processing
           document_code
+          excise
         ],
       )
     end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Wipe out stale excise keys from session

### Why?

I am doing this because:

- When users go back to previous questions, we need
to wipe out the excise key from the session. Otherwise, we end up with stale excise keys on routes
that don't have excise at all, causing the error:

https://transformuk.atlassian.net/browse/HOTT-857