### PR TITLE
HOTT-1009: Adds step to take input for the meursing additional code

### DIFF
--- a/app/controllers/steps/meursing_additional_codes_controller.rb
+++ b/app/controllers/steps/meursing_additional_codes_controller.rb
@@ -1,0 +1,23 @@
+module Steps
+  class MeursingAdditionalCodesController < BaseController
+    def show
+      @step = Steps::MeursingAdditionalCode.new(meursing_additional_code_params)
+    end
+
+    def create
+      @step = Steps::MeursingAdditionalCode.new(meursing_additional_code_params)
+
+      validate(@step)
+    end
+
+    private
+
+    def meursing_additional_code_params
+      if params[:steps_meursing_additional_code].present?
+        params.require(:steps_meursing_additional_code).permit(:meursing_additional_code)
+      else
+        {}
+      end
+    end
+  end
+end

--- a/app/controllers/steps/meursing_additional_codes_controller.rb
+++ b/app/controllers/steps/meursing_additional_codes_controller.rb
@@ -13,11 +13,7 @@ module Steps
     private
 
     def meursing_additional_code_params
-      if params[:steps_meursing_additional_code].present?
-        params.require(:steps_meursing_additional_code).permit(:meursing_additional_code)
-      else
-        {}
-      end
+      params.fetch(:steps_meursing_additional_code, {}).permit(:meursing_additional_code)
     end
   end
 end

--- a/app/helpers/commodity_helper.rb
+++ b/app/helpers/commodity_helper.rb
@@ -22,6 +22,10 @@ module CommodityHelper
     commodity_context_service.call(commodity_source, commodity_code, query)
   end
 
+  def applicable_meursing_codes?
+    xi_filtered_commodity.meursing_code?
+  end
+
   def applicable_additional_codes
     @applicable_additional_codes ||=
       {}.tap do |additional_codes|

--- a/app/helpers/meursing_additional_code_helper.rb
+++ b/app/helpers/meursing_additional_code_helper.rb
@@ -1,0 +1,26 @@
+module MeursingAdditionalCodeHelper
+  def meursing_lookup_hint_text
+    hint_text = t(
+      'meursing_additional_code.hint_text',
+      link: meursing_lookup_link,
+    )
+
+    sanitize(
+      hint_text,
+      tags: %w[p a],
+      attributes: %w[class target rel href],
+    )
+  end
+
+  private
+
+  def meursing_lookup_link
+    link_to(
+      t('meursing_additional_code.link_text'),
+      meursing_lookup_url,
+      class: 'govuk-link',
+      target: '_blank',
+      rel: 'noopener norefferer',
+    )
+  end
+end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -39,12 +39,22 @@ module ServiceHelper
     @trade_tariff_frontend_url ||= Rails.configuration.trade_tariff_frontend_url
   end
 
+  def meursing_lookup_url
+    xi_only_service_url_for('/meursing_lookup/steps/start')
+  end
+
   private
 
-  def service_url_for(relative_path)
+  def service_url_for(path)
     return '#' if trade_tariff_frontend_url.blank?
 
-    File.join(trade_tariff_frontend_url, referred_service_url, relative_path)
+    File.join(trade_tariff_frontend_url, referred_service_url, path)
+  end
+
+  def xi_only_service_url_for(path)
+    return '#' if trade_tariff_frontend_url.blank?
+
+    File.join(trade_tariff_frontend_url, 'xi', path)
   end
 
   def referred_service_url

--- a/app/models/api/commodity.rb
+++ b/app/models/api/commodity.rb
@@ -29,6 +29,8 @@ module Api
                :heading,
                :ancestors
 
+    alias_method :meursing_code?, :meursing_code
+
     def description
       super.html_safe
     end

--- a/app/models/steps/additional_code.rb
+++ b/app/models/steps/additional_code.rb
@@ -1,7 +1,5 @@
 module Steps
   class AdditionalCode < Steps::Base
-    include CommodityHelper
-
     STEPS_TO_REMOVE_FROM_SESSION = %w[document_code excise].freeze
 
     attribute :measure_type_id, :string

--- a/app/models/steps/annual_turnover.rb
+++ b/app/models/steps/annual_turnover.rb
@@ -33,6 +33,7 @@ module Steps
     end
 
     def next_step_for_row_to_ni
+      return meursing_additional_codes_path if user_session.annual_turnover == 'yes' && applicable_meursing_codes?
       return customs_value_path if user_session.annual_turnover == 'yes'
 
       planned_processing_path

--- a/app/models/steps/base.rb
+++ b/app/models/steps/base.rb
@@ -3,6 +3,7 @@ module Steps
     include ActiveModel::Model
     include ActiveModel::Attributes
     include Rails.application.routes.url_helpers
+    include CommodityHelper
 
     STEPS_TO_REMOVE_FROM_SESSION = [].freeze
 

--- a/app/models/steps/certificate_of_origin.rb
+++ b/app/models/steps/certificate_of_origin.rb
@@ -21,9 +21,8 @@ module Steps
 
     def next_step_path
       return duty_path if user_session.certificate_of_origin == 'yes'
-      return meursing_additional_codes_path if applicable_meursing_codes?
 
-      customs_value_path
+      interstitial_path
     end
 
     def previous_step_path

--- a/app/models/steps/certificate_of_origin.rb
+++ b/app/models/steps/certificate_of_origin.rb
@@ -21,6 +21,7 @@ module Steps
 
     def next_step_path
       return duty_path if user_session.certificate_of_origin == 'yes'
