### PR TITLE
Move exchange rate

### DIFF
--- a/app/views/steps/duty/show.html.erb
+++ b/app/views/steps/duty/show.html.erb
@@ -1,6 +1,7 @@
 <%= link_to('Back', :back, class: "govuk-back-link") %>
 
 <span class="govuk-caption-xl">Calculate import duties</span>
+
 <% if @duty_options.nil? %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
@@ -13,8 +14,9 @@
   <p class="govuk-body">You are importing commodity <%= link_to(commodity.formatted_commodity_code(user_session.additional_codes), commodity_url(commodity.code), class: 'govuk-link') %> from <strong><%= country_of_origin_description %> </strong> on <strong><%= l user_session.import_date %></strong>.</p>
   <%= render 'steps/duty/calculations/trade_details' %>
   <%= render 'steps/duty/calculations/options' %>
+
+  <% if @gbp_to_eur_exchange_rate.present? %>
+    <p class="govuk-body-s">Please note - the current page uses an exchange rate of <strong><%= @gbp_to_eur_exchange_rate %> GBP to EUR</strong>.</p>
+  <% end %>
 <% end %>
 
-<% if @gbp_to_eur_exchange_rate.present? %>
-  <p class="govuk-body-s">Please note - the current page uses an exchange rate of <strong><%= @gbp_to_eur_exchange_rate %> GBP to EUR</strong>.</p>
-<% end %>


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Moves exchange rate rendering to only show when there are duties that apply

### Why?

I am doing this because:

- We shouldn't show the exchange rate when there is no duty to convert
