### PR TITLE
Accept only the first footnote suffix

### DIFF
--- a/app/models/duty_option_result.rb
+++ b/app/models/duty_option_result.rb
@@ -15,11 +15,11 @@ class DutyOptionResult
   attribute :geographical_area_description
 
   def footnote
-    (super + footnote_suffix).html_safe
+    super + footnote_suffix
   end
 
   def footnote_suffix
-    @footnote_suffix.presence || ''
+    @footnote_suffix.presence || ''.html_safe
   end
 
   def footnote_suffix=(suffix)

--- a/app/models/duty_option_result.rb
+++ b/app/models/duty_option_result.rb
@@ -13,4 +13,18 @@ class DutyOptionResult
   attribute :warning_text
   attribute :order_number
   attribute :geographical_area_description
+
+  def footnote
+    (super + footnote_suffix).html_safe
+  end
+
+  def footnote_suffix
+    @footnote_suffix.presence || ''
+  end
+
+  def footnote_suffix=(suffix)
+    return if @footnote_suffix
+
+    @footnote_suffix = suffix
+  end
 end

--- a/app/models/row_to_ni_duty_calculator.rb
+++ b/app/models/row_to_ni_duty_calculator.rb
@@ -31,16 +31,16 @@ class RowToNiDutyCalculator
 
                  uk_only = cheapest_xi_option.nil?
 
-                 footnote_suffix = I18n.t("row_to_ni_measure_type_footnotes_suffixes.#{category}.uk_only.#{option.source}", uk_only_text: uk_only_text_for(category, option, uk_option)).html_safe if uk_only
+                 footnote_suffix = I18n.t("row_to_ni_measure_type_footnotes_suffixes.#{category}.uk_only.#{option.source}_html", uk_only_text: uk_only_text_for(category, option, uk_option)) if uk_only
 
                  option
                end
 
       next if option.blank?
 
-      footnote_suffix ||= I18n.t("row_to_ni_measure_type_footnotes_suffixes.#{option.category}.#{option.source}").html_safe
+      footnote_suffix ||= I18n.t("row_to_ni_measure_type_footnotes_suffixes.#{option.category}.#{option.source}_html")
 
-      option.footnote_suffix = footnote_suffix
+      option.footnote_suffix = footnote_suffix.html_safe
 
       acc << option
     end
@@ -64,10 +64,10 @@ class RowToNiDutyCalculator
   end
 
   def default_options_for(category)
-    footnote_suffix = I18n.t("row_to_ni_measure_type_footnotes_suffixes.#{category}.xi_only.xi").html_safe
+    footnote_suffix = I18n.t("row_to_ni_measure_type_footnotes_suffixes.#{category}.xi_only.xi_html")
 
     xi_options.public_send("#{category}_options").each do |option|
-      option.footnote_suffix = footnote_suffix
+      option.footnote_suffix = footnote_suffix.html_safe
     end
   end
 

--- a/app/models/row_to_ni_duty_calculator.rb
+++ b/app/models/row_to_ni_duty_calculator.rb
@@ -40,7 +40,7 @@ class RowToNiDutyCalculator
 
       footnote_suffix ||= I18n.t("row_to_ni_measure_type_footnotes_suffixes.#{option.category}.#{option.source}").html_safe
 
-      option.footnote = option.footnote.concat(footnote_suffix).html_safe
+      option.footnote_suffix = footnote_suffix
 
       acc << option
     end
@@ -67,7 +67,7 @@ class RowToNiDutyCalculator
     footnote_suffix = I18n.t("row_to_ni_measure_type_footnotes_suffixes.#{category}.xi_only.xi").html_safe
 
     xi_options.public_send("#{category}_options").each do |option|
-      option.footnote = option.footnote.concat(footnote_suffix).html_safe
+      option.footnote_suffix = footnote_suffix
     end
   end
 

--- a/config/locales/footnotes.en.yml
+++ b/config/locales/footnotes.en.yml
@@ -1182,67 +1182,67 @@ en:
   
   row_to_ni_measure_type_footnotes_suffixes:
     third_country_tariff:
-      uk:
+      uk_html:
         <p class="govuk-body">
           UK import duties apply, as the difference between the UK third country duty and the EU third country duty is lower than 3% of the customs value of your trade.
         </p>
-      xi:
+      xi_html:
         <p class="govuk-body">
           EU import duties apply, as the difference between the UK third country duty and the EU third country duty exceeds 3% of the customs value of your trade.
         </p>
     tariff_preference:
       xi_only:
-        xi:
+        xi_html:
           <p class="govuk-body">
             EU preferential duties may be applied.
           </p>
       uk_only:
-        uk:
+        uk_html:
           <p class="govuk-body">
             UK preferential duties may be applied, as the difference between the UK preferential duty and the EU third-country duty is lower than 3% of the customs value of your trade.
           </p>
