### PR TITLE
HOTT-1109: Extract complex document code extraction into own service

### DIFF
--- a/app/helpers/commodity_helper.rb
+++ b/app/helpers/commodity_helper.rb
@@ -53,15 +53,7 @@ module CommodityHelper
   end
 
   def applicable_document_codes
-    @applicable_document_codes ||=
-      {}.tap do |applicable_document_codes|
-        if user_session.deltas_applicable?
-          applicable_document_codes['uk'] = surface_document_codes(commodity: uk_filtered_commodity)
-          applicable_document_codes['xi'] = surface_document_codes(commodity: xi_filtered_commodity)
-        else
-          applicable_document_codes[user_session.commodity_source] = surface_document_codes
-        end
-      end
+    @applicable_document_codes ||= ApplicableDocumentCodesService.new.call
   end
 
   def applicable_document_codes?
@@ -114,18 +106,6 @@ module CommodityHelper
     return user_session.other_country_of_origin if user_session.country_of_origin == 'OTHER'
 
     user_session.country_of_origin
-  end
-
-  def surface_document_codes(commodity: filtered_commodity)
-    commodity.applicable_measures.each_with_object({}) { |measure, acc|
-      next unless measure.expresses_document?
-      next if measure.document_codes.blank?
-
-      acc[measure.measure_type.id] ||= []
-      acc[measure.measure_type.id].concat(measure.document_codes)
-    }.slice(
-      *Api::MeasureType::SUPPORTED_MEASURE_TYPE_IDS,
-    )
   end
 
   def xi_query_params

--- a/app/services/applicable_document_codes_service.rb
+++ b/app/services/applicable_document_codes_service.rb
@@ -1,0 +1,47 @@
+class ApplicableDocumentCodesService
+  include CommodityHelper
+
+  def initialize
+    @applicable_document_codes = {}
+  end
+
+  def call
+    return delta_measure_condition_documents if user_session.deltas_applicable?
+
+    send("#{user_session.commodity_source}_measure_condition_documents")
+  end
+
+  private
+
+  def delta_measure_condition_documents
+    @applicable_document_codes['uk'] = surface_document_codes(uk_filtered_commodity)
+    @applicable_document_codes['xi'] = surface_document_codes(xi_filtered_commodity)
+    @applicable_document_codes
+  end
+
+  def uk_measure_condition_documents
+    @applicable_document_codes['uk'] = surface_document_codes(uk_filtered_commodity)
+    @applicable_document_codes
+  end
+
+  def xi_measure_condition_documents
+    @applicable_document_codes['xi'] = surface_document_codes(xi_filtered_commodity)
+    @applicable_document_codes
+  end
+
+  def surface_document_codes(commodity)
+    commodity.applicable_measures.each_with_object({}) { |measure, acc|
+      next unless measure.expresses_document?
+      next if measure.document_codes.blank?
+
+      acc[measure.measure_type.id] ||= []
+      acc[measure.measure_type.id].concat(measure.document_codes)
+    }.slice(
+      *Api::MeasureType::SUPPORTED_MEASURE_TYPE_IDS,
+    )
+  end
+
+  def user_session
+    UserSession.get
+  end
+end

--- a/spec/fixtures/xi/commodities/7202999000.json
+++ b/spec/fixtures/xi/commodities/7202999000.json
@@ -1,0 +1,1 @@
+../../uk/commodities/7202999000.json

--- a/spec/helpers/commodity_helper_spec.rb
+++ b/spec/helpers/commodity_helper_spec.rb
@@ -293,6 +293,10 @@ RSpec.describe CommodityHelper, :user_session do
   end
 
   describe '#applicable_document_codes' do
