### PR TITLE
Extend deltas applicable logic. Fix row to ni routing

### DIFF
--- a/app/models/steps/annual_turnover.rb
+++ b/app/models/steps/annual_turnover.rb
@@ -21,7 +21,19 @@ module Steps
     end
 
     def next_step_path
+      return next_step_for_gb_to_ni if user_session.gb_to_ni_route?
+
+      next_step_for_row_to_ni
+    end
+
+    def next_step_for_gb_to_ni
       return duty_path if user_session.annual_turnover == 'yes'
+
+      planned_processing_path
+    end
+
+    def next_step_for_row_to_ni
+      return customs_value_path if user_session.annual_turnover == 'yes'
 
       planned_processing_path
     end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -181,7 +181,7 @@ class UserSession
       no_zero_mfn_duty? &&
       trader_scheme? &&
       final_use_in_ni? &&
-      non_commercial_purposes?
+      small_turnover_or_non_commercial_purposes?
   end
 
   def import_into_gb?
@@ -224,8 +224,8 @@ class UserSession
     planned_processing == 'commercial_purposes'
   end
 
-  def non_commercial_purposes?
-    !commercial_purposes?
+  def small_turnover_or_non_commercial_purposes?
+    small_turnover? || !commercial_purposes?
   end
 
   def no_trade_defence?

--- a/spec/factories/user_session.rb
+++ b/spec/factories/user_session.rb
@@ -82,7 +82,7 @@ FactoryBot.define do
     zero_mfn_duty { false }
     trader_scheme { 'yes' }
     final_use { 'yes' }
-    planned_processing { 'commercial_processing' }
+    planned_processing { 'commercial_processing' } # Either this needs to be true or annual_turnover is < 500k
   end
 
   trait :with_vat do
@@ -117,6 +117,12 @@ FactoryBot.define do
   trait :with_gb_to_ni_route do
     import_destination { 'XI' }
     country_of_origin { 'GB' }
+  end
+
+  trait :with_row_to_ni_route do
+    import_destination { 'XI' }
+    country_of_origin { 'OTHER' }
+    other_country_of_origin { 'AR' }
   end
 
   trait :with_document_codes do

--- a/spec/models/steps/annual_turnover_spec.rb
+++ b/spec/models/steps/annual_turnover_spec.rb
@@ -53,14 +53,26 @@ RSpec.describe Steps::AnnualTurnover, :step, :user_session do
   end
 
   describe '#next_step_path' do
-    context 'when annual_turnover is less than 500k' do
-      let(:user_session) { build(:user_session, :with_small_turnover) }
+    context 'when annual_turnover is less than 500k and on the gb to ni route' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_small_turnover) }
 
       it { expect(step.next_step_path).to eq(duty_path) }
     end
 
-    context 'when annual_turnover is more than 500k' do
-      let(:user_session) { build(:user_session, :with_large_turnover) }
+    context 'when annual_turnover is more than 500k and on the gb to ni route' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_large_turnover) }
+
+      it { expect(step.next_step_path).to eq(planned_processing_path) }
+    end
+
+    context 'when annual_turnover is less than 500k and on the row to ni route' do
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_small_turnover) }
+
+      it { expect(step.next_step_path).to eq(customs_value_path) }
+    end
+
+    context 'when annual_turnover is more than 500k and on the row to ni route' do
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_large_turnover) }
 
       it { expect(step.next_step_path).to eq(planned_processing_path) }
     end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -299,8 +299,14 @@ RSpec.describe UserSession do
   end
 
   describe '#deltas_applicable?' do
-    context 'when on a deltas applicable route' do
-      subject(:user_session) { build(:user_session, :deltas_applicable) }
+    context 'when on a deltas applicable route with unnacceptable commercial purposes and a small turnover' do
+      subject(:user_session) { build(:user_session, :deltas_applicable, :with_small_turnover, planned_processing: 'commercial_purposes') }
+
+      it { is_expected.to be_deltas_applicable }
+    end
+
+    context 'when on a deltas applicable route with acceptable commercial processing and a high turnover' do
+      subject(:user_session) { build(:user_session, :deltas_applicable, :with_large_turnover, planned_processing: 'without_any_processing') }
 
       it { is_expected.to be_deltas_applicable }
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1002

### What?

I have added/removed/altered:

- [x] Extend deltas applicable logic to short circuit on small turnover
- [x] Make ROW to NI route lead to delta duty calculations when there is a small turnover (e.g. go straight to customs value)

### Why?

I am doing this because:

- The delta logic changed when we separated the two questions
- The current routing is just wrong for the ROW to NI route
