### PR TITLE
Standardise OptionCollection api

### DIFF
--- a/app/models/option_collection.rb
+++ b/app/models/option_collection.rb
@@ -1,28 +1,21 @@
-class OptionCollection
-  include Enumerable
+class OptionCollection < SimpleDelegator
+  WRAPPED_METHODS = %i[
+    reject
+    select
+    sort_by
+    uniq
+  ].freeze
 
   def initialize(options)
+    super
+
     @options = options
   end
 
-  def each(&block)
-    @options.each(&block)
-  end
-
-  def <<(option)
-    @options << option
-  end
-
-  def uniq(&block)
-    self.class.new(super(&block))
-  end
-
-  def size
-    @options.size
-  end
-
-  def sort_by(&block)
-    self.class.new(super(&block))
+  WRAPPED_METHODS.each do |method|
+    define_method(method) do |&block|
+      self.class.new(super(&block))
+    end
   end
 
   def tariff_preference_options

--- a/spec/models/duty_calculator_spec.rb
+++ b/spec/models/duty_calculator_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe DutyCalculator, :user_session do
       ]
     end
 
+    it { expect(calculator.options).to be_a(OptionCollection) }
+
     it 'returns the correct duty options' do
       result = calculator.options.to_a.map do |option_result|
         option_result.attributes.deep_symbolize_keys

--- a/spec/models/option_collection_spec.rb
+++ b/spec/models/option_collection_spec.rb
@@ -98,4 +98,15 @@ RSpec.describe OptionCollection do
   describe '#size' do
     it { expect(collection.size).to eq(options.size) }
   end
+
+  shared_examples_for 'a wrapped option collection method' do |method|
+    subject(:collection) { described_class.new([]) }
+
+    it { expect(collection.public_send(method, &:foo)).to be_a(described_class) }
+  end
+
+  it_behaves_like 'a wrapped option collection method', :reject
+  it_behaves_like 'a wrapped option collection method', :select
+  it_behaves_like 'a wrapped option collection method', :sort_by
+  it_behaves_like 'a wrapped option collection method', :uniq
 end

--- a/spec/support/shared_examples/a_duty_calculator.rb
+++ b/spec/support/shared_examples/a_duty_calculator.rb
@@ -62,6 +62,8 @@ RSpec.shared_examples 'a duty calculator' do |config|
         )
       end
 
+      it { expect(calculator.options).to be_a(OptionCollection) }
+
       it 'passes the uk preference option and the xi preference option' do
         calculator.options
 
@@ -85,6 +87,8 @@ RSpec.shared_examples 'a duty calculator' do |config|
           ],
         )
       end
+
+      it { expect(calculator.options).to be_a(OptionCollection) }
 
       it 'passes the uk preference option and the xi mfn option' do
         calculator.options
@@ -118,6 +122,8 @@ RSpec.shared_examples 'a duty calculator' do |config|
         )
       end
 
+      it { expect(calculator.options).to be_a(OptionCollection) }
+
       it 'returns the correct options' do
         expect(calculator.options.to_a).to eq([uk_third_country_tariff_option, public_send("xi_#{config[:category]}_option")])
       end
@@ -142,6 +148,8 @@ RSpec.shared_examples 'a duty calculator' do |config|
           ],
         )
       end
+
+      it { expect(calculator.options).to be_a(OptionCollection) }
 
       it 'returns the correct options' do
         expect(calculator.options.to_a).to eq([uk_third_country_tariff_option, public_send("xi_cheapest_#{config[:category]}_option")])
@@ -175,6 +183,8 @@ RSpec.shared_examples 'a duty calculator' do |config|
           ],
         )
       end
+
+      it { expect(calculator.options).to be_a(OptionCollection) }
 
       it 'returns the correct options' do
         expect(calculator.options.to_a).to eq(


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-924

### What?

I have added/removed/altered:

- [x] Move to delegator over enumerable
- [x] Verify that wrapped methods wrap properly

### Why?

I am doing this because:

- OptionCollection wasn't returning an OptionCollection when calling reject
- OptionCollection needs to return an instance of itself everything certain array methods are called on the delegated subject
- Avoid regressions in behaviour