+      return meursing_additional_codes_path if applicable_meursing_codes?
 
       customs_value_path
     end

--- a/app/models/steps/confirmation.rb
+++ b/app/models/steps/confirmation.rb
@@ -1,7 +1,5 @@
 module Steps
   class Confirmation < Steps::Base
-    include CommodityHelper
-
     def next_step_path
       duty_path
     end

--- a/app/models/steps/document_code.rb
+++ b/app/models/steps/document_code.rb
@@ -1,7 +1,5 @@
 module Steps
   class DocumentCode < Steps::Base
-    include CommodityHelper
-
     attribute :measure_type_id, :string
     attribute :document_code_uk, :string
     attribute :document_code_xi, :string

--- a/app/models/steps/excise.rb
+++ b/app/models/steps/excise.rb
@@ -2,8 +2,6 @@ module Steps
   class Excise < Steps::Base
     DISABLED_ADDITIONAL_CODES = %w[440 441].freeze
 
-    include CommodityHelper
-
     attribute :measure_type_id, :string
     attribute :additional_code, :string
 

--- a/app/models/steps/interstitial.rb
+++ b/app/models/steps/interstitial.rb
@@ -1,19 +1,29 @@
 module Steps
   class Interstitial < Steps::Base
+    STEPS_TO_REMOVE_FROM_SESSION = %w[meursing_additional_code].freeze
+
     def next_step_path
+      return meursing_additional_codes_path if user_session.meursing_route? && applicable_meursing_codes?
+
       customs_value_path
     end
 
     def previous_step_path
-      return country_of_origin_path if user_session.gb_to_ni_route?
+      return previous_step_for_gb_to_ni if user_session.gb_to_ni_route?
 
       previous_step_for_row_to_ni
     end
 
     private
 
+    def previous_step_for_gb_to_ni
+      return certificate_of_origin_path if user_session.certificate_of_origin == 'no'
+
+      country_of_origin_path
+    end
+
     def previous_step_for_row_to_ni
-      return country_of_origin_path if user_session.trade_defence
+      return country_of_origin_path if user_session.trade_defence?
       return trader_scheme_path if user_session.trader_scheme == 'no'
       return final_use_path if user_session.final_use == 'no'
       return planned_processing_path if user_session.unacceptable_processing?

--- a/app/models/steps/meursing_additional_code.rb
+++ b/app/models/steps/meursing_additional_code.rb
@@ -17,6 +17,7 @@ module Steps
     end
 
     def previous_step_path
+      return annual_turnover_path if user_session.annual_turnover == 'yes'
       return planned_processing_path if user_session.planned_processing.present? && user_session.acceptable_processing?
 
       interstitial_path

--- a/app/models/steps/meursing_additional_code.rb
+++ b/app/models/steps/meursing_additional_code.rb
@@ -1,0 +1,25 @@
+module Steps
+  class MeursingAdditionalCode < Steps::Base
+    attribute :meursing_additional_code, :string
+
+    validates :meursing_additional_code, format: { with: /\A\d{3}\z/ }
+
+    def meursing_additional_code
+      super || user_session.meursing_additional_code
+    end
+
+    def save
+      user_session.meursing_additional_code = meursing_additional_code
+    end
+
+    def next_step_path
+      customs_value_path
+    end
+
+    def previous_step_path
+      return planned_processing_path if user_session.planned_processing.present? && user_session.acceptable_processing?
+
+      interstitial_path
+    end
+  end
+end

--- a/app/models/steps/planned_processing.rb
+++ b/app/models/steps/planned_processing.rb
@@ -38,6 +38,7 @@ module Steps
 
     def next_step_for_row_to_ni
       return interstitial_path if user_session.unacceptable_processing?
+      return meursing_additional_codes_path if user_session.acceptable_processing? && applicable_meursing_codes?
 
       customs_value_path
     end

--- a/app/models/steps/prefill.rb
+++ b/app/models/steps/prefill.rb
@@ -1,7 +1,5 @@
 module Steps
   class Prefill < Steps::Base
-    include CommodityHelper
-
     def next_step_path
       return duty_path if user_session.ni_to_gb_route? || user_session.eu_to_ni_route?
 

--- a/app/models/steps/vat.rb
+++ b/app/models/steps/vat.rb
@@ -1,7 +1,5 @@
 module Steps
   class Vat < Steps::Base
-    include CommodityHelper
-
     attribute :vat, :string
 
     validates :vat, presence: true

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -14,7 +14,8 @@ class UserSession
                     :planned_processing,
                     :customs_value,
                     :measure_amount,
-                    :vat
+                    :vat,
+                    :meursing_additional_code
 
   non_answer_attributes :commodity_code,
                         :commodity_source,
@@ -191,6 +192,10 @@ class UserSession
       trader_scheme? &&
       final_use_in_ni? &&
       small_turnover_or_non_commercial_purposes?
+  end
+
+  def meursing_route?
+    gb_to_ni_route? || row_to_ni_route?
   end
 
   def import_into_gb?

--- a/app/views/steps/interstitial/shared/_context.html.erb
+++ b/app/views/steps/interstitial/shared/_context.html.erb
@@ -1,3 +1,2 @@
 <h1 class="govuk-heading-xl"><%= heading %></h1>
 <p class="govuk-body"><%= body %></p>
