### PR TITLE
Update copy for single excise class

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
     vat: Applicable VAT rate
     excise: Excise additional code
   excise_page:
-    hint_html: "<p>There are multiple excise duties that could be applied to trade in this commodity code. Select which class of excise duty applies to your trade</p>%{small_brewers_relief_hint_text}<p>For more information on excise duty classes, please see %{excise_link}</p>"
+    hint_html: "<p>Excise duty applies to trade in this commodity code. Select which class of excise duty applies to your trade</p>%{small_brewers_relief_hint_text}<p>For more information on excise duty classes, please see %{excise_link}</p>"
     link_text: "UK Trade: excise, duties, reliefs, drawbacks and allowances (opens in new browser window)"
     small_brewers_relief_link_text: "Small Breweries' Relief (SBR)"
     small_brewers_relief_hint_text_html: "<p>Please note that the work to calculate the %{small_brewers_relief_link} is in development and will be available shortly.</p>"


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-872

### What?

Before

![image](https://user-images.githubusercontent.com/8156884/128891620-10ade7e0-9265-49b8-96c2-db1d7aec635e.png)

After

![image](https://user-images.githubusercontent.com/8156884/128891580-5aa28795-a8ae-4e3b-b08c-8aaf6619c278.png)


I have added/removed/altered:

- [x] Updates the hint copy for excise show page

### Why?

I am doing this because:

- Semantically reflects the situation where there is only one class of excise duty
