### PR TITLE
Use ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,12 @@ commands:
       - run:
           name: "Push new app in dark mode"
           command: |
-            export IMAGE=tariff-dutycalculator
-            export DOCKER_IMAGE=${IMAGE}:<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
+            export DOCKER_IMAGE=tariff-dutycalculator
+            export DOCKER_TAG=<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
 
             # Push as "dark" instance
-            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push  "$CF_APP-<< parameters.environment_key >>-ecr" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE" --docker-username "$AWS_ACCESS_KEY_ID"
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push  "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
 
-            cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "enginetransformation/$DOCKER_IMAGE"
             # Map dark route
             cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
             # Enable routing from this service to the backend applications which are private
@@ -156,13 +155,6 @@ jobs:
             export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
             echo $GIT_NEW_REVISION >REVISION
             docker build -t $IMAGE_NAME:$DOCKER_TAG .
-
-      - run:
-          name: "Push image"
-          command: |
-            echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker tag $IMAGE_NAME:$DOCKER_TAG enginetransformation/$IMAGE_NAME:$DOCKER_TAG
-            docker push enginetransformation/$IMAGE_NAME:$DOCKER_TAG
       - run:
           name: "Push image to ECR"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@
 version: 2.1
 
 orbs:
+  aws-cli: circleci/aws-cli@2.0.3
   cloudfoundry: circleci/cloudfoundry@1.0
   cypress: cypress-io/cypress@1.27.0
   node: circleci/node@2
@@ -40,11 +41,13 @@ commands:
       - run:
           name: "Push new app in dark mode"
           command: |
-            export IMAGE=enginetransformation/tariff-dutycalculator
+            export IMAGE=tariff-dutycalculator
             export DOCKER_IMAGE=${IMAGE}:<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
 
             # Push as "dark" instance
-            cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$DOCKER_IMAGE"
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push  "$CF_APP-<< parameters.environment_key >>-ecr" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE" --docker-username "$AWS_ACCESS_KEY_ID"
+
+            cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "enginetransformation/$DOCKER_IMAGE"
             # Map dark route
             cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
             # Enable routing from this service to the backend applications which are private
@@ -130,29 +133,42 @@ jobs:
 
   build:
     environment:
-      IMAGE_NAME: enginetransformation/tariff-dutycalculator
+      IMAGE_NAME: tariff-dutycalculator
     parameters:
       dev-build:
         default: false
         type: boolean
     docker:
-      - image: cimg/ruby:3.0.2-node
+      - image: cimg/base:2021.04
     steps:
       - checkout
       - setup_remote_docker:
           version: 20.10.2
           docker_layer_caching: false
+      - aws-cli/install
+      - run:
+          name: "Set docker tag"
+          command: |
+            echo "export DOCKER_TAG=<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1}" >> $BASH_ENV
       - run:
           name: "Build Docker image"
           command: |
             export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
             echo $GIT_NEW_REVISION >REVISION
-            docker build -t $IMAGE_NAME:<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1} .
+            docker build -t $IMAGE_NAME:$DOCKER_TAG .
+
       - run:
           name: "Push image"
           command: |
             echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push $IMAGE_NAME:<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1}
+            docker tag $IMAGE_NAME:$DOCKER_TAG enginetransformation/$IMAGE_NAME:$DOCKER_TAG
+            docker push enginetransformation/$IMAGE_NAME:$DOCKER_TAG
+      - run:
+          name: "Push image to ECR"
+          command: |
+            aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
+            docker tag $IMAGE_NAME:$DOCKER_TAG $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
+            docker push $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
 
   test:
     docker:


### PR DESCRIPTION
### Jira link

n/a

### What?

I have added/removed/altered:

- [ ] Push docker image to AWS Elastic Container Registry instead of DockerHub
- [ ] Provide credentials to deploy to CF from ECR

### Why?

I am doing this because:

- We are moving away from DockerHub after the recent policy changes

