### PR TITLE
Bumps uktt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'newrelic_rpm'
 gem 'puma'
 gem 'railties', '~> 6'
 gem 'sentry-raven'
-gem 'uktt', git: 'https://github.com/trade-tariff/uktt.git', ref: 'faraday'
+gem 'uktt', git: 'https://github.com/trade-tariff/uktt.git'
 gem 'webpacker'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'newrelic_rpm'
 gem 'puma'
 gem 'railties', '~> 6'
 gem 'sentry-raven'
-gem 'uktt', git: 'https://github.com/trade-tariff/uktt.git'
+gem 'uktt', git: 'https://github.com/trade-tariff/uktt.git', ref: 'faraday'
 gem 'webpacker'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,13 @@
 GIT
   remote: https://github.com/trade-tariff/uktt.git
-  revision: 58b98e7a84b749c0288786c88f498e04a91b25da
+  revision: 0fca9fc1ff05dda2c177ab05ab33207bcac683e0
+  ref: faraday
   specs:
-    uktt (2.4.0)
-      retriable
+    uktt (2.5.0)
+      faraday
+      faraday-net_http_persistent
+      faraday_middleware
+      net-http-persistent
 
 GEM
   remote: https://rubygems.org/
@@ -41,6 +45,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crass (1.0.6)
     deep_merge (1.2.1)
     diff-lcs (1.4.4)
@@ -72,6 +77,8 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
     faraday-patron (1.0.0)
+    faraday_middleware (1.1.0)
+      faraday (~> 1.0)
     ffi (1.15.3)
     foreman (0.87.2)
     govuk_design_system_formbuilder (2.4.0)
@@ -98,6 +105,8 @@ GEM
     minitest (5.14.4)
     msgpack (1.4.2)
     multipart-post (2.1.1)
+    net-http-persistent (4.0.1)
+      connection_pool (~> 2.2)
     newrelic_rpm (7.2.0)
     nio4r (2.5.7)
     nokogiri (1.11.7)
@@ -145,7 +154,6 @@ GEM
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
-    retriable (3.1.2)
     rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/trade-tariff/uktt.git
-  revision: 0fca9fc1ff05dda2c177ab05ab33207bcac683e0
-  ref: faraday
+  revision: 063a14b75bb21636e9622e54303397fbeb1e4d61
   specs:
     uktt (2.5.0)
       faraday


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Bumps uktt gem

### Why?

I am doing this because:

- We're moving to using persistent faraday for better performance
- We're also validating/public/private routing of the uktt gem after the change