-<p class="govuk-body">Click on the 'Continue' button to enter the customs value of your import, to help to calculate the applicable import duties.</p>

--- a/app/views/steps/interstitial/show.html.erb
+++ b/app/views/steps/interstitial/show.html.erb
@@ -3,7 +3,11 @@
 <span class="govuk-caption-xl">Calculate import duties</span>
 
 <% if user_session.gb_to_ni_route? %>
-  <%= render partial: 'steps/interstitial/shared/context', locals: { heading: t('interstitial.gb_to_ni.heading'), body: t('interstitial.gb_to_ni.body') } %>
+  <% if user_session.trade_defence? %>
+  <%= render partial: 'steps/interstitial/shared/context', locals: { heading: t('interstitial.gb_to_ni.trade_defence.heading'), body: t('interstitial.gb_to_ni.trade_defence.body') } %>
+  <% else %>
+  <%= render partial: 'steps/interstitial/shared/context', locals: { heading: t('interstitial.gb_to_ni.certificate_of_origin.heading'), body: t('interstitial.gb_to_ni.certificate_of_origin.body') } %>
+  <% end %>
 <% elsif user_session.row_to_ni_route? %>
   <% if user_session.trade_defence %>
     <%= render partial: 'steps/interstitial/shared/context', locals: { heading: t('interstitial.row_to_ni.trade_defence.heading'), body: t('interstitial.row_to_ni.trade_defence.body') } %>

--- a/app/views/steps/meursing_additional_codes/show.html.erb
+++ b/app/views/steps/meursing_additional_codes/show.html.erb
@@ -1,0 +1,26 @@
+<%= render 'steps/shared/back_link' %>
+
+<span class="govuk-caption-xl">Calculate import duties</span>
+
+<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: meursing_additional_codes_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-7">
+      Enter a 'Meursing code' to work out applicable duties
+    </h1>
+  </legend>
+
+  <p class="govuk-body govuk-!-margin-bottom-5">
+    This commodity code features duties which may be dependent on the sugar, flour, milk fat and milk protein content. To fully define the applicable duties, you need to specify the additional code that defines the content of these ingredients.
+  </p>
+
+  <%= f.govuk_text_field :meursing_additional_code,
+    width: 'one-quarter',
+    label: { text: 'Enter the 3-digit additional code', class: 'govuk-label govuk-label--s' },
+    hint: { text:  meursing_lookup_hint_text }, prefix_text: '7'  %>
+
+  <%= f.govuk_submit %>
+<% end %>
+
+<%= render 'shared/commodity_details' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,8 +104,13 @@ en:
 
   interstitial:
     gb_to_ni:
-      heading: Duties apply to this import
-      body: As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk' under all circumstances.
+      trade_defence:
+        heading: EU duties apply to this import
+        body: As this commodity attracts a trade defence measure, imports of this commodity are treated as 'at risk' under all circumstances.
+      certificate_of_origin:
+        heading: EU duties apply to this import
+        body: As you have no valid proof of origin, imports of this commodity are subject to EU import duties.
+
     row_to_ni:
       trade_defence:
         heading: EU duties apply to this import
@@ -223,7 +228,7 @@ en:
         steps/meursing_additional_code:
           attributes:
             meursing_additional_code:
-              invalid: Specify a valid 3 digit meursing additional code
+              invalid: Specify a valid 3-digit Meursing additional code
         steps/customs_value:
           attributes:
             monetary_value:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
     final_use: Are your goods for final use in the UK - Online Tariff Duty calculator
     import_date: When will the good be imported - Online Tariff Duty calculator
     confirmation: Check your answers - Online Tariff Duty calculator
+    meursing_additional_code: Enter a 'Meursing Code' for this commodity - Online Tariff Duty calculator
     customs_value: What is the customs value of this import - Online Tariff Duty calculator
     document_code: Do you have any of the following documents - Online Tariff Duty Calculator
     trader_scheme: Are you authorised under the UK Trader Scheme - Online Tariff Duty calculator
@@ -187,6 +188,11 @@ en:
     commercial_purposes:
       label_text_html: >
         The goods will be processed for <strong>commercial purposes other than those listed above</strong>
+  meursing_additional_code:
+    link_text: Meursing code finder (opens in new tab)
+    hint_text: >
+      If you know the additional code for your commodity, enter it in the box below. If you do not know the code, then use the %{link} to find the additional code.
+
   activemodel:
     errors:
       models:
@@ -214,6 +220,10 @@ en:
           attributes:
             certificate_of_origin:
               blank: Select one of the two options
+        steps/meursing_additional_code:
+          attributes:
+            meursing_additional_code:
+              invalid: Specify a valid 3 digit meursing additional code
         steps/customs_value:
           attributes:
             monetary_value:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,9 @@ Rails.application.routes.draw do
     get 'additional-codes/:measure_type_id', to: 'steps/additional_codes#show', as: 'additional_codes'
     post 'additional-codes/:measure_type_id', to: 'steps/additional_codes#create'
 
+    get 'meursing-additional-codes', to: 'steps/meursing_additional_codes#show', as: 'meursing_additional_codes'
+    post 'meursing-additional-codes', to: 'steps/meursing_additional_codes#create'
+
     get 'excise/:measure_type_id', to: 'steps/excise#show', as: 'excise'
     post 'excise/:measure_type_id', to: 'steps/excise#create'
 

