### PR TITLE
Adds business logic model method for expressing documents

### DIFF
--- a/app/models/api/measure_condition.rb
+++ b/app/models/api/measure_condition.rb
@@ -1,5 +1,14 @@
 module Api
   class MeasureCondition < Api::Base
+    DOCUMENT_CONDITION_CODES = [
+      'B', # Presentation of a certificate/licence/document'
+      'H', # Presentation of a certificate/licence/document'
+      'E', # The quantity or the price per unit declared, as appropriate, is equal or less than the specified maximum, or presentation of the required document'
+      'A', # Presentation of an anti-dumping/countervailing document'
+      'C', # Presentation of a certificate/licence/document'
+      'I', # The quantity or the price per unit declared, as appropriate, is equal or less than the specified maximum, or presentation of the required document'
+    ].freeze
+
     attributes :id,
                :action,
                :action_code,
@@ -18,6 +27,10 @@ module Api
 
     def expresses_unit?
       (condition_measurement_unit_code || condition_monetary_unit_code).present?
+    end
+
+    def expresses_document?
+      condition_code.in?(DOCUMENT_CONDITION_CODES)
     end
   end
 end

--- a/spec/models/api/measure_condition_spec.rb
+++ b/spec/models/api/measure_condition_spec.rb
@@ -45,4 +45,20 @@ RSpec.describe Api::MeasureCondition do
       end
     end
   end
+
+  describe '#expresses_document?' do
+    subject(:measure_condition) { described_class.new(condition_code: condition_code) }
+
+    context 'when the condition_code is a document condition code' do
+      let(:condition_code) { 'I' }
+
+      it { is_expected.to be_expresses_document }
+    end
+
+    context 'when the condition_code is not a document condition code' do
+      let(:condition_code) { 'V' }
+
+      it { is_expected.not_to be_expresses_document }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds business logic method for expressing documents

### Why?

I am doing this because:

- This is needed for returning document codes for measure types with duties we can apply in the duty calculator
