### PR TITLE
Removes Factor and ASV percent measure units from duty calculation consideration

### DIFF
--- a/app/services/applicable_measure_unit_merger.rb
+++ b/app/services/applicable_measure_unit_merger.rb
@@ -1,6 +1,8 @@
 class ApplicableMeasureUnitMerger
   include CommodityHelper
 
+  UNHANDLED_MEASURE_UNITS = %w[FC1X].freeze
+
   def call
     return delta_measure_units if user_session.deltas_applicable?
 
@@ -10,15 +12,29 @@ class ApplicableMeasureUnitMerger
   private
 
   def delta_measure_units
-    uk_filtered_commodity.applicable_measure_units.merge(xi_filtered_commodity.applicable_measure_units)
+    clean_unhandled_measure_units do
+      uk_filtered_commodity.applicable_measure_units.merge(xi_filtered_commodity.applicable_measure_units)
+    end
   end
 
   def uk_measure_units
-    uk_filtered_commodity.applicable_measure_units
+    clean_unhandled_measure_units do
+      uk_filtered_commodity.applicable_measure_units
+    end
   end
 
   def xi_measure_units
-    xi_filtered_commodity.applicable_measure_units.merge(uk_filtered_commodity.applicable_excise_measure_units)
+    clean_unhandled_measure_units do
+      xi_filtered_commodity.applicable_measure_units.merge(uk_filtered_commodity.applicable_excise_measure_units)
+    end
+  end
+
+  def clean_unhandled_measure_units
+    yield.tap do |units|
+      UNHANDLED_MEASURE_UNITS.each do |unhandled_unit|
+        units.delete(unhandled_unit)
+      end
+    end
   end
 
   def user_session

--- a/app/services/applicable_measure_unit_merger.rb
+++ b/app/services/applicable_measure_unit_merger.rb
@@ -1,7 +1,10 @@
 class ApplicableMeasureUnitMerger
   include CommodityHelper
 
-  UNHANDLED_MEASURE_UNITS = %w[FC1X].freeze
+  UNHANDLED_MEASURE_UNITS = %w[
+    ASV
+    FC1X
+  ].freeze
 
   def call
     return delta_measure_units if user_session.deltas_applicable?

--- a/spec/fixtures/uk/commodities/0103921100.json
+++ b/spec/fixtures/uk/commodities/0103921100.json
@@ -44,6 +44,14 @@
           "unit_question": "Please enter unit: Factor",
           "unit_hint": "Please correctly enter unit: Factor",
           "unit": null
+        },
+        "ASV": {
+          "measurement_unit_code": "ASV",
+          "measurement_unit_qualifier_code": "",
+          "abbreviation": "% vol",
+          "unit_question": "What is the alcohol percentage (%) of the goods you are importing?",
+          "unit_hint": "Enter the alcohol by volume (ABV) percentage",
+          "unit": "percent"
         }
       },
       "applicable_additional_codes": {

--- a/spec/fixtures/uk/commodities/0103921100.json
+++ b/spec/fixtures/uk/commodities/0103921100.json
@@ -36,6 +36,14 @@
           "measure_sids": [
             -1010806389
           ]
+        },
+        "FC1X": {
+          "measurement_unit_code": "FC1",
+          "measurement_unit_qualifier_code": "X",
+          "abbreviation": "Factor",
+          "unit_question": "Please enter unit: Factor",
+          "unit_hint": "Please correctly enter unit: Factor",
+          "unit": null
         }
       },
       "applicable_additional_codes": {


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes FC1X from all routes measure units

### Why?

I am doing this because:

- We currently don't know how to handle this and the additional code filtering that would stop this from being shown isn't currently happening