--- a/config/webpack/base.js
+++ b/config/webpack/base.js
@@ -1,3 +1,0 @@
-const { webpackConfig } = require('@rails/webpacker')
-
-module.exports = webpackConfig

--- a/config/webpack/base.js
+++ b/config/webpack/base.js
@@ -1,0 +1,3 @@
+const { webpackConfig } = require('@rails/webpacker')
+
+module.exports = webpackConfig

--- a/spec/controllers/steps/meursing_additional_code_controller_spec.rb
+++ b/spec/controllers/steps/meursing_additional_code_controller_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe Steps::MeursingAdditionalCodesController, :user_session do
+  let(:user_session) { build(:user_session, :with_commodity_information) }
+
+  describe 'GET #show' do
+    subject(:response) { get :show }
+
+    it 'assigns the correct step' do
+      response
+      expect(assigns[:step]).to be_a(Steps::MeursingAdditionalCode)
+    end
+
+    it { expect(response).to have_http_status(:ok) }
+    it { expect(response).to render_template('meursing_additional_codes/show') }
+  end
+
+  describe 'POST #create' do
+    subject(:response) { post :create, params: answers }
+
+    let(:answers) { { steps_meursing_additional_code: { meursing_additional_code: meursing_additional_code } } }
+
+    context 'when the step answers are valid' do
+      let(:meursing_additional_code) { '000' }
+
+      it 'assigns the correct step' do
+        response
+        expect(assigns[:step]).to be_a(Steps::MeursingAdditionalCode)
+      end
+
+      it { expect { response }.to change(user_session, :meursing_additional_code).from(nil).to('000') }
+      it { expect(response).to redirect_to(customs_value_path) }
+    end
+
+    context 'when the step answers are invalid' do
+      let(:meursing_additional_code) { '' }
+
+      it 'assigns the correct step' do
+        response
+        expect(assigns[:step]).to be_a(Steps::MeursingAdditionalCode)
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to render_template('meursing_additional_codes/show') }
+      it { expect { response }.not_to change(user_session, :meursing_additional_code).from(nil) }
+    end
+  end
+end

--- a/spec/factories/steps/meursing_additional_code.rb
+++ b/spec/factories/steps/meursing_additional_code.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :meursing_additional_code, class: 'Steps::MeursingAdditionalCode', parent: :step do
+    transient do
+      possible_attributes { { meursing_additional_code: 'meursing_additional_code' } }
+    end
+
+    meursing_additional_code { nil }
+  end
+end

--- a/spec/factories/user_session.rb
+++ b/spec/factories/user_session.rb
@@ -29,6 +29,18 @@ FactoryBot.define do
     referred_service { 'uk' }
   end
 
+  trait :with_meursing_commodity do
+    commodity_code { '0103921100' }
+    commodity_source { 'xi' }
+    referred_service { 'xi' }
+  end
+
+  trait :with_non_meursing_commodity do
+    commodity_code { '0702000007' }
+    commodity_source { 'xi' }
+    referred_service { 'xi' }
+  end
+
   trait :with_import_date do
     import_date { '2025-01-01' }
   end
@@ -114,6 +126,11 @@ FactoryBot.define do
     end
   end
 
+  trait :with_eu_to_ni_route do
+    import_destination { 'XI' }
+    country_of_origin { 'PL' }
+  end
+
   trait :with_gb_to_ni_route do
     import_destination { 'XI' }
     country_of_origin { 'GB' }
@@ -128,6 +145,16 @@ FactoryBot.define do
   trait :with_row_to_gb_route do
     import_destination { 'UK' }
     country_of_origin { 'AR' }
+  end
+
+  trait :with_eu_to_gb_route do
+    import_destination { 'UK' }
+    country_of_origin { 'PL' }
+  end
+
+  trait :with_ni_to_gb_route do
+    import_destination { 'UK' }
+    country_of_origin { 'XI' }
   end
 
   trait :with_document_codes do

--- a/spec/fixtures/xi/commodities/0103921100.json
+++ b/spec/fixtures/xi/commodities/0103921100.json
@@ -9527,7 +9527,7 @@
   "consigned": false,
   "consigned_from": null,
   "basic_duty_rate": "<span>35.10</span> EUR / <abbr title='Hectokilogram'>100 kg</abbr>",
