### PR TITLE
HOTT-1111: Make attribute api more robust to new attributes

### DIFF
--- a/app/models/api/commodity.rb
+++ b/app/models/api/commodity.rb
@@ -32,7 +32,7 @@ module Api
     alias_method :meursing_code?, :meursing_code
 
     def description
-      super.html_safe
+      attributes[:description].html_safe
     end
 
     def code

--- a/app/models/api/measure_condition.rb
+++ b/app/models/api/measure_condition.rb
@@ -62,13 +62,13 @@ module Api
     has_many :measure_condition_components, MeasureConditionComponent
 
     def document_code
-      return super if super.present?
+      return attributes[:document_code] if attributes[:document_code].present?
 
       'None'
     end
 
     def certificate_description
-      return "#{document_code} - #{super}" unless document_code == 'None'
+      return "#{document_code} - #{attributes[:certificate_description]}" unless document_code == 'None'
 
       'None of the above'
     end

--- a/app/models/api/monetary_exchange_rate.rb
+++ b/app/models/api/monetary_exchange_rate.rb
@@ -7,11 +7,11 @@ module Api
                :validity_start_date
 
     def validity_start_date
-      Date.parse(super)
+      Date.parse(attributes[:validity_start_date])
     end
 
     def exchange_rate
-      super.to_f
+      attributes[:exchange_rate].to_f
     end
 
     class << self

--- a/spec/models/api/base_spec.rb
+++ b/spec/models/api/base_spec.rb
@@ -6,6 +6,21 @@ RSpec.describe Api::Base, :user_session do
     allow(Rails.application.config.http_client_xi).to receive(:retrieve).and_call_original
   end
 
+  describe '#initialize' do
+    context 'when initialized with unknown attributes' do
+      subject(:resource) { Api::Measure.new(foo: :bar) }
+
+      it { expect { resource }.not_to raise_error }
+      it { expect(resource).not_to respond_to(:foo) }
+    end
+
+    context 'when initialized with known attributes' do
+      subject(:resource) { Api::Measure.new(id: :bar) }
+
+      it { expect(resource.id).to eq(:bar) }
+    end
+  end
+
   describe '#build' do
     subject(:api_resource) { Api::Commodity }
 

--- a/spec/models/api/measure_spec.rb
+++ b/spec/models/api/measure_spec.rb
@@ -506,6 +506,8 @@ RSpec.describe Api::Measure, :user_session do
               'measurement_unit_code' => nil,
               'measurement_unit_qualifier_code' => nil,
               'meta' => nil,
+              'duty_expression_abbreviation' => nil,
+              'duty_expression_description' => nil,
             },
           ]
         end
@@ -514,18 +516,16 @@ RSpec.describe Api::Measure, :user_session do
           expect(measure.applicable_components.as_json).to eq(
             [
               {
-                'attributes' => {
-                  'duty_amount' => 10.0,
-                  'duty_expression_abbreviation' => nil,
-                  'duty_expression_description' => nil,
-                  'duty_expression_id' => '01',
-                  'id' => '20121795-01',
-                  'measurement_unit_code' => nil,
-                  'measurement_unit_qualifier_code' => nil,
-                  'meta' => nil,
-                  'monetary_unit_abbreviation' => nil,
-                  'monetary_unit_code' => nil,
-                },
+                'duty_amount' => 10.0,
+                'duty_expression_abbreviation' => nil,
+                'duty_expression_description' => nil,
+                'duty_expression_id' => '01',
+                'id' => '20121795-01',
+                'measurement_unit_code' => nil,
+                'measurement_unit_qualifier_code' => nil,
+                'meta' => nil,
+                'monetary_unit_abbreviation' => nil,
+                'monetary_unit_code' => nil,
               },
             ],
           )

--- a/spec/models/api/monetary_exchange_rate_spec.rb
+++ b/spec/models/api/monetary_exchange_rate_spec.rb
@@ -24,14 +24,12 @@ RSpec.describe Api::MonetaryExchangeRate, :user_session, type: :model do
 
       it 'returns the latest exchange rate' do
         expect(described_class.for(currency).as_json).to eq(
-          'attributes' => {
-            'meta' => nil,
-            'id' => nil,
-            'child_monetary_unit_code' => 'GBP',
-            'exchange_rate' => '0.8571',
-            'operation_date' => '2021-06-29',
-            'validity_start_date' => '2021-07-01T00:00:00.000Z',
-          },
+          'meta' => nil,
+          'id' => nil,
+          'child_monetary_unit_code' => 'GBP',
+          'exchange_rate' => '0.8571',
+          'operation_date' => '2021-06-29',
+          'validity_start_date' => '2021-07-01T00:00:00.000Z',
         )
       end
     end
@@ -41,14 +39,12 @@ RSpec.describe Api::MonetaryExchangeRate, :user_session, type: :model do
 
       it 'returns the exchange rate matching the month and year of the import date' do
         expect(described_class.for(currency).as_json).to eq(
-          'attributes' => {
-            'meta' => nil,
-            'id' => nil,
-            'child_monetary_unit_code' => 'GBP',
-            'exchange_rate' => '0.8512',
-            'operation_date' => '2021-04-29',
-            'validity_start_date' => '2021-04-01T00:00:00.000Z',
-          },
+          'meta' => nil,
+          'id' => nil,
+          'child_monetary_unit_code' => 'GBP',
+          'exchange_rate' => '0.8512',
+          'operation_date' => '2021-04-29',
+          'validity_start_date' => '2021-04-01T00:00:00.000Z',
         )
       end
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1111

### What?

I have added/removed/altered:

- [x] Move to a more robust attributes api

### Why?

I am doing this because:

- This is required to support new attributes that aren't defined on the models being returned by the backend not causing exceptions
