### PR TITLE
HOTT-1119: Separate browse and search urls

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,3 +3,4 @@ DUTY_CALCULATOR_HOST=http://test.host
 PORT=3002
 ROUTE_THROUGH_FRONTEND=true
 TRADE_TARIFF_FRONTEND_URL="https://dev.trade-tariff.service.gov.uk"
+UPDATED_NAVIGATION=true

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 API_SERVICE_BACKEND_URL_OPTIONS={"uk":"https://dev.trade-tariff.service.gov.uk","xi":"https://dev.trade-tariff.service.gov.uk/xi"}
 FRONTEND_HOST=http://test.host
 TRADE_TARIFF_FRONTEND_URL='https://dev.trade-tariff.service.gov.uk'
+UPDATED_NAVIGATION=true

--- a/app/controllers/steps/base_controller.rb
+++ b/app/controllers/steps/base_controller.rb
@@ -60,7 +60,7 @@ module Steps
     end
 
     def ensure_session_integrity
-      return redirect_to trade_tariff_url if commodity_code.blank?
+      return redirect_to sections_url if commodity_code.blank?
     end
 
     def initialize_commodity_context_service

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -7,8 +7,16 @@ module ServiceHelper
     t("header.#{referred_service}")
   end
 
-  def trade_tariff_url
+  def sections_url
     service_url_for('/sections')
+  end
+
+  def search_url
+    service_url_for('/find_commodity')
+  end
+
+  def browse_url
+    service_url_for('/browse')
   end
 
   def a_to_z_url

--- a/app/views/navbar/_main.html.erb
+++ b/app/views/navbar/_main.html.erb
@@ -1,13 +1,22 @@
 <div class="govuk-header__content">
-  <a href="<%= trade_tariff_url %>" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
+  <a href="<%= sections_url %>" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
     <%= header %>
   </a>
   <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="proposition-links" aria-label="Show or hide Top Level Navigation">Menu</button>
   <nav id="proposition-menu"  aria-label="Top Level Navigation">
     <ul id="proposition-links" class="govuk-header__navigation ">
-      <li class="govuk-header__navigation-item">
-        <%= link_to 'Search or browse the Tariff', trade_tariff_url, class: "govuk-header__link" %>
-      </li>
+      <% if TradeTariffDutyCalculator.updated_navigation? %>
+        <li class="govuk-header__navigation-item">
+          <%= link_to 'Search', search_url, class: "govuk-header__link" %>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <%= link_to 'Browse', browse_url, class: "govuk-header__link" %>
+        </li>
+      <% else %>
+        <li class="govuk-header__navigation-item">
+          <%= link_to 'Search or browse the Tariff', sections_url, class: "govuk-header__link" %>
+        </li>
+      <% end %>
       <li class="govuk-header__navigation-item">
         <%= link_to "A-Z", a_to_z_url, class: "govuk-header__link" %>
       </li>

--- a/app/views/steps/confirmation/show.html.erb
+++ b/app/views/steps/confirmation/show.html.erb
@@ -7,7 +7,7 @@
     <dt class="govuk-summary-list__key">Commodity code</dt>
     <dd class="govuk-summary-list__value"><%= commodity.formatted_commodity_code %></dd>
     <dd class="govuk-summary-list__actions">
-      <%= link_to('Change', trade_tariff_url, class: 'govuk-link') %>
+      <%= link_to('Change', sections_url, class: 'govuk-link') %>
     </dd>
   </div>
   <%= render partial: 'entry', collection: @decorated_step.user_answers, as: :entry %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,4 +17,9 @@ module TradeTariffDutyCalculator
     config.trade_tariff_frontend_url = ENV['TRADE_TARIFF_FRONTEND_URL']
     config.duty_calculator_host      = ENV.fetch('DUTY_CALCULATOR_HOST', 'http://localhost')
   end
+
+  # TODO: HOTT-1048 - remove once in production
+  def self.updated_navigation?
+    ENV['UPDATED_NAVIGATION'].to_s == 'true'
+  end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -51,91 +51,42 @@ RSpec.describe ServiceHelper, :user_session do
     end
   end
 
-  describe '#trade_tariff_url' do
-    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
+  shared_examples_for 'a service url' do |helper_method, path|
+    context 'when frontend url is set and service is not set' do
+      let(:service) { nil }
       let(:frontend_url) { 'https://dev.trade-tariff.service.gov.uk' }
 
-      it 'returns the dev trade tariff url' do
-        expect(helper.trade_tariff_url).to eq(
-          'https://dev.trade-tariff.service.gov.uk/sections',
-        )
-      end
+      it { expect(helper.public_send(helper_method)).to eq("https://dev.trade-tariff.service.gov.uk#{path}") }
     end
 
-    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
-      let(:frontend_url) { nil }
+    context 'when frontend url is set and service is `uk`' do
+      let(:service) { 'uk' }
+      let(:frontend_url) { 'https://dev.trade-tariff.service.gov.uk' }
 
-      it 'returns the staging trade tariff url' do
-        expect(helper.trade_tariff_url).to eq('#')
-      end
+      it { expect(helper.public_send(helper_method)).to eq("https://dev.trade-tariff.service.gov.uk#{path}") }
     end
 