-  "meursing_code": false,
+  "meursing_code": true,
   "declarable": true,
   "footnotes": [
     {

--- a/spec/fixtures/xi/commodities/0702000007.json
+++ b/spec/fixtures/xi/commodities/0702000007.json
@@ -1,0 +1,1 @@
+../../uk/commodities/0702000007.json

--- a/spec/helpers/commodity_helper_spec.rb
+++ b/spec/helpers/commodity_helper_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe CommodityHelper, :user_session do
     end
   end
 
+  describe '#applicable_meursing_codes?' do
+    it { expect(helper.applicable_meursing_codes?).to eq(true) }
+
+    it 'passes xi to the Commodity builder' do
+      helper.applicable_meursing_codes?
+
+      expect(Api::Commodity).to have_received(:build).with('xi', anything, anything)
+    end
+  end
+
   describe '#applicable_vat_options' do
     let(:expected_options) do
       {

--- a/spec/helpers/meursing_additional_code_helper_spec.rb
+++ b/spec/helpers/meursing_additional_code_helper_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe MeursingAdditionalCodeHelper do
+  describe '#meursing_lookup_hint_text' do
+    subject(:meursing_lookup_hint_text) { helper.meursing_lookup_hint_text }
+
+    it { is_expected.to be_html_safe }
+
+    it 'returns the properly sanitized hint' do
+      expected_hint = 'If you know the additional code for your commodity, enter it in the box below. If you do not know the code, then use the <a class="govuk-link" target="_blank" rel="noopener norefferer" href="https://dev.trade-tariff.service.gov.uk/xi/meursing_lookup/steps/start">Meursing code finder (opens in new tab)</a> to find the additional code.'
+
+      expect(meursing_lookup_hint_text).to include(expected_hint)
+    end
+  end
+end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -186,6 +186,8 @@ RSpec.describe ServiceHelper, :user_session do
 
   describe '#feedback_url' do
     context 'when TRADE_TARIFF_FRONTEND_URL is set' do
+      let(:frontend_url) { 'https://dev.trade-tariff.service.gov.uk' }
+
       it 'returns the dev trade tariff tools url' do
         expect(helper.feedback_url).to eq(
           'https://dev.trade-tariff.service.gov.uk/feedback',
@@ -196,9 +198,25 @@ RSpec.describe ServiceHelper, :user_session do
     context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
       let(:frontend_url) { nil }
 
-      it 'returns the dev trade tariff tools url' do
-        expect(helper.feedback_url).to eq('#')
+      it { expect(helper.feedback_url).to eq('#') }
+    end
+  end
+
+  describe '#meursing_lookup_url' do
+    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
+      let(:frontend_url) { 'https://dev.trade-tariff.service.gov.uk' }
+
+      it 'returns the dev trade tariff meursing lookup url' do
+        expected_url = 'https://dev.trade-tariff.service.gov.uk/xi/meursing_lookup/steps/start'
+
+        expect(helper.meursing_lookup_url).to eq(expected_url)
       end
+    end
+
+    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
+      let(:frontend_url) { nil }
+
+      it { expect(helper.meursing_lookup_url).to eq('#') }
     end
   end
 end

--- a/spec/models/api/commodity_spec.rb
+++ b/spec/models/api/commodity_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Api::Commodity, :user_session, type: :model do
                   import_measures: [],
                   export_measures: []
 
+  describe '#meursing_code?' do
+    subject(:commodity) { described_class.new(meursing_code: false) }
+
+    it { expect(commodity.meursing_code?).to eq(false) }
+  end
+
   describe '#description' do
     it 'returns the expected description' do
       expect(commodity.description).to eq('Cherry Tomatoes')

--- a/spec/models/steps/additional_code_spec.rb
+++ b/spec/models/steps/additional_code_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
       ]
     end
 
-    it 'returns the correct additonal code options for the given measure' do
+    it 'returns the correct additional code options for the given measure' do
       expect(step.options_for_select_for(source: 'uk')).to eq(expected_options)
     end
   end

--- a/spec/models/steps/annual_turnover_spec.rb
+++ b/spec/models/steps/annual_turnover_spec.rb
@@ -65,10 +65,16 @@ RSpec.describe Steps::AnnualTurnover, :step, :user_session do
       it { expect(step.next_step_path).to eq(planned_processing_path) }
     end
 
-    context 'when annual_turnover is less than 500k and on the row to ni route' do
-      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_small_turnover) }
+    context 'when annual_turnover is less than 500k and on the row to ni route with no meursing codes' do
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_small_turnover, :with_non_meursing_commodity) }
 
       it { expect(step.next_step_path).to eq(customs_value_path) }
+    end
+
+    context 'when annual_turnover is less than 500k and on the row to ni route with meursing codes' do
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_small_turnover, :with_meursing_commodity) }
+
+      it { expect(step.next_step_path).to eq(meursing_additional_codes_path) }
     end
 
     context 'when annual_turnover is more than 500k and on the row to ni route' do

--- a/spec/models/steps/certificate_of_origin_spec.rb
+++ b/spec/models/steps/certificate_of_origin_spec.rb
@@ -58,28 +58,22 @@ RSpec.describe Steps::CertificateOfOrigin, :step, :user_session do
   end
 
   describe '#next_step_path' do
-    context 'when there is a certificate of origin available' do
-      let(:session_attributes) { { 'certificate_of_origin' => 'yes' } }
+    context 'when there is a certificate of origin' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, certificate_of_origin: 'yes') }
 
-      it 'returns duty_path' do
-        expect(
-          step.next_step_path,
-        ).to eq(
-          duty_path,
-        )
-      end
+      it { expect(step.next_step_path).to eq(duty_path) }
     end
 
-    context 'when there is no certificate of origin available' do
-      let(:session_attributes) { { 'certificate_of_origin' => 'no' } }
+    context 'when there is no certificate of origin and no applicable meursing codes' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_non_meursing_commodity, certificate_of_origin: 'no') }
 
-      it 'returns customs_value_path' do
-        expect(
-          step.next_step_path,
-        ).to eq(
-          customs_value_path,
-        )
-      end
+      it { expect(step.next_step_path).to eq(customs_value_path) }
+    end
+
+    context 'when there is no certificate of origin and applicable meursing codes' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_meursing_commodity, certificate_of_origin: 'no') }
+
+      it { expect(step.next_step_path).to eq(meursing_additional_codes_path) }
     end
   end
 