+    before do
+      allow(ApplicableDocumentCodesService).to receive(:new).and_call_original
+    end
+
     let(:expected_options) do
       {
         'uk' => {
@@ -302,8 +306,12 @@ RSpec.describe CommodityHelper, :user_session do
       }
     end
 
-    it 'returns the applicable document codes' do
-      expect(helper.applicable_document_codes).to eq(expected_options)
+    it { expect(helper.applicable_document_codes).to eq(expected_options) }
+
+    it 'calls out to the ApplicableDocumentCodesService' do
+      helper.applicable_document_codes
+
+      expect(ApplicableDocumentCodesService).to have_received(:new)
     end
   end
 

--- a/spec/models/steps/customs_value_spec.rb
+++ b/spec/models/steps/customs_value_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Steps::CustomsValue, :step, :user_session do
   let(:monetary_value) { '12_500' }
   let(:insurance_cost) { '1_200' }
   let(:shipping_cost) { '340' }
-  let(:applicable_document_codes) { {} }
 
   describe 'STEPS_TO_REMOVE_FROM_SESSION' do
     it 'returns the correct list of steps' do
@@ -264,7 +263,6 @@ RSpec.describe Steps::CustomsValue, :step, :user_session do
       allow(Api::Commodity).to receive(:build).and_return(filtered_commodity)
       allow(ApplicableMeasureUnitMerger).to receive(:new).and_call_original
       allow(filtered_commodity).to receive(:applicable_measure_units).and_return(applicable_measure_units)
-      allow(filtered_commodity).to receive(:applicable_document_codes).and_return(applicable_document_codes)
     end
 
     context 'when there are applicable measure units' do
@@ -303,7 +301,6 @@ RSpec.describe Steps::CustomsValue, :step, :user_session do
 
       let(:first_measure_type_id) { '105' }
       let(:applicable_additional_codes) { {} }
-      let(:applicable_document_codes) { {} }
       let(:applicable_vat_options) { {} }
 
       before do

--- a/spec/services/applicable_document_codes_service_spec.rb
+++ b/spec/services/applicable_document_codes_service_spec.rb
@@ -1,0 +1,173 @@
+RSpec.describe ApplicableDocumentCodesService, :user_session do
+  subject(:service) { described_class.new }
+
+  describe '#call' do
+    before do
+      allow(Api::Commodity).to receive(:build).and_call_original
+    end
+
+    context 'when on the deltas route' do
+      let(:user_session) do
+        build(
+          :user_session,
+          :with_commodity_information,
+          :with_customs_value,
+          :with_measure_amount,
+          :deltas_applicable,
+          commodity_code: '7202999000',
+        )
+      end
+
+      let(:expected_documents) do
+        {
+          'uk' => {
+            '105' => [
+              { code: 'C644', description: 'C644 - ' },
+              { code: 'Y929', description: 'Y929 - ' },
+              { code: 'None', description: 'None of the above' },
+            ],
+            '117' => [
+              { code: 'C990', description: 'C990 - ' },
+              { code: 'None', description: 'None of the above' },
+            ],
+          },
+          'xi' => {
+            '105' => [
+              { code: 'C644', description: 'C644 - ' },
+              { code: 'Y929', description: 'Y929 - ' },
+              { code: 'None', description: 'None of the above' },
+            ],
+            '117' => [
+              { code: 'C990', description: 'C990 - ' },
+              { code: 'None', description: 'None of the above' },
+            ],
+          },
+        }
+      end
+
+      it 'fetches the xi commodity' do
+        service.call
+
+        expect(Api::Commodity).to have_received(:build).with(
+          'xi',
+          '7202999000',
+          anything,
+        )
+      end
+
+      it 'fetches the uk commodity' do
+        service.call
+
+        expect(Api::Commodity).to have_received(:build).with(
+          'uk',
+          '7202999000',
+          anything,
+        )
+      end
+
+      it { expect(service.call).to eq(expected_documents) }
+    end
+
+    context 'when on an xi route' do
+      let(:user_session) do
+        build(
+          :user_session,
+          :with_commodity_information,
+          :with_customs_value,
+          :with_measure_amount,
+          commodity_source: 'xi',
+          commodity_code: '7202999000',
+        )
+      end
+
+      let(:expected_documents) do
+        {
+          'xi' => {
+            '105' => [
+              { code: 'C644', description: 'C644 - ' },
+              { code: 'Y929', description: 'Y929 - ' },
+              { code: 'None', description: 'None of the above' },
+            ],
+            '117' => [
+              { code: 'C990', description: 'C990 - ' },
+              { code: 'None', description: 'None of the above' },
+            ],
+          },
+        }
+      end
+
+      it 'does not fetch the uk commodity' do
+        service.call
+
+        expect(Api::Commodity).not_to have_received(:build).with(
+          'uk',
+          '7202999000',
+          anything,
+        )
+      end
+
+      it 'fetches the xi commodity' do
+        service.call
+
+        expect(Api::Commodity).to have_received(:build).with(
+          'xi',
+          '7202999000',
+          anything,
+        )
+      end
+
+      it { expect(service.call).to eq(expected_documents) }
+    end
+
+    context 'when on a uk route' do
+      let(:user_session) do
+        build(
+          :user_session,
+          :with_commodity_information,
+          :with_customs_value,
+          :with_measure_amount,
+          commodity_source: 'uk',
+          commodity_code: '7202999000',
+        )
+      end
+
+      let(:expected_documents) do
+        {
+          'uk' => {
+            '105' => [
+              { code: 'C644', description: 'C644 - ' },
+              { code: 'Y929', description: 'Y929 - ' },
+              { code: 'None', description: 'None of the above' },
+            ],
+            '117' => [
+              { code: 'C990', description: 'C990 - ' },
+              { code: 'None', description: 'None of the above' },
+            ],
+          },
+        }
+      end
+
+      it 'does not fetch the xi commodity' do
+        service.call
+
+        expect(Api::Commodity).not_to have_received(:build).with(
+          'xi',
+          '7202999000',
+          anything,
+        )
+      end
+
+      it 'fetches the uk commodity' do
+        service.call
+
+        expect(Api::Commodity).to have_received(:build).with(
+          'uk',
+          '7202999000',
+          anything,
+        )
+      end
+
+      it { expect(service.call).to eq(expected_documents) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1109

### What?

I have added/removed/altered:

- [x] Extracted ApplicableDocumentCodesService
- [x] Added ApplicableDocumentCodesService coverage

### Why?

I am doing this because:

- This is an improvement in itself but it makes fixing the linked ticket issue easier