-    context 'when service choice is XI' do
+    context 'when frontend url is set and service is `xi`' do
       let(:service) { 'xi' }
-
-      it 'returns the dev trade tariff url for XI' do
-        expect(helper.trade_tariff_url).to eq(
-          'https://dev.trade-tariff.service.gov.uk/xi/sections',
-        )
-      end
-    end
-  end
-
-  describe '#a_to_z_url' do
-    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
       let(:frontend_url) { 'https://dev.trade-tariff.service.gov.uk' }
 
-      it 'returns the dev trade tariff a to z url' do
-        expect(helper.a_to_z_url).to eq(
-          'https://dev.trade-tariff.service.gov.uk/a-z-index/a',
-        )
-      end
+      it { expect(helper.public_send(helper_method)).to eq("https://dev.trade-tariff.service.gov.uk/xi#{path}") }
     end
 
-    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
+    context 'when frontend url is not set' do
       let(:frontend_url) { nil }
 
-      it 'returns the dev trade tariff a to z url' do
-        expect(helper.a_to_z_url).to eq('#')
-      end
+      it { expect(helper.public_send(helper_method)).to eq('#') }
     end
   end
 
-  describe '#tools_url' do
-    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
-      it 'returns the dev trade tariff tools url' do
-        expect(helper.tools_url).to eq(
-          'https://dev.trade-tariff.service.gov.uk/tools',
-        )
-      end
-    end
-
-    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
-      let(:frontend_url) { nil }
-
-      it 'returns the dev trade tariff tools url' do
-        expect(helper.tools_url).to eq('#')
-      end
-    end
-  end
-
-  describe '#help_url' do
-    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
-      it 'returns the dev trade tariff tools url' do
-        expect(helper.help_url).to eq(
-          'https://dev.trade-tariff.service.gov.uk/help',
-        )
-      end
-    end
-
-    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
-      let(:frontend_url) { nil }
-
-      it 'returns the dev trade tariff tools url' do
-        expect(helper.help_url).to eq('#')
-      end
-    end
-  end
+  it_behaves_like 'a service url', :sections_url, '/sections'
+  it_behaves_like 'a service url', :search_url, '/find_commodity'
+  it_behaves_like 'a service url', :browse_url, '/browse'
+  it_behaves_like 'a service url', :a_to_z_url, '/a-z-index/a'
+  it_behaves_like 'a service url', :tools_url, '/tools'
+  it_behaves_like 'a service url', :feedback_url, '/feedback'
+  it_behaves_like 'a service url', :help_url, '/help'
 
   describe '#previous_service_url' do
     let(:commodity_code) { '0702000007' }
@@ -167,56 +118,18 @@ RSpec.describe ServiceHelper, :user_session do
   describe '#commodity_url' do
     let(:commodity_code) { '0702000007' }
 
-    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
-      it 'returns the dev trade tariff tools url' do
-        expect(helper.commodity_url(commodity_code)).to eq(
-          "https://dev.trade-tariff.service.gov.uk/commodities/#{commodity_code}",
-        )
-      end
+    context 'when frontend url is set' do
+      let(:frontend_url) { 'https://dev.trade-tariff.service.gov.uk' }
+
+      it { expect(helper.commodity_url(commodity_code)).to eq("https://dev.trade-tariff.service.gov.uk/commodities/#{commodity_code}") }
     end
 
-    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
+    context 'when frontend url is not set' do
       let(:frontend_url) { nil }
 
-      it 'returns the dev trade tariff tools url' do
+      it 'returns the correct url' do
         expect(helper.commodity_url(commodity_code)).to eq('#')
       end
-    end
-  end
-
-  describe '#feedback_url' do
-    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
-      let(:frontend_url) { 'https://dev.trade-tariff.service.gov.uk' }
-
-      it 'returns the dev trade tariff tools url' do
-        expect(helper.feedback_url).to eq(
-          'https://dev.trade-tariff.service.gov.uk/feedback',
-        )
-      end
-    end
-
-    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
-      let(:frontend_url) { nil }
-
-      it { expect(helper.feedback_url).to eq('#') }
-    end
-  end
-
-  describe '#meursing_lookup_url' do
-    context 'when TRADE_TARIFF_FRONTEND_URL is set' do
-      let(:frontend_url) { 'https://dev.trade-tariff.service.gov.uk' }
-
-      it 'returns the dev trade tariff meursing lookup url' do
-        expected_url = 'https://dev.trade-tariff.service.gov.uk/xi/meursing_lookup/steps/start'
-
-        expect(helper.meursing_lookup_url).to eq(expected_url)
-      end
-    end
-
-    context 'when TRADE_TARIFF_FRONTEND_URL is not set' do
-      let(:frontend_url) { nil }
-
-      it { expect(helper.meursing_lookup_url).to eq('#') }
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1119

### What?

![Screenshot from 2021-11-18 12-01-30](https://user-images.githubusercontent.com/8156884/142411817-d58ba5f4-0b23-4aa4-91b6-9bd9dbdbd9c1.png)

I have added/removed/altered:

- [x] Added separate nav items for browse and search when using the updated navigation
- [x] Refactored and improved common tests of service urls using shared examples

### Why?

I am doing this because:

- This is needed to make sure that the duty calculator reflects what's currently on the other environments