@@ -87,13 +81,7 @@ RSpec.describe Steps::CertificateOfOrigin, :step, :user_session do
     context 'when final use answer is NO' do
       let(:session_attributes) { { 'final_use' => 'no' } }
 
-      it 'returns final_use_path' do
-        expect(
-          step.previous_step_path,
-        ).to eq(
-          final_use_path,
-        )
-      end
+      it { expect(step.previous_step_path).to eq(final_use_path) }
     end
 
     context 'when trader scheme answer is NO' do
@@ -101,13 +89,7 @@ RSpec.describe Steps::CertificateOfOrigin, :step, :user_session do
         { 'trader_scheme' => 'no' }
       end
 
-      it 'returns trader_scheme_path' do
-        expect(
-          step.previous_step_path,
-        ).to eq(
-          trader_scheme_path,
-        )
-      end
+      it { expect(step.previous_step_path).to eq(trader_scheme_path) }
     end
 
     context 'when planned processing answer is commercial_purposes' do
@@ -117,13 +99,7 @@ RSpec.describe Steps::CertificateOfOrigin, :step, :user_session do
         }
       end
 
-      it 'returns planned_processing_path' do
-        expect(
-          step.previous_step_path,
-        ).to eq(
-          planned_processing_path,
-        )
-      end
+      it { expect(step.previous_step_path).to eq(planned_processing_path) }
     end
   end
 end

--- a/spec/models/steps/certificate_of_origin_spec.rb
+++ b/spec/models/steps/certificate_of_origin_spec.rb
@@ -64,16 +64,10 @@ RSpec.describe Steps::CertificateOfOrigin, :step, :user_session do
       it { expect(step.next_step_path).to eq(duty_path) }
     end
 
-    context 'when there is no certificate of origin and no applicable meursing codes' do
-      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_non_meursing_commodity, certificate_of_origin: 'no') }
+    context 'when there is no certificate of origin' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, certificate_of_origin: 'no') }
 
-      it { expect(step.next_step_path).to eq(customs_value_path) }
-    end
-
-    context 'when there is no certificate of origin and applicable meursing codes' do
-      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_meursing_commodity, certificate_of_origin: 'no') }
-
-      it { expect(step.next_step_path).to eq(meursing_additional_codes_path) }
+      it { expect(step.next_step_path).to eq(interstitial_path) }
     end
   end
 

--- a/spec/models/steps/customs_value_spec.rb
+++ b/spec/models/steps/customs_value_spec.rb
@@ -181,19 +181,25 @@ RSpec.describe Steps::CustomsValue, :step, :user_session do
 
   describe '#previous_step_path' do
     context 'when there is a trade defence and on the GB to NI route' do
-      let(:user_session) { build(:user_session, :with_gb_to_ni_route, trade_defence: true) }
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_non_meursing_commodity, trade_defence: true) }
 
       it { expect(step.previous_step_path).to eq(interstitial_path) }
     end
 
     context 'when there is no trade defence and on the GB to NI route' do
-      let(:user_session) { build(:user_session, :with_gb_to_ni_route, trade_defence: false) }
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_non_meursing_commodity, trade_defence: false) }
 
       it { expect(step.previous_step_path).to eq(certificate_of_origin_path) }
     end
 
+    context 'when there are applicable meursing codes on the GB to NI route' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_meursing_commodity) }
+
+      it { expect(step.previous_step_path).to eq(meursing_additional_codes_path) }
+    end
+
     context 'when on RoW to GB route' do
-      let(:user_session) { build(:user_session, :with_row_to_gb_route) }
+      let(:user_session) { build(:user_session, :with_row_to_gb_route, :with_non_meursing_commodity) }
 
       it { expect(step.previous_step_path).to eq(country_of_origin_path) }
     end
@@ -205,25 +211,31 @@ RSpec.describe Steps::CustomsValue, :step, :user_session do
     end
 
     context 'when the planned processing question has been answered and on the Row to NI route' do
-      let(:user_session) { build(:user_session, :with_row_to_ni_route, planned_processing: 'commercial_processing') }
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_non_meursing_commodity, planned_processing: 'commercial_processing') }
 
       it { expect(step.previous_step_path).to eq(planned_processing_path) }
     end
 
     context 'when the annual turnover question has been answered and on the Row to NI route' do
-      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_small_turnover) }
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_non_meursing_commodity, :with_small_turnover) }
 
       it { expect(step.previous_step_path).to eq(annual_turnover_path) }
     end
 
     context 'when the goods are not for final use and on the Row to NI route' do
-      let(:user_session) { build(:user_session, :with_row_to_ni_route, final_use: 'no') }
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_non_meursing_commodity, final_use: 'no') }
 
       it { expect(step.previous_step_path).to eq(final_use_path) }
     end
 
+    context 'when there are applicable meursing codes on the Row to NI route' do
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_meursing_commodity) }
+
+      it { expect(step.previous_step_path).to eq(meursing_additional_codes_path) }
+    end
+
     context 'when on the Row to NI route' do
-      let(:user_session) { build(:user_session, :with_row_to_ni_route) }
+      let(:user_session) { build(:user_session, :with_row_to_ni_route, :with_non_meursing_commodity) }
 
       it { expect(step.previous_step_path).to eq(trader_scheme_path) }
     end
@@ -259,7 +271,7 @@ RSpec.describe Steps::CustomsValue, :step, :user_session do
       allow(filtered_commodity).to receive(:applicable_document_codes).and_return(applicable_document_codes)
     end
 
