### PR TITLE
Use newly created show action to more quickly return geographical areas

### DIFF
--- a/app/controllers/steps/base_controller.rb
+++ b/app/controllers/steps/base_controller.rb
@@ -17,9 +17,9 @@ module Steps
                   :user_session
 
     def country_of_origin_description
-      Api::GeographicalArea.find(
-        country_of_origin_code,
+      Api::GeographicalArea.build(
         user_session.import_destination.downcase.to_sym,
+        country_of_origin_code.upcase,
       ).description
     end
 

--- a/app/decorators/confirmation_decorator.rb
+++ b/app/decorators/confirmation_decorator.rb
@@ -92,7 +92,7 @@ class ConfirmationDecorator < SimpleDelegator
 
     value = user_session.other_country_of_origin if value == 'OTHER'
 
-    Api::GeographicalArea.find(value, user_session.import_destination.downcase.to_sym).description
+    Api::GeographicalArea.build(user_session.import_destination.downcase.to_sym, value.upcase).description
   end
 
   def annual_turnover(value)

--- a/app/models/api/geographical_area.rb
+++ b/app/models/api/geographical_area.rb
@@ -27,22 +27,18 @@ module Api
       countries
     end
 
-    def self.non_eu_countries(service = :xi)
-      eu_ids = european_union_members(service).map(&:geographical_area_id).concat(UK)
-      build_collection(service, 'Country')
+    def self.non_eu_countries
+      eu_ids = european_union_members.map(&:geographical_area_id).concat(UK)
+      build_collection(:xi, 'Country')
         .reject { |country| eu_ids.include?(country.geographical_area_id) }
     end
 
-    def self.european_union_members(service = :xi)
-      build_collection(service).find(&:european_union?).children_geographical_areas
+    def self.european_union_members
+      build(:xi, EU).children_geographical_areas
     end
 
     def self.eu_member?(geographical_area_id)
       european_union_members.map(&:geographical_area_id).include?(geographical_area_id)
-    end
-
-    def self.find(id, service = :uk)
-      build_collection(service).find { |geographical_area| geographical_area.id == id }
     end
 
     def self.northern_ireland

--- a/app/models/steps/country_of_origin.rb
+++ b/app/models/steps/country_of_origin.rb
@@ -37,7 +37,7 @@ module Steps
     end
 
     def self.options_for(service, include_eu_members: true)
-      return Api::GeographicalArea.non_eu_countries(service.to_sym) unless include_eu_members
+      return Api::GeographicalArea.non_eu_countries unless include_eu_members
 
       Api::GeographicalArea.list_countries(service.to_sym)
     end

--- a/spec/fixtures/xi/geographical_areas/1013.json
+++ b/spec/fixtures/xi/geographical_areas/1013.json
@@ -1,0 +1,260 @@
+{
+  "meta": null,
+  "children_geographical_areas": [
+    {
+      "id": "AT",
+      "description": "Austria",
+      "geographical_area_id": "AT",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "BE",
+      "description": "Belgium",
+      "geographical_area_id": "BE",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "BG",
+      "description": "Bulgaria",
+      "geographical_area_id": "BG",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "CY",
+      "description": "Cyprus",
+      "geographical_area_id": "CY",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "CZ",
+      "description": "Czechia",
+      "geographical_area_id": "CZ",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "DE",
+      "description": "Germany",
+      "geographical_area_id": "DE",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "DK",
+      "description": "Denmark",
+      "geographical_area_id": "DK",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "EE",
+      "description": "Estonia",
+      "geographical_area_id": "EE",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "ES",
+      "description": "Spain",
+      "geographical_area_id": "ES",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "EU",
+      "description": "European Union",
+      "geographical_area_id": "EU",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "FI",
+      "description": "Finland",
+      "geographical_area_id": "FI",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "FR",
+      "description": "France",
+      "geographical_area_id": "FR",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "GR",
+      "description": "Greece",
+      "geographical_area_id": "GR",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "HR",
+      "description": "Croatia",
+      "geographical_area_id": "HR",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "HU",
+      "description": "Hungary",
+      "geographical_area_id": "HU",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "IE",
+      "description": "Ireland",
+      "geographical_area_id": "IE",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "IT",
+      "description": "Italy",
+      "geographical_area_id": "IT",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "LT",
+      "description": "Lithuania",
+      "geographical_area_id": "LT",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "LU",
+      "description": "Luxembourg",
+      "geographical_area_id": "LU",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "LV",
+      "description": "Latvia",
+      "geographical_area_id": "LV",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "MT",
+      "description": "Malta",
+      "geographical_area_id": "MT",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "NL",
+      "description": "Netherlands",
+      "geographical_area_id": "NL",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "PL",
+      "description": "Poland",
+      "geographical_area_id": "PL",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "PT",
+      "description": "Portugal",
+      "geographical_area_id": "PT",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "RO",
+      "description": "Romania",
+      "geographical_area_id": "RO",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "SE",
+      "description": "Sweden",
+      "geographical_area_id": "SE",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "SI",
+      "description": "Slovenia",
+      "geographical_area_id": "SI",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    },
+    {
+      "id": "SK",
+      "description": "Slovakia",
+      "geographical_area_id": "SK",
+      "children_geographical_areas": [
+
+      ],
+      "meta": null
+    }
+  ],
+  "id": "1013",
+  "geographical_area_id": "1013",
+  "description": "European Union"
+}

--- a/spec/fixtures/xi/geographical_areas/GB.json
+++ b/spec/fixtures/xi/geographical_areas/GB.json
@@ -1,0 +1,9 @@
+{
+  "meta": null,
+  "children_geographical_areas": [
+
+  ],
+  "id": "GB",
+  "geographical_area_id": "GB",
+  "description": "United Kingdom"
+}

--- a/spec/models/api/geographical_area_spec.rb
+++ b/spec/models/api/geographical_area_spec.rb
@@ -104,12 +104,4 @@ RSpec.describe Api::GeographicalArea do
       expect(members).not_to include('GB')
     end
   end
-
-  describe '.find' do
-    it 'returns the country found by id' do
-      country = described_class.find(id)
-
-      expect(country.description).to eq('Nicaragua')
-    end
-  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-873

### What?

I have added/removed/altered:

- [x] Use the new show endpoint when fetching specific geographical areas
- [x] Removes show simulating find method

See: https://github.com/trade-tariff/trade-tariff-backend/pull/276

### Why?

I am doing this because:

- This will make the fetching specific geographical areas significantly faster