-        xi:
+        xi_html:
           <p class="govuk-body">
             The UK preference is not available, as the difference between the UK preferential duty and the EU third-country duty exceeds 3% of the customs value of your trade.
           </p>
-      uk:
+      uk_html:
         <p class="govuk-body">
           UK preferential duties may be applied, as the difference between the UK preferential duty and the EU preferential duty is lower than 3% of the customs value of your trade.
         </p>
-      xi:
+      xi_html:
         <p class="govuk-body">
           EU preferential duties may be applied, as the difference between the UK preferential duty and the EU preferential duty exceeds 3% of the customs value of your trade.
         </p>
     suspension:
       xi_only:
-        xi:
+        xi_html:
           <p class="govuk-body">
             EU suspension duties may be applied.
           </p>
       uk_only:
-        uk:
+        uk_html:
           <p class="govuk-body">
             UK suspension duties may be applied, as the difference between the UK suspension duty and the EU third-country duty is lower than 3% of the customs value of your trade.
           </p>
-        xi:
+        xi_html:
           <p class="govuk-body">
             The UK %{uk_only_text} is not available, as the difference between the UK suspended duty and the EU third-country duty exceeds 3% of the customs value of your trade.
           </p>
-      uk:
+      uk_html:
         <p class="govuk-body">
           UK suspensions may be applied, as the difference between the UK suspension duty and the EU suspension duty is lower than 3% of the customs value of your trade.
         </p>
-      xi:
+      xi_html:
         <p class="govuk-body">
           EU suspensions may be applied, as the difference between the UK suspension duty and the EU suspension duty exceeds 3% of the customs value of your trade.
         </p>
     quota:
       uk_only:
-        uk:
+        uk_html:
           <p class="govuk-body">
             UK quotas may be used, as the difference between the UK in-quota duty and the EU third-country duty is lower than 3% of the customs value of your trade.
           </p>
-        xi:
+        xi_html:
           <p class="govuk-body">
             The UK quota %{uk_only_text} is not available, as the difference between the UK quota duty and the EU third-country duty exceeds 3% of the customs value of your trade.
           </p>

--- a/spec/models/duty_option_result_spec.rb
+++ b/spec/models/duty_option_result_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe DutyOptionResult do
+  subject(:result) { described_class.new }
+
   it_behaves_like 'a resource that has attributes',
                   type: 'tariff_preference',
                   category: :tariff_preference,
@@ -11,4 +13,66 @@ RSpec.describe DutyOptionResult do
                   warning_text: nil,
                   order_number: nil,
                   geographical_area_description: 'United Kingdom (excluding Northern Ireland)'
+
+  describe '#footnote_suffix' do
+    it { expect(result.footnote_suffix).to eq('') }
+
+    context 'when there is a suffix' do
+      before do
+        result.footnote_suffix = 'foo'
+      end
+
+      it { expect(result.footnote_suffix).to eq('foo') }
+    end
+  end
+
+  describe '#footnote_suffix=' do
+    context 'when there is already a suffix' do
+      before do
+        result.footnote_suffix = 'foo'
+      end
+
+      it 'does not set a new suffix' do
+        result.footnote_suffix = 'bar'
+
+        expect(result.footnote_suffix).to eq('foo')
+      end
+    end
+
+    context 'when there is no suffix' do
+      it 'does not set a new suffix' do
+        result.footnote_suffix = 'bar'
+
+        expect(result.footnote_suffix).to eq('bar')
+      end
+    end
+  end
+
+  describe '#footnote' do
+    subject(:result) { build(:duty_option_result, :third_country_tariff) }
+
+    context 'when there is a suffix' do
+      let(:expected_footnote) do
+        "<p class=\"govuk-body\">\n  A ‘Third country’ duty is the tariff charged where there isn’t a trade agreement or a customs union available. It can also be referred to as the Most Favoured Nation (<abbr title=\"Most Favoured Nation\">MFN</abbr>) rate.\n</p>bar"
+      end
+
+      before do
+        result.footnote_suffix = 'bar'
+      end
+
+      it 'returns the footnote with a suffix' do
+        expect(result.footnote).to eq(expected_footnote)
+      end
+    end
+
+    context 'when there is no suffix' do
+      let(:expected_footnote) do
+        "<p class=\"govuk-body\">\n  A ‘Third country’ duty is the tariff charged where there isn’t a trade agreement or a customs union available. It can also be referred to as the Most Favoured Nation (<abbr title=\"Most Favoured Nation\">MFN</abbr>) rate.\n</p>"
+      end
+
+      it 'returns the footnote' do
+        expect(result.footnote).to eq(expected_footnote)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-809

### What?

I have added/removed/altered:

- [x] Accept only the first suffix in the duty option result
- [x] Adds corresponding specs for the footnote suffix behaviour

### Why?

I am doing this because:

- This is needed to avoid accumulating suffixes into the duty option result