-    context 'when there are applicable measures' do
+    context 'when there are applicable measure units' do
       it { expect(step.next_step_path).to eq(measure_amount_path) }
     end
 

--- a/spec/models/steps/interstitial_spec.rb
+++ b/spec/models/steps/interstitial_spec.rb
@@ -4,15 +4,37 @@ RSpec.describe Steps::Interstitial, :step, :user_session do
   let(:user_session) { build(:user_session) }
 
   describe 'STEPS_TO_REMOVE_FROM_SESSION' do
-    it { expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to be_empty }
+    it { expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(%w[meursing_additional_code]) }
   end
 
   describe '#next_step_path' do
-    it { expect(step.next_step_path).to eq(customs_value_path) }
+    context 'when on a meursing route with applicable meursing codes' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_meursing_commodity) }
+
+      it { expect(step.next_step_path).to eq(meursing_additional_codes_path) }
+    end
+
+    context 'when on a meursing route with no applicable meursing codes' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, :with_non_meursing_commodity) }
+
+      it { expect(step.next_step_path).to eq(customs_value_path) }
+    end
+
+    context 'when not on a meursing route' do
+      let(:user_session) { build(:user_session, :with_row_to_gb_route) }
+
+      it { expect(step.next_step_path).to eq(customs_value_path) }
+    end
   end
 
   describe '#previous_step_path' do
-    context 'when on GB to NI route' do
+    context 'when on GB to NI route with a negative certificate of origin answer' do
+      let(:user_session) { build(:user_session, :with_gb_to_ni_route, certificate_of_origin: 'no') }
+
+      it { expect(step.previous_step_path).to eq(certificate_of_origin_path) }
+    end
+
+    context 'when on GB to NI route with no certificate of origin answer' do
       let(:user_session) { build(:user_session, :with_gb_to_ni_route) }
 
       it { expect(step.previous_step_path).to eq(country_of_origin_path) }

--- a/spec/models/steps/meursing_additional_code_spec.rb
+++ b/spec/models/steps/meursing_additional_code_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Steps::MeursingAdditionalCode, :step, :user_session do
       it 'adds the correct validation error message' do
         step.valid?
 
-        expect(step.errors.messages[:meursing_additional_code]).to eq(['Specify a valid 3 digit meursing additional code'])
+        expect(step.errors.messages[:meursing_additional_code]).to eq(['Specify a valid 3-digit Meursing additional code'])
       end
     end
   end
@@ -50,6 +50,12 @@ RSpec.describe Steps::MeursingAdditionalCode, :step, :user_session do
   end
 
   describe '#previous_step_path' do
+    context 'when annual_turnover is less than 500k' do
+      let(:user_session) { build(:user_session, :with_small_turnover) }
+
+      it { expect(step.previous_step_path).to eq(annual_turnover_path) }
+    end
+
     context 'when the planned processing is acceptable' do
       let(:user_session) { build(:user_session, planned_processing: 'without_any_processing') }
 

--- a/spec/models/steps/meursing_additional_code_spec.rb
+++ b/spec/models/steps/meursing_additional_code_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe Steps::MeursingAdditionalCode, :step, :user_session do
+  subject(:step) { build(:meursing_additional_code, meursing_additional_code: meursing_additional_code) }
+
+  let(:meursing_additional_code) { nil }
+
+  let(:user_session) { build(:user_session) }
+
+  describe 'STEPS_TO_REMOVE_FROM_SESSION' do
+    it 'returns the correct list of steps' do
+      expect(described_class::STEPS_TO_REMOVE_FROM_SESSION).to eq(%w[])
+    end
+  end
+
+  describe '#validations' do
+    context 'when meursing_additional_code_code is formatted correctly' do
+      let(:meursing_additional_code) { '000' }
+
+      it { expect(step).to be_valid }
+
+      it 'has no validation errors' do
+        step.valid?
+
+        expect(step.errors.messages[:meursing_additional_code]).to be_empty
+      end
+    end
+
+    context 'when meursing_additional_code_code is not formatted correctly' do
+      let(:meursing_additional_code) { 'flibble' }
+
+      it { expect(step).not_to be_valid }
+
+      it 'adds the correct validation error message' do
+        step.valid?
+
+        expect(step.errors.messages[:meursing_additional_code]).to eq(['Specify a valid 3 digit meursing additional code'])
+      end
+    end
+  end
+
+  describe '#save' do
+    let(:meursing_additional_code) { '000' }
+
+    it 'saves the meursing_additional_code_code to the session' do
+      expect { step.save }.to change(user_session, :meursing_additional_code).from(nil).to('000')
+    end
+  end
+
+  describe '#next_step_path' do
+    it { expect(step.next_step_path).to eq(customs_value_path) }
+  end
+
+  describe '#previous_step_path' do
+    context 'when the planned processing is acceptable' do
+      let(:user_session) { build(:user_session, planned_processing: 'without_any_processing') }
+
+      it { expect(step.previous_step_path).to eq(planned_processing_path) }
+    end
+
+    context 'when the planned processing is unacceptable' do
+      let(:user_session) { build(:user_session, planned_processing: 'commercial_purposes') }
+
+      it { expect(step.previous_step_path).to eq(interstitial_path) }
+    end
+
+    context 'when the planned processing is not answered' do
+      let(:user_session) { build(:user_session) }
+
+      it { expect(step.previous_step_path).to eq(interstitial_path) }
+    end
+  end
+end

