### PR TITLE
HOTT-1011: Calculate meursing duties

### DIFF
--- a/app/controllers/steps/duty_controller.rb
+++ b/app/controllers/steps/duty_controller.rb
@@ -11,17 +11,17 @@ module Steps
 
     def duty_options
       return nil if user_session.no_duty_to_pay?
-      return DutyCalculator.new(filtered_commodity).options unless user_session.deltas_applicable?
+      return send("#{user_session.commodity_source}_options") unless user_session.deltas_applicable?
 
       RowToNiDutyCalculator.new(uk_options, xi_options).options if user_session.deltas_applicable?
     end
 
     def uk_options
-      @uk_options ||= DutyCalculator.new(filtered_commodity(source: 'uk')).options
+      @uk_options ||= DutyCalculator.new(uk_filtered_commodity).options
     end
 
     def xi_options
-      @xi_options ||= DutyCalculator.new(filtered_commodity(source: 'xi')).options
+      @xi_options ||= DutyCalculator.new(xi_filtered_commodity).options
     end
 
     def title

--- a/app/helpers/commodity_helper.rb
+++ b/app/helpers/commodity_helper.rb
@@ -1,9 +1,10 @@
 module CommodityHelper
   def filtered_commodity(query: default_filter, source: user_session.commodity_source)
     commodity_source = source || user_session.commodity_source
-    commodity_code = user_session.commodity_code
+    commodity_code   = user_session.commodity_code
+    query            = query.merge(xi_query_params) if source == 'xi'
 
-    commodity_context_service.call(commodity_source, commodity_code, query)
+    commodity_context_service.call(commodity_source, commodity_code, query.merge(xi_query_params))
   end
 
   def uk_filtered_commodity
@@ -11,7 +12,7 @@ module CommodityHelper
   end
 
   def xi_filtered_commodity
-    filtered_commodity(source: 'xi')
+    filtered_commodity(source: 'xi', query: xi_query_params)
   end
 
   def commodity
@@ -125,5 +126,11 @@ module CommodityHelper
     }.slice(
       *Api::MeasureType::SUPPORTED_MEASURE_TYPE_IDS,
     )
+  end
+
+  def xi_query_params
+    default_filter.tap do |query|
+      query.merge!('filter[meursing_additional_code_id]' => user_session.meursing_additional_code) if user_session.meursing_additional_code.present?
+    end
   end
 end

--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -66,7 +66,7 @@ module Api
     end
 
     def applicable_components
-      @applicable_components ||= document_components.presence || measure_components
+      @applicable_components ||= document_components.presence || resolved_or_standard_measure_components
     end
 
     def all_duties_zero?
@@ -103,8 +103,12 @@ module Api
 
     private
 
+    def resolved_or_standard_measure_components
+      resolved_measure_components.presence || measure_components
+    end
+
     def all_components
-      measure_conditions.flat_map(&:measure_condition_components) + measure_components
+      measure_conditions.flat_map(&:measure_condition_components) + resolved_or_standard_measure_components
     end
 
     def document_components

--- a/app/services/expression_evaluators/compound.rb
+++ b/app/services/expression_evaluators/compound.rb
@@ -11,7 +11,17 @@ module ExpressionEvaluators
     private
 
     def calculation_duty_expression
-      sanitize(measure.duty_expression&.formatted_base, tags: %w[span abbr], attributes: %w[title])
+      sanitize(duty_expression, tags: %w[span abbr strong br], attributes: %w[title])
+    end
+
+    def duty_expression
+      base_duty_expression = measure.duty_expression&.formatted_base
+
+      if measure.resolved_duty_expression.present?
+        "#{base_duty_expression}<br>#{measure.resolved_duty_expression}"
+      else
+        base_duty_expression
+      end
     end
 
     def build_expression

--- a/spec/controllers/steps/duty_controller_spec.rb
+++ b/spec/controllers/steps/duty_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::DutyController, :user_session do
     allow(Api::MonetaryExchangeRate).to receive(:for).with('GBP').and_call_original
   end
 
