### PR TITLE
Adds resolved_measure_components as measure relationship

### DIFF
--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -2,6 +2,7 @@ module Api
   class Measure < Api::Base
     has_many :measure_conditions, MeasureCondition
     has_many :measure_components, MeasureComponent
+    has_many :resolved_measure_components, MeasureComponent
 
     has_one :measure_type, MeasureType
     has_one :geographical_area, GeographicalArea

--- a/spec/factories/api/measure.rb
+++ b/spec/factories/api/measure.rb
@@ -26,8 +26,9 @@ FactoryBot.define do
     additional_code      {}
     suspension_legal_act {}
 
-    measure_components { [] }
     measure_conditions { [] }
+    measure_components { [] }
+    resolved_measure_components { [] }
 
     initialize_with do
       meta = { 'meta' => { 'duty_calculator' => { 'source' => source } } }

--- a/spec/models/api/measure_spec.rb
+++ b/spec/models/api/measure_spec.rb
@@ -1,6 +1,14 @@
 RSpec.describe Api::Measure, :user_session do
-  subject(:measure) { build(:measure, :third_country_tariff, source: 'xi', measure_components: measure_components) }
+  subject(:measure) { build(:measure) }
 
+  let(:user_session) do
+    build(
+      :user_session,
+      :with_commodity_information,
+      :with_document_codes,
+      :with_excise_additional_codes,
+    )
+  end
   let(:measure_components) do
     [
       {
@@ -16,14 +24,16 @@ RSpec.describe Api::Measure, :user_session do
     ]
   end
 
-  let(:user_session) do
-    build(
-      :user_session,
-      :with_commodity_information,
-      :with_document_codes,
-      :with_excise_additional_codes,
-    )
-  end
+  it_behaves_like 'a has_many relationship', :measure_conditions
+  it_behaves_like 'a has_many relationship', :measure_components
+  it_behaves_like 'a has_many relationship', :resolved_measure_components
+
+  it_behaves_like 'a has_one relationship', :measure_type
+  it_behaves_like 'a has_one relationship', :geographical_area
+  it_behaves_like 'a has_one relationship', :duty_expression
+  it_behaves_like 'a has_one relationship', :order_number
+  it_behaves_like 'a has_one relationship', :additional_code
+  it_behaves_like 'a has_one relationship', :suspension_legal_act
 
   it_behaves_like 'a resource that has attributes', measure_conditions: [],
                                                     measure_components: [],
@@ -43,6 +53,8 @@ RSpec.describe Api::Measure, :user_session do
                                                     resolved_duty_expression: ''
 
   describe '#evaluator' do
+    subject(:measure) { build(:measure, :third_country_tariff, source: 'xi', measure_components: measure_components) }
+
     context 'when an ad_valorem measure' do
       let(:measure_components) { [attributes_for(:measure_component, :ad_valorem)] }
 

--- a/spec/support/shared_examples/a_has_many_relationship.rb
+++ b/spec/support/shared_examples/a_has_many_relationship.rb
@@ -1,0 +1,4 @@
+RSpec.shared_examples 'a has_many relationship' do |relation|
+  it { is_expected.to respond_to(relation) }
+  it { is_expected.to have_attributes(relation => []) }
+end

--- a/spec/support/shared_examples/a_has_one_relationship.rb
+++ b/spec/support/shared_examples/a_has_one_relationship.rb
@@ -1,0 +1,3 @@
+RSpec.shared_examples 'a has_one relationship' do |relation|
+  it { is_expected.to respond_to(relation) }
+end


### PR DESCRIPTION
### Jira link

HOTT-1009

### What?

I have added/removed/altered:

- [x] Added surfaced resolved measure components to the measure model

### Why?

I am doing this because:

- This is required to work with resolved components as part of duty calculations for meursing measures
