### PR TITLE
Make duty calculator width the same as frontend

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -9,6 +9,7 @@
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 $govuk-global-styles: true;
+$govuk-page-width: 1140px;
 
 @import "~govuk-frontend/govuk/all";
 @import "accessible-autocomplete";


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1131

### What?

I have added/removed/altered:

- [x] Updated page width

### Why?

I am doing this because:

- To match the frontend application that this app shadows