-  let(:user_session) { build(:user_session, :with_commodity_information, commodity_code: '0103921100') }
+  let(:user_session) { build(:user_session, import_destination: 'XI', commodity_code: '0103921100') }
   let(:duty_calculator) { instance_double('DutyCalculator', options: []) }
 
   describe 'GET #show' do

--- a/spec/factories/api/measure.rb
+++ b/spec/factories/api/measure.rb
@@ -122,5 +122,11 @@ FactoryBot.define do
     trait :provisional_anti_dumping do
       measure_type { attributes_for :measure_type, :provisional_anti_dumping }
     end
+
+    trait :with_resolved_duty_expression do
+      resolved_duty_expression do
+        "<span>9.00</span> % <strong>+ <span>0.00</span> EUR / <abbr title='Hectokilogram'>100 kg</abbr></strong> MAX <span>24.20</span> % <strong>+ <span>0.00</span> EUR / <abbr title='Hectokilogram'>100 kg</abbr></strong>"
+      end
+    end
   end
 end

--- a/spec/services/expression_evaluators/compound_spec.rb
+++ b/spec/services/expression_evaluators/compound_spec.rb
@@ -55,14 +55,6 @@ RSpec.describe ExpressionEvaluators::Compound, :user_session do
     ]
   end
 
-  let(:expected_evaluation) do
-    {
-      calculation: '<span>144.10</span> GBP / <abbr title="Tonne">1000 kg/biodiesel</abbr>',
-      formatted_value: '£800.00',
-      value: 800.0,
-    }
-  end
-
   let(:user_session) do
     build(
       :user_session,
@@ -73,5 +65,35 @@ RSpec.describe ExpressionEvaluators::Compound, :user_session do
     )
   end
 
+  let(:expected_evaluation) do
+    {
+      calculation: '<span>144.10</span> GBP / <abbr title="Tonne">1000 kg/biodiesel</abbr>',
+      formatted_value: '£800.00',
+      value: 800.0,
+    }
+  end
+
   it { expect(evaluator.call).to eq(expected_evaluation) }
+
+  context 'when a resolved duty expression is returned' do
+    let(:measure) do
+      build(
+        :measure,
+        :third_country_tariff,
+        :with_resolved_duty_expression,
+        id: 3_211_138,
+        measure_components: measure_components,
+      )
+    end
+
+    let(:expected_evaluation) do
+      {
+        calculation: '<span>144.10</span> GBP / <abbr title="Tonne">1000 kg/biodiesel</abbr><br><span>9.00</span> % <strong>+ <span>0.00</span> EUR / <abbr title="Hectokilogram">100 kg</abbr></strong> MAX <span>24.20</span> % <strong>+ <span>0.00</span> EUR / <abbr title="Hectokilogram">100 kg</abbr></strong>',
+        formatted_value: '£800.00',
+        value: 800.0,
+      }
+    end
+
+    it { expect(evaluator.call).to eq(expected_evaluation) }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1011

### What?

![Screenshot from 2021-11-04 14-11-18](https://user-images.githubusercontent.com/8156884/140329066-6dcc8577-0f76-4338-a5f1-1a680d96c771.png)

When a measure expresses meursing components and we have an answer from the user
about which code applies to their trade, we have enough information to
have the backend api surface the resolved measure components that we can
then use to execute duty calculations on the measure option that a
trader then take advantage of.

I've also updated the compound evaluator to express resolved meursing
duty expressions by concatenating the duty expression with a \<br\> tag
and the resolved duty expression coming back from the api response.

I have added/removed/altered:

- [x] Extend applicable measure components to include the resolved components
- [x] Update xi filtered commodities to include the meursing additional code so we retrieve the resolved meursing components
- [x] Use meursing components in the duty duty calculator over the standard components
- [x] Fill in test coverage for changed implemnetations

### Why?

- XI currently has measures with meursing components that we cannot currently calculate
