### PR TITLE
Wait on queue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ orbs:
   node: circleci/node@2
   ruby: circleci/ruby@1.1.4
   slack: circleci/slack@4.3.0
+  queue: eddiewebb/queue@1.6.1
 
 commands:
   cf_deploy_docker:
@@ -201,6 +202,8 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "development"
     steps:
+      - queue/until_front_of_line:
+          time: '10'
       - cf_deploy_docker:
           dev-release: true
           space: "development"
@@ -214,6 +217,8 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "staging"
     steps:
+      - queue/until_front_of_line:
+          time: '10'
       - cf_deploy_docker:
           space: "staging"
           environment_key: "staging"
@@ -226,6 +231,8 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "production"
     steps:
+      - queue/until_front_of_line:
+          time: '10'
       - cf_deploy_docker:
           space: "production"
           environment_key: "production"


### PR DESCRIPTION
### Jira link

HOTT-935

### What?

I have added/removed/altered:

- [ ] Added an ORB that uses the CircleCI API to query and wait on concurrent jobs to finish 

### Why?

I am doing this because:
- to prevent race conditions on the deploy stage 

### Have you? (optional)

- [ ] Created CircleCI API token for the project
- [ ] Added  CIRCLECI_API_KEY to project's environment in CircleCI
 
### Deployment risks (optional)

- Makes changes to our complex routing setup that may affect apis to proxying to backend