--- a/spec/models/steps/planned_processing_spec.rb
+++ b/spec/models/steps/planned_processing_spec.rb
@@ -55,56 +55,37 @@ RSpec.describe Steps::PlannedProcessing, :step, :user_session do
       context 'when the answer is not commercial_purposes' do
         let(:answer) { 'without_any_processing' }
 
-        it 'returns duty_path' do
-          expect(
-            step.next_step_path,
-          ).to eq(
-            duty_path,
-          )
-        end
+        it { expect(step.next_step_path).to eq(duty_path) }
       end
 
       context 'when the answer is commercial_purposes' do
         let(:answer) { 'commercial_purposes' }
 
-        it 'returns certificate_of_origin_path' do
-          expect(
-            step.next_step_path,
-          ).to eq(
-            certificate_of_origin_path,
-          )
-        end
+        it { expect(step.next_step_path).to eq(certificate_of_origin_path) }
       end
     end
 
     context 'when on RoW to NI route' do
-      shared_examples_for 'a step with a next step as customs' do |answer|
-        let(:session_attributes) do
-          {
-            'import_destination' => 'XI',
-            'country_of_origin' => 'OTHER',
-            'other_country_of_origin' => 'AR',
-            'planned_processing' => answer,
-          }
-        end
+      shared_examples_for 'a step with a next step as customs_value' do |answer, meursing_trait|
+        let(:user_session) { build(:user_session, meursing_trait, :with_row_to_ni_route, planned_processing: answer) }
 
         it { expect(step.next_step_path).to eq(customs_value_path) }
       end
 
-      it_behaves_like 'a step with a next step as customs', 'commercial_processing'
-      it_behaves_like 'a step with a next step as customs', 'without_any_processing'
+      shared_examples_for 'a step with a next step as meursing_additional_codes' do |answer, meursing_trait|
+        let(:user_session) { build(:user_session, meursing_trait, :with_row_to_ni_route, planned_processing: answer) }
+
+        it { expect(step.next_step_path).to eq(meursing_additional_codes_path) }
+      end
+
+      it_behaves_like 'a step with a next step as customs_value', 'commercial_processing', :with_non_meursing_commodity
+      it_behaves_like 'a step with a next step as customs_value', 'without_any_processing', :with_non_meursing_commodity
+
+      it_behaves_like 'a step with a next step as meursing_additional_codes', 'commercial_processing', :with_meursing_commodity
+      it_behaves_like 'a step with a next step as meursing_additional_codes', 'without_any_processing', :with_meursing_commodity
 
       context 'when the answer is commercial_purposes' do
-        let(:answer) { 'commercial_purposes' }
-
-        let(:session_attributes) do
-          {
-            'import_destination' => 'XI',
-            'country_of_origin' => 'OTHER',
-            'other_country_of_origin' => 'AR',
-            'planned_processing' => answer,
-          }
-        end
+        let(:user_session) { build(:user_session, planned_processing: 'commercial_purposes') }
 
         it { expect(step.next_step_path).to eq(interstitial_path) }
       end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe UserSession do
   it_behaves_like 'a user session attribute', :certificate_of_origin, 'yes'
   it_behaves_like 'a user session attribute', :planned_processing, 'commercial_processing'
   it_behaves_like 'a user session attribute', :vat, 'VATZ'
+  it_behaves_like 'a user session attribute', :meursing_additional_code, '000'
 
   it_behaves_like 'a user session dual route attribute', :document_code, { '142' => 'N851', '353' => 'Y929' }
   it_behaves_like 'a user session dual route attribute', :additional_code, { '142' => '2340', '353' => '2601' }
@@ -374,6 +375,28 @@ RSpec.describe UserSession do
 
       it { is_expected.not_to be_deltas_applicable }
     end
+  end
+
+  describe '#meursing_route?' do
+    shared_examples_for 'a meursing route' do |route_trait|
+      subject(:user_session) { build(:user_session, route_trait) }
+
+      it { is_expected.to be_meursing_route }
+    end
+
+    shared_examples_for 'a non-meursing route' do |route_trait|
+      subject(:user_session) { build(:user_session, route_trait) }
+
+      it { is_expected.not_to be_meursing_route }
+    end
+
+    it_behaves_like 'a meursing route', :with_gb_to_ni_route
+    it_behaves_like 'a meursing route', :with_row_to_ni_route
+
+    it_behaves_like 'a non-meursing route', :with_eu_to_ni_route
+    it_behaves_like 'a non-meursing route', :with_eu_to_gb_route
+    it_behaves_like 'a non-meursing route', :with_row_to_gb_route
+    it_behaves_like 'a non-meursing route', :with_ni_to_gb_route
   end
 
   describe '#import_into_gb?' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1009

### What?

![Screenshot from 2021-11-01 17-38-36](https://user-images.githubusercontent.com/8156884/139715361-715500d7-407d-42dc-923d-1eb530a48640.png)

I have added/removed/altered:

- [x] Added step to take input for the meursing additional code
- [x] Make sure the step fits into the row to ni and gb to ni journeys
- [x] Updated certificate of origin step to go to interstitial page with a negative answer
- [x] Updated interstitial page to include the certificate of origin variation of the interstitial message

### Why?

I am doing this because:

- This is needed so we can resolve measures that have measure components with meursing duty expressions and then calculate duties for them
