### PR TITLE
Removes merging complexity in merger now that we can ignore the sids

### DIFF
--- a/app/models/api/base_component.rb
+++ b/app/models/api/base_component.rb
@@ -32,5 +32,9 @@ module Api
     def operator
       duty_expression_abbreviation
     end
+
+    def unit
+      "#{measurement_unit_code}#{measurement_unit_qualifier_code}"
+    end
   end
 end

--- a/app/services/applicable_measure_unit_merger.rb
+++ b/app/services/applicable_measure_unit_merger.rb
@@ -10,11 +10,7 @@ class ApplicableMeasureUnitMerger
   private
 
   def delta_measure_units
-    uk_filtered_commodity.applicable_measure_units.merge(xi_filtered_commodity.applicable_measure_units) do |_key, uk_units, xi_units|
-      uk_units['measure_sids'] += xi_units['measure_sids']
-
-      uk_units
-    end
+    uk_filtered_commodity.applicable_measure_units.merge(xi_filtered_commodity.applicable_measure_units)
   end
 
   def uk_measure_units

--- a/app/services/expression_evaluators/measure_unit.rb
+++ b/app/services/expression_evaluators/measure_unit.rb
@@ -7,7 +7,7 @@ module ExpressionEvaluators
         calculation: calculation_duty_expression,
         value: value,
         formatted_value: number_to_currency(value),
-        unit: measure_unit_answers.first[:unit],
+        unit: presented_unit[:unit],
         total_quantity: total_quantity,
       }
     end
@@ -40,24 +40,18 @@ module ExpressionEvaluators
     end
 
     def total_quantity
-      measure_unit_answers.first[:answer].to_f
+      presented_unit[:answer].to_f
     end
 
-    def measure_unit_answers
-      @measure_unit_answers ||= measure_applicable_units.map do |unit, values|
-        {
-          answer: user_session.measure_amount[unit.downcase.to_s],
-          unit: values['unit'],
-        }
-      end
+    def presented_unit
+      @presented_unit ||= {
+        answer: user_session.measure_amount[component.unit.downcase.to_s],
+        unit: applicable_unit['unit'],
+      }
     end
 
-    def measure_applicable_units
-      units = ApplicableMeasureUnitMerger.new.call
-
-      units.select do |_unit, values|
-        values['measure_sids'].include?(measure.id)
-      end
+    def applicable_unit
+      ApplicableMeasureUnitMerger.new.call[component.unit]
     end
 
     def eur_to_gbp_rate

--- a/spec/models/api/base_component_spec.rb
+++ b/spec/models/api/base_component_spec.rb
@@ -114,8 +114,20 @@ RSpec.describe Api::BaseComponent do
   end
 
   describe '#operator' do
-    it 'returns %' do
-      expect(component.operator).to eq '%'
+    it { expect(component.operator).to eq('%') }
+  end
+
+  describe 'unit' do
+    context 'when the component has unit attributes' do
+      subject(:component) { described_class.new(attributes_for(:measure_component, :with_measure_units)) }
+
+      it { expect(component.unit).to eq('DTN') }
+    end
+
+    context 'when the component has no unit attributes' do
+      subject(:component) { described_class.new(attributes_for(:measure_component)) }
+
+      it { expect(component.unit).to eq('') }
     end
   end
 end

--- a/spec/services/applicable_measure_unit_merger_spec.rb
+++ b/spec/services/applicable_measure_unit_merger_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ApplicableMeasureUnitMerger, :user_session do
             'unit_question' => 'What is the weight of the goods you will be importing?',
             'unit_hint' => 'Enter the value in decitonnes (100kg)',
             'unit' => 'x 100 kg',
-            'measure_sids' => [2_046_828, 2_046_828],
+            'measure_sids' => [2_046_828],
           },
           'RET' => {
             'measurement_unit_code' => 'RET',


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Handles pulling out the measure unit answers for the measure unit evaluator without needing to lookup the measure sid

### Why?

I am doing this because:

- This wasn't actually ever needed - the component tells you the unit
