### PR TITLE
Extend deltas applicable logic to exclude trade defence measures

### DIFF
--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -83,6 +83,8 @@ class UserSession
     session['trade_defence']
   end
 
+  alias_method :trade_defence?, :trade_defence
+
   def trade_defence=(value)
     session['trade_defence'] = value
   end
@@ -248,7 +250,7 @@ class UserSession
   end
 
   def deltas_applicable?
-    row_to_ni_route? && planned_processing != 'commercial_purposes'
+    row_to_ni_route? && planned_processing != 'commercial_purposes' && !trade_defence?
   end
 
   def import_into_gb?

--- a/spec/factories/user_session.rb
+++ b/spec/factories/user_session.rb
@@ -59,6 +59,7 @@ FactoryBot.define do
   end
 
   trait :deltas_applicable do
+    trade_defence { false }
     import_destination { 'XI' }
     country_of_origin { 'OTHER' }
     other_country_of_origin { 'AR' }

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -790,21 +790,16 @@ RSpec.describe UserSession do
   end
 
   describe '#deltas_applicable?' do
-    context 'when on RoW to NI route and planned_processing is commercial_purposes' do
-      subject(:user_session) do
-        build(
-          :user_session,
-          :deltas_applicable,
-        )
-      end
+    context 'when on a deltas applicable route' do
+      subject(:user_session) { build(:user_session, :deltas_applicable) }
 
-      it 'returns true' do
-        expect(user_session.deltas_applicable?).to be true
-      end
+      it { is_expected.to be_deltas_applicable }
     end
 
-    it 'returns false' do
-      expect(user_session.deltas_applicable?).to be false
+    context 'when not on a deltas applicable route' do
+      subject(:user_session) { build(:user_session) }
+
+      it { is_expected.not_to be_deltas_applicable }
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-884

### What?

I have added/removed/altered:

- [x] Force EU measures when there are trade defence measures in place on the deltas applicable route
- [x] Extend user session factory to define the deltas applicable logic to fix the tests

### Why?

I am doing this because:

- EU duties always apply whenever there are trade defence measures on the EU measures for a given commodity
