### PR TITLE
Use default form builder

### DIFF
--- a/app/views/steps/additional_codes/show.html.erb
+++ b/app/views/steps/additional_codes/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: additional_codes_path do |f| %>
+<%= form_for @step, url: additional_codes_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
   <h1 class="govuk-heading-xl">Describe your goods in more detail</h1>

--- a/app/views/steps/annual_turnover/show.html.erb
+++ b/app/views/steps/annual_turnover/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: annual_turnover_path do |f| %>
+<%= form_for @step, url: annual_turnover_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
 

--- a/app/views/steps/certificate_of_origin/show.html.erb
+++ b/app/views/steps/certificate_of_origin/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: certificate_of_origin_path do |f| %>
+<%= form_for @step, url: certificate_of_origin_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
   <%= f.govuk_collection_radio_buttons :certificate_of_origin, Steps::CertificateOfOrigin::OPTIONS, :id, :name, legend: { text: 'Do you have a valid proof of preferential origin?', size: 'xl', tag: 'h1' }, hint: { text: 'If you have a valid Certificate of Origin proving that your goods were materially manufactured in the UK, then you are eligible to take advantage of the 0% customs duties made available under the UK / EU Trade and Cooperation Agreement.' }, include_hidden: true %>

--- a/app/views/steps/customs_value/show.html.erb
+++ b/app/views/steps/customs_value/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: customs_value_path do |f| %>
+<%= form_for @step, url: customs_value_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
   <h1 class="govuk-heading-xl">What is the customs value of this import?</h1>

--- a/app/views/steps/document_codes/show.html.erb
+++ b/app/views/steps/document_codes/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: document_codes_path do |f| %>
+<%= form_for @step, url: document_codes_path do |f| %>
   <%= f.govuk_error_summary %>
 
   <span class="govuk-caption-xl">Calculate import duties</span>

--- a/app/views/steps/excise/show.html.erb
+++ b/app/views/steps/excise/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: excise_path do |f| %>
+<%= form_for @step, url: excise_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
   <h1 class="govuk-heading-xl">Which class of excise is applicable to your trade?</h1>

--- a/app/views/steps/final_use/show.html.erb
+++ b/app/views/steps/final_use/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: final_use_path do |f| %>
+<%= form_for @step, url: final_use_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
 

--- a/app/views/steps/import_date/show.html.erb
+++ b/app/views/steps/import_date/show.html.erb
@@ -1,6 +1,6 @@
 <%= link_to('Back', previous_service_url(commodity.code), class: "govuk-back-link") %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: import_date_path, html: { novalidate: true } do |f| %>
+<%= form_for @step, url: import_date_path, html: { novalidate: true } do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
   <%= f.govuk_date_field :import_date,

--- a/app/views/steps/import_destination/show.html.erb
+++ b/app/views/steps/import_destination/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: import_destination_path do |f| %>
+<%= form_for @step, url: import_destination_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
 

--- a/app/views/steps/measure_amount/show.html.erb
+++ b/app/views/steps/measure_amount/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: measure_amount_path do |f| %>
+<%= form_for @step, url: measure_amount_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
 

--- a/app/views/steps/meursing_additional_codes/show.html.erb
+++ b/app/views/steps/meursing_additional_codes/show.html.erb
@@ -2,7 +2,7 @@
 
 <span class="govuk-caption-xl">Calculate import duties</span>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: meursing_additional_codes_path do |f| %>
+<%= form_for @step, url: meursing_additional_codes_path do |f| %>
   <%= f.govuk_error_summary %>
 
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">

--- a/app/views/steps/planned_processing/show.html.erb
+++ b/app/views/steps/planned_processing/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: planned_processing_path do |f| %>
+<%= form_for @step, url: planned_processing_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
 

--- a/app/views/steps/trader_scheme/show.html.erb
+++ b/app/views/steps/trader_scheme/show.html.erb
@@ -1,6 +1,6 @@
 <%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: trader_scheme_path do |f| %>
+<%= form_for @step, url: trader_scheme_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
 

--- a/app/views/steps/vat/show.html.erb
+++ b/app/views/steps/vat/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'steps/shared/back_link' %>
 
-<%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: vat_path do |f| %>
+<%= form_for @step, url: vat_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
 


### PR DESCRIPTION
### Jira link

N/A

### What?

I have added/removed/altered:

- [x] Removed builder from all form_for invocations

### Why?

I am doing this because:

- This is defaulting to the form builder inherited via the BaseController
