### PR TITLE
HOTT-1109: Fix bug in document codes presentation

### DIFF
--- a/app/services/applicable_document_codes_service.rb
+++ b/app/services/applicable_document_codes_service.rb
@@ -6,9 +6,13 @@ class ApplicableDocumentCodesService
   end
 
   def call
-    return delta_measure_condition_documents if user_session.deltas_applicable?
+    if user_session.deltas_applicable?
+      delta_measure_condition_documents
+    else
+      send("#{user_session.commodity_source}_measure_condition_documents")
+    end
 
-    send("#{user_session.commodity_source}_measure_condition_documents")
+    @applicable_document_codes
   end
 
   private
@@ -16,29 +20,34 @@ class ApplicableDocumentCodesService
   def delta_measure_condition_documents
     @applicable_document_codes['uk'] = surface_document_codes(uk_filtered_commodity)
     @applicable_document_codes['xi'] = surface_document_codes(xi_filtered_commodity)
-    @applicable_document_codes
   end
 
   def uk_measure_condition_documents
     @applicable_document_codes['uk'] = surface_document_codes(uk_filtered_commodity)
-    @applicable_document_codes
   end
 
   def xi_measure_condition_documents
     @applicable_document_codes['xi'] = surface_document_codes(xi_filtered_commodity)
-    @applicable_document_codes
   end
 
   def surface_document_codes(commodity)
-    commodity.applicable_measures.each_with_object({}) { |measure, acc|
+    document_codes = commodity.applicable_measures.each_with_object({}) do |measure, acc|
       next unless measure.expresses_document?
       next if measure.document_codes.blank?
 
-      acc[measure.measure_type.id] ||= []
-      acc[measure.measure_type.id].concat(measure.document_codes)
-    }.slice(
-      *Api::MeasureType::SUPPORTED_MEASURE_TYPE_IDS,
-    )
+      acc[measure.measure_type.id] ||= Set.new
+      acc[measure.measure_type.id] = acc[measure.measure_type.id] | measure.document_codes
+    end
+
+    document_codes = document_codes.each_with_object({}) do |(measure_type_id, measure_type_document_codes), acc|
+      measure_type_document_codes = measure_type_document_codes.to_a
+      last_option = measure_type_document_codes.delete(code: 'None', description: 'None of the above')
+
+      acc[measure_type_id] = measure_type_document_codes.sort_by { |document_code| document_code[:code] }
+      acc[measure_type_id] << last_option if last_option
+    end
+
+    document_codes.slice(*Api::MeasureType::SUPPORTED_MEASURE_TYPE_IDS)
   end
 
   def user_session

--- a/spec/fixtures/uk/commodities/7202999000.json
+++ b/spec/fixtures/uk/commodities/7202999000.json
@@ -368,6 +368,1384 @@
         {
           "condition_code": "B",
           "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "C655",
+          "requirement": "Other certificates: Certificate of inspection for organic products",
+          "action": "Import/export allowed after control",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "Y929",
+          "requirement": "Particular provisions: Goods not concerned by Regulation (EC) No 834/2007 (organic products)",
+          "action": "Import/export allowed after control",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        },
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
+          "document_code": "",
+          "requirement": null,
+          "action": "Import/export not allowed after control",
+          "duty_expression": "",
+          "condition_duty_amount": null,
+          "condition_monetary_unit_code": null,
+          "monetary_unit_abbreviation": null,
+          "condition_measurement_unit_code": null,
+          "condition_measurement_unit_qualifier_code": null,
+          "measure_condition_components": [
+
+          ]
+        }
+      ],
+      "measure_components": [
+
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+          {
+            "id": "AD",
+            "description": "Andorra",
+            "geographical_area_id": "AD"
+          },
+          {
+            "id": "AE",
+            "description": "United Arab Emirates",
+            "geographical_area_id": "AE"
+          },
+          {
+            "id": "AF",
+            "description": "Afghanistan",
+            "geographical_area_id": "AF"
+          },
+          {
+            "id": "AG",
+            "description": "Antigua and Barbuda",
+            "geographical_area_id": "AG"
+          },
+          {
+            "id": "AI",
+            "description": "Anguilla",
+            "geographical_area_id": "AI"
+          },
+          {
+            "id": "AL",
+            "description": "Albania",
+            "geographical_area_id": "AL"
+          },
+          {
+            "id": "AM",
+            "description": "Armenia",
+            "geographical_area_id": "AM"
+          },
+          {
+            "id": "AO",
+            "description": "Angola",
+            "geographical_area_id": "AO"
+          },
+          {
+            "id": "AQ",
+            "description": "Antarctica",
+            "geographical_area_id": "AQ"
+          },
+          {
+            "id": "AR",
+            "description": "Argentina",
+            "geographical_area_id": "AR"
+          },
+          {
+            "id": "AS",
+            "description": "American Samoa",
+            "geographical_area_id": "AS"
+          },
+          {
+            "id": "AT",
+            "description": "Austria",
+            "geographical_area_id": "AT"
+          },
+          {
+            "id": "AU",
+            "description": "Australia",
+            "geographical_area_id": "AU"
+          },
+          {
+            "id": "AW",
+            "description": "Aruba",
+            "geographical_area_id": "AW"
+          },
+          {
+            "id": "AZ",
+            "description": "Azerbaijan",
+            "geographical_area_id": "AZ"
+          },
+          {
+            "id": "BA",
+            "description": "Bosnia and Herzegovina",
+            "geographical_area_id": "BA"
+          },
+          {
+            "id": "BB",
+            "description": "Barbados",
+            "geographical_area_id": "BB"
+          },
+          {
+            "id": "BD",
+            "description": "Bangladesh",
+            "geographical_area_id": "BD"
+          },
+          {
+            "id": "BE",
+            "description": "Belgium",
+            "geographical_area_id": "BE"
+          },
+          {
+            "id": "BF",
+            "description": "Burkina Faso",
+            "geographical_area_id": "BF"
+          },
+          {
+            "id": "BG",
+            "description": "Bulgaria",
+            "geographical_area_id": "BG"
+          },
+          {
+            "id": "BH",
+            "description": "Bahrain",
+            "geographical_area_id": "BH"
+          },
+          {
+            "id": "BI",
+            "description": "Burundi",
+            "geographical_area_id": "BI"
+          },
+          {
+            "id": "BJ",
+            "description": "Benin",
+            "geographical_area_id": "BJ"
+          },
+          {
+            "id": "BL",
+            "description": "Saint Barthélemy",
+            "geographical_area_id": "BL"
+          },
+          {
+            "id": "BM",
+            "description": "Bermuda",
+            "geographical_area_id": "BM"
+          },
+          {
+            "id": "BN",
+            "description": "Brunei",
+            "geographical_area_id": "BN"
+          },
+          {
+            "id": "BO",
+            "description": "Bolivia",
+            "geographical_area_id": "BO"
+          },
+          {
+            "id": "BQ",
+            "description": "Bonaire, Sint Eustatius and Saba",
+            "geographical_area_id": "BQ"
+          },
+          {
+            "id": "BR",
+            "description": "Brazil",
+            "geographical_area_id": "BR"
+          },
+          {
+            "id": "BS",
+            "description": "The Bahamas",
+            "geographical_area_id": "BS"
+          },
+          {
+            "id": "BT",
+            "description": "Bhutan",
+            "geographical_area_id": "BT"
+          },
+          {
+            "id": "BV",
+            "description": "Bouvet Island",
+            "geographical_area_id": "BV"
+          },
+          {
+            "id": "BW",
+            "description": "Botswana",
+            "geographical_area_id": "BW"
+          },
+          {
+            "id": "BY",
+            "description": "Belarus",
+            "geographical_area_id": "BY"
+          },
+          {
+            "id": "BZ",
+            "description": "Belize",
+            "geographical_area_id": "BZ"
+          },
+          {
+            "id": "CA",
+            "description": "Canada",
+            "geographical_area_id": "CA"
+          },
+          {
+            "id": "CC",
+            "description": "Cocos (Keeling) Islands",
+            "geographical_area_id": "CC"
+          },
+          {
+            "id": "CD",
+            "description": "Congo (Democratic Republic)",
+            "geographical_area_id": "CD"
+          },
+          {
+            "id": "CF",
+            "description": "Central African Republic",
+            "geographical_area_id": "CF"
+          },
+          {
+            "id": "CG",
+            "description": "Congo",
+            "geographical_area_id": "CG"
+          },
+          {
+            "id": "CH",
+            "description": "Switzerland",
+            "geographical_area_id": "CH"
+          },
+          {
+            "id": "CI",
+            "description": "Ivory Coast",
+            "geographical_area_id": "CI"
+          },
+          {
+            "id": "CK",
+            "description": "Cook Islands",
+            "geographical_area_id": "CK"
+          },
+          {
+            "id": "CL",
+            "description": "Chile",
+            "geographical_area_id": "CL"
+          },
+          {
+            "id": "CM",
+            "description": "Cameroon",
+            "geographical_area_id": "CM"
+          },
+          {
+            "id": "CN",
+            "description": "China",
+            "geographical_area_id": "CN"
+          },
+          {
+            "id": "CO",
+            "description": "Colombia",
+            "geographical_area_id": "CO"
+          },
+          {
+            "id": "CR",
+            "description": "Costa Rica",
+            "geographical_area_id": "CR"
+          },
+          {
+            "id": "CU",
+            "description": "Cuba",
+            "geographical_area_id": "CU"
+          },
+          {
+            "id": "CV",
+            "description": "Cabo Verde",
+            "geographical_area_id": "CV"
+          },
+          {
+            "id": "CW",
+            "description": "Curaçao",
+            "geographical_area_id": "CW"
+          },
+          {
+            "id": "CX",
+            "description": "Christmas Island",
+            "geographical_area_id": "CX"
+          },
+          {
+            "id": "CY",
+            "description": "Cyprus",
+            "geographical_area_id": "CY"
+          },
+          {
+            "id": "CZ",
+            "description": "Czechia",
+            "geographical_area_id": "CZ"
+          },
+          {
+            "id": "DE",
+            "description": "Germany",
+            "geographical_area_id": "DE"
+          },
+          {
+            "id": "DJ",
+            "description": "Djibouti",
+            "geographical_area_id": "DJ"
+          },
+          {
+            "id": "DK",
+            "description": "Denmark",
+            "geographical_area_id": "DK"
+          },
+          {
+            "id": "DM",
+            "description": "Dominica",
+            "geographical_area_id": "DM"
+          },
+          {
+            "id": "DO",
+            "description": "Dominican Republic",
+            "geographical_area_id": "DO"
+          },
+          {
+            "id": "DZ",
+            "description": "Algeria",
+            "geographical_area_id": "DZ"
+          },
+          {
+            "id": "EC",
+            "description": "Ecuador",
+            "geographical_area_id": "EC"
+          },
+          {
+            "id": "EE",
+            "description": "Estonia",
+            "geographical_area_id": "EE"
+          },
+          {
+            "id": "EG",
+            "description": "Egypt",
+            "geographical_area_id": "EG"
+          },
+          {
+            "id": "EH",
+            "description": "Western Sahara",
+            "geographical_area_id": "EH"
+          },
+          {
+            "id": "ER",
+            "description": "Eritrea",
+            "geographical_area_id": "ER"
+          },
+          {
+            "id": "ES",
+            "description": "Spain",
+            "geographical_area_id": "ES"
+          },
+          {
+            "id": "ET",
+            "description": "Ethiopia",
+            "geographical_area_id": "ET"
+          },
+          {
+            "id": "EU",
+            "description": "European Union",
+            "geographical_area_id": "EU"
+          },
+          {
+            "id": "FI",
+            "description": "Finland",
+            "geographical_area_id": "FI"
+          },
+          {
+            "id": "FJ",
+            "description": "Fiji",
+            "geographical_area_id": "FJ"
+          },
+          {
+            "id": "FK",
+            "description": "Falkland Islands",
+            "geographical_area_id": "FK"
+          },
+          {
+            "id": "FM",
+            "description": "Micronesia",
+            "geographical_area_id": "FM"
+          },
+          {
+            "id": "FO",
+            "description": "Faroe Islands",
+            "geographical_area_id": "FO"
+          },
+          {
+            "id": "FR",
+            "description": "France",
+            "geographical_area_id": "FR"
+          },
+          {
+            "id": "GA",
+            "description": "Gabon",
+            "geographical_area_id": "GA"
+          },
+          {
+            "id": "GB",
+            "description": "United Kingdom",
+            "geographical_area_id": "GB"
+          },
+          {
+            "id": "GD",
+            "description": "Grenada",
+            "geographical_area_id": "GD"
+          },
+          {
+            "id": "GE",
+            "description": "Georgia",
+            "geographical_area_id": "GE"
+          },
+          {
+            "id": "GH",
+            "description": "Ghana",
+            "geographical_area_id": "GH"
+          },
+          {
+            "id": "GI",
+            "description": "Gibraltar",
+            "geographical_area_id": "GI"
+          },
+          {
+            "id": "GL",
+            "description": "Greenland",
+            "geographical_area_id": "GL"
+          },
+          {
+            "id": "GM",
+            "description": "The Gambia",
+            "geographical_area_id": "GM"
+          },
+          {
+            "id": "GN",
+            "description": "Guinea",
+            "geographical_area_id": "GN"
+          },
+          {
+            "id": "GQ",
+            "description": "Equatorial Guinea",
+            "geographical_area_id": "GQ"
+          },
+          {
+            "id": "GR",
+            "description": "Greece",
+            "geographical_area_id": "GR"
+          },
+          {
+            "id": "GS",
+            "description": "South Georgia and South Sandwich Islands",
+            "geographical_area_id": "GS"
+          },
+          {
+            "id": "GT",
+            "description": "Guatemala",
+            "geographical_area_id": "GT"
+          },
+          {
+            "id": "GU",
+            "description": "Guam",
+            "geographical_area_id": "GU"
+          },
+          {
+            "id": "GW",
+            "description": "Guinea-Bissau",
+            "geographical_area_id": "GW"
+          },
+          {
+            "id": "GY",
+            "description": "Guyana",
+            "geographical_area_id": "GY"
+          },
+          {
+            "id": "HK",
+            "description": "Hong Kong",
+            "geographical_area_id": "HK"
+          },
+          {
+            "id": "HM",
+            "description": "Heard Island and McDonald Islands",
+            "geographical_area_id": "HM"
+          },
+          {
+            "id": "HN",
+            "description": "Honduras",
+            "geographical_area_id": "HN"
+          },
+          {
+            "id": "HR",
+            "description": "Croatia",
+            "geographical_area_id": "HR"
+          },
+          {
+            "id": "HT",
+            "description": "Haiti",
+            "geographical_area_id": "HT"
+          },
+          {
+            "id": "HU",
+            "description": "Hungary",
+            "geographical_area_id": "HU"
+          },
+          {
+            "id": "ID",
+            "description": "Indonesia",
+            "geographical_area_id": "ID"
+          },
+          {
+            "id": "IE",
+            "description": "Ireland",
+            "geographical_area_id": "IE"
+          },
+          {
+            "id": "IL",
+            "description": "Israel",
+            "geographical_area_id": "IL"
+          },
+          {
+            "id": "IN",
+            "description": "India",
+            "geographical_area_id": "IN"
+          },
+          {
+            "id": "IO",
+            "description": "British Indian Ocean Territory",
+            "geographical_area_id": "IO"
+          },
+          {
+            "id": "IQ",
+            "description": "Iraq",
+            "geographical_area_id": "IQ"
+          },
+          {
+            "id": "IR",
+            "description": "Iran",
+            "geographical_area_id": "IR"
+          },
+          {
+            "id": "IS",
+            "description": "Iceland",
+            "geographical_area_id": "IS"
+          },
+          {
+            "id": "IT",
+            "description": "Italy",
+            "geographical_area_id": "IT"
+          },
+          {
+            "id": "JM",
+            "description": "Jamaica",
+            "geographical_area_id": "JM"
+          },
+          {
+            "id": "JO",
+            "description": "Jordan",
+            "geographical_area_id": "JO"
+          },
+          {
+            "id": "JP",
+            "description": "Japan",
+            "geographical_area_id": "JP"
+          },
+          {
+            "id": "KE",
+            "description": "Kenya",
+            "geographical_area_id": "KE"
+          },
+          {
+            "id": "KG",
+            "description": "Kyrgyzstan",
+            "geographical_area_id": "KG"
+          },
+          {
+            "id": "KH",
+            "description": "Cambodia",
+            "geographical_area_id": "KH"
+          },
+          {
+            "id": "KI",
+            "description": "Kiribati",
+            "geographical_area_id": "KI"
+          },
+          {
+            "id": "KM",
+            "description": "Comoros",
+            "geographical_area_id": "KM"
+          },
+          {
+            "id": "KN",
+            "description": "St Kitts and Nevis",
+            "geographical_area_id": "KN"
+          },
+          {
+            "id": "KP",
+            "description": "North Korea",
+            "geographical_area_id": "KP"
+          },
+          {
+            "id": "KR",
+            "description": "South Korea",
+            "geographical_area_id": "KR"
+          },
+          {
+            "id": "KW",
+            "description": "Kuwait",
+            "geographical_area_id": "KW"
+          },
+          {
+            "id": "KY",
+            "description": "Cayman Islands",
+            "geographical_area_id": "KY"
+          },
+          {
+            "id": "KZ",
+            "description": "Kazakhstan",
+            "geographical_area_id": "KZ"
+          },
+          {
+            "id": "LA",
+            "description": "Laos",
+            "geographical_area_id": "LA"
+          },
+          {
+            "id": "LB",
+            "description": "Lebanon",
+            "geographical_area_id": "LB"
+          },
+          {
+            "id": "LC",
+            "description": "St Lucia",
+            "geographical_area_id": "LC"
+          },
+          {
+            "id": "LI",
+            "description": "Liechtenstein",
+            "geographical_area_id": "LI"
+          },
+          {
+            "id": "LK",
+            "description": "Sri Lanka",
+            "geographical_area_id": "LK"
+          },
+          {
+            "id": "LR",
+            "description": "Liberia",
+            "geographical_area_id": "LR"
+          },
+          {
+            "id": "LS",
+            "description": "Lesotho",
+            "geographical_area_id": "LS"
+          },
+          {
+            "id": "LT",
+            "description": "Lithuania",
+            "geographical_area_id": "LT"
+          },
+          {
+            "id": "LU",
+            "description": "Luxembourg",
+            "geographical_area_id": "LU"
+          },
+          {
+            "id": "LV",
+            "description": "Latvia",
+            "geographical_area_id": "LV"
+          },
+          {
+            "id": "LY",
+            "description": "Libya",
+            "geographical_area_id": "LY"
+          },
+          {
+            "id": "MA",
+            "description": "Morocco",
+            "geographical_area_id": "MA"
+          },
+          {
+            "id": "MD",
+            "description": "Moldova",
+            "geographical_area_id": "MD"
+          },
+          {
+            "id": "ME",
+            "description": "Montenegro",
+            "geographical_area_id": "ME"
+          },
+          {
+            "id": "MG",
+            "description": "Madagascar",
+            "geographical_area_id": "MG"
+          },
+          {
+            "id": "MH",
+            "description": "Marshall Islands",
+            "geographical_area_id": "MH"
+          },
+          {
+            "id": "MK",
+            "description": "North Macedonia",
+            "geographical_area_id": "MK"
+          },
+          {
+            "id": "ML",
+            "description": "Mali",
+            "geographical_area_id": "ML"
+          },
+          {
+            "id": "MM",
+            "description": "Myanmar (Burma)",
+            "geographical_area_id": "MM"
+          },
+          {
+            "id": "MN",
+            "description": "Mongolia",
+            "geographical_area_id": "MN"
+          },
+          {
+            "id": "MO",
+            "description": "Macao",
+            "geographical_area_id": "MO"
+          },
+          {
+            "id": "MP",
+            "description": "Northern Mariana Islands",
+            "geographical_area_id": "MP"
+          },
+          {
+            "id": "MR",
+            "description": "Mauritania",
+            "geographical_area_id": "MR"
+          },
+          {
+            "id": "MS",
+            "description": "Montserrat",
+            "geographical_area_id": "MS"
+          },
+          {
+            "id": "MT",
+            "description": "Malta",
+            "geographical_area_id": "MT"
+          },
+          {
+            "id": "MU",
+            "description": "Mauritius",
+            "geographical_area_id": "MU"
+          },
+          {
+            "id": "MV",
+            "description": "Maldives",
+            "geographical_area_id": "MV"
+          },
+          {
+            "id": "MW",
+            "description": "Malawi",
+            "geographical_area_id": "MW"
+          },
+          {
+            "id": "MX",
+            "description": "Mexico",
+            "geographical_area_id": "MX"
+          },
+          {
+            "id": "MY",
+            "description": "Malaysia",
+            "geographical_area_id": "MY"
+          },
+          {
+            "id": "MZ",
+            "description": "Mozambique",
+            "geographical_area_id": "MZ"
+          },
+          {
+            "id": "NA",
+            "description": "Namibia",
+            "geographical_area_id": "NA"
+          },
+          {
+            "id": "NC",
+            "description": "New Caledonia",
+            "geographical_area_id": "NC"
+          },
+          {
+            "id": "NE",
+            "description": "Niger",
+            "geographical_area_id": "NE"
+          },
+          {
+            "id": "NF",
+            "description": "Norfolk Island",
+            "geographical_area_id": "NF"
+          },
+          {
+            "id": "NG",
+            "description": "Nigeria",
+            "geographical_area_id": "NG"
+          },
+          {
+            "id": "NI",
+            "description": "Nicaragua",
+            "geographical_area_id": "NI"
+          },
+          {
+            "id": "NL",
+            "description": "Netherlands",
+            "geographical_area_id": "NL"
+          },
+          {
+            "id": "NO",
+            "description": "Norway",
+            "geographical_area_id": "NO"
+          },
+          {
+            "id": "NP",
+            "description": "Nepal",
+            "geographical_area_id": "NP"
+          },
+          {
+            "id": "NR",
+            "description": "Nauru",
+            "geographical_area_id": "NR"
+          },
+          {
+            "id": "NU",
+            "description": "Niue",
+            "geographical_area_id": "NU"
+          },
+          {
+            "id": "NZ",
+            "description": "New Zealand",
+            "geographical_area_id": "NZ"
+          },
+          {
+            "id": "OM",
+            "description": "Oman",
+            "geographical_area_id": "OM"
+          },
+          {
+            "id": "PA",
+            "description": "Panama",
+            "geographical_area_id": "PA"
+          },
+          {
+            "id": "PE",
+            "description": "Peru",
+            "geographical_area_id": "PE"
+          },
+          {
+            "id": "PF",
+            "description": "French Polynesia",
+            "geographical_area_id": "PF"
+          },
+          {
+            "id": "PG",
+            "description": "Papua New Guinea",
+            "geographical_area_id": "PG"
+          },
+          {
+            "id": "PH",
+            "description": "Philippines",
+            "geographical_area_id": "PH"
+          },
+          {
+            "id": "PK",
+            "description": "Pakistan",
+            "geographical_area_id": "PK"
+          },
+          {
+            "id": "PL",
+            "description": "Poland",
+            "geographical_area_id": "PL"
+          },
+          {
+            "id": "PM",
+            "description": "Saint Pierre and Miquelon",
+            "geographical_area_id": "PM"
+          },
+          {
+            "id": "PN",
+            "description": "Pitcairn, Henderson, Ducie and Oeno Islands",
+            "geographical_area_id": "PN"
+          },
+          {
+            "id": "PS",
+            "description": "Occupied Palestinian Territories",
+            "geographical_area_id": "PS"
+          },
+          {
+            "id": "PT",
+            "description": "Portugal",
+            "geographical_area_id": "PT"
+          },
+          {
+            "id": "PW",
+            "description": "Palau",
+            "geographical_area_id": "PW"
+          },
+          {
+            "id": "PY",
+            "description": "Paraguay",
+            "geographical_area_id": "PY"
+          },
+          {
+            "id": "QA",
+            "description": "Qatar",
+            "geographical_area_id": "QA"
+          },
+          {
+            "id": "QP",
+            "description": "High seas (Maritime domain outside of territorial waters)",
+            "geographical_area_id": "QP"
+          },
+          {
+            "id": "QQ",
+            "description": "Stores and provisions",
+            "geographical_area_id": "QQ"
+          },
+          {
+            "id": "QS",
+            "description": "Stores and provisions within the framework of trade with Third Countries",
+            "geographical_area_id": "QS"
+          },
+          {
+            "id": "QU",
+            "description": "Countries and territories not specified",
+            "geographical_area_id": "QU"
+          },
+          {
+            "id": "QW",
+            "description": "Countries and territories not specified within the framework of trade with third countries",
+            "geographical_area_id": "QW"
+          },
+          {
+            "id": "RO",
+            "description": "Romania",
+            "geographical_area_id": "RO"
+          },
+          {
+            "id": "RU",
+            "description": "Russia",
+            "geographical_area_id": "RU"
+          },
+          {
+            "id": "RW",
+            "description": "Rwanda",
+            "geographical_area_id": "RW"
+          },
+          {
+            "id": "SA",
+            "description": "Saudi Arabia",
+            "geographical_area_id": "SA"
+          },
+          {
+            "id": "SB",
+            "description": "Solomon Islands",
+            "geographical_area_id": "SB"
+          },
+          {
+            "id": "SC",
+            "description": "Seychelles",
+            "geographical_area_id": "SC"
+          },
+          {
+            "id": "SD",
+            "description": "Sudan",
+            "geographical_area_id": "SD"
+          },
+          {
+            "id": "SE",
+            "description": "Sweden",
+            "geographical_area_id": "SE"
+          },
+          {
+            "id": "SG",
+            "description": "Singapore",
+            "geographical_area_id": "SG"
+          },
+          {
+            "id": "SH",
+            "description": "Saint Helena, Ascension and Tristan da Cunha",
+            "geographical_area_id": "SH"
+          },
+          {
+            "id": "SI",
+            "description": "Slovenia",
+            "geographical_area_id": "SI"
+          },
+          {
+            "id": "SK",
+            "description": "Slovakia",
+            "geographical_area_id": "SK"
+          },
+          {
+            "id": "SL",
+            "description": "Sierra Leone",
+            "geographical_area_id": "SL"
+          },
+          {
+            "id": "SM",
+            "description": "San Marino",
+            "geographical_area_id": "SM"
+          },
+          {
+            "id": "SN",
+            "description": "Senegal",
+            "geographical_area_id": "SN"
+          },
+          {
+            "id": "SO",
+            "description": "Somalia",
+            "geographical_area_id": "SO"
+          },
+          {
+            "id": "SR",
+            "description": "Suriname",
+            "geographical_area_id": "SR"
+          },
+          {
+            "id": "SS",
+            "description": "South Sudan",
+            "geographical_area_id": "SS"
+          },
+          {
+            "id": "ST",
+            "description": "Sao Tome and Principe",
+            "geographical_area_id": "ST"
+          },
+          {
+            "id": "SV",
+            "description": "El Salvador",
+            "geographical_area_id": "SV"
+          },
+          {
+            "id": "SX",
+            "description": "Sint Maarten (Dutch part)",
+            "geographical_area_id": "SX"
+          },
+          {
+            "id": "SY",
+            "description": "Syria",
+            "geographical_area_id": "SY"
+          },
+          {
+            "id": "SZ",
+            "description": "Eswatini",
+            "geographical_area_id": "SZ"
+          },
+          {
+            "id": "TC",
+            "description": "Turks and Caicos Islands",
+            "geographical_area_id": "TC"
+          },
+          {
+            "id": "TD",
+            "description": "Chad",
+            "geographical_area_id": "TD"
+          },
+          {
+            "id": "TF",
+            "description": "French Southern Territories",
+            "geographical_area_id": "TF"
+          },
+          {
+            "id": "TG",
+            "description": "Togo",
+            "geographical_area_id": "TG"
+          },
+          {
+            "id": "TH",
+            "description": "Thailand",
+            "geographical_area_id": "TH"
+          },
+          {
+            "id": "TJ",
+            "description": "Tajikistan",
+            "geographical_area_id": "TJ"
+          },
+          {
+            "id": "TK",
+            "description": "Tokelau",
+            "geographical_area_id": "TK"
+          },
+          {
+            "id": "TL",
+            "description": "East Timor",
+            "geographical_area_id": "TL"
+          },
+          {
+            "id": "TM",
+            "description": "Turkmenistan",
+            "geographical_area_id": "TM"
+          },
+          {
+            "id": "TN",
+            "description": "Tunisia",
+            "geographical_area_id": "TN"
+          },
+          {
+            "id": "TO",
+            "description": "Tonga",
+            "geographical_area_id": "TO"
+          },
+          {
+            "id": "TR",
+            "description": "Turkey",
+            "geographical_area_id": "TR"
+          },
+          {
+            "id": "TT",
+            "description": "Trinidad and Tobago",
+            "geographical_area_id": "TT"
+          },
+          {
+            "id": "TV",
+            "description": "Tuvalu",
+            "geographical_area_id": "TV"
+          },
+          {
+            "id": "TW",
+            "description": "Taiwan",
+            "geographical_area_id": "TW"
+          },
+          {
+            "id": "TZ",
+            "description": "Tanzania",
+            "geographical_area_id": "TZ"
+          },
+          {
+            "id": "UA",
+            "description": "Ukraine",
+            "geographical_area_id": "UA"
+          },
+          {
+            "id": "UG",
+            "description": "Uganda",
+            "geographical_area_id": "UG"
+          },
+          {
+            "id": "UM",
+            "description": "United States Minor Outlying Islands",
+            "geographical_area_id": "UM"
+          },
+          {
+            "id": "US",
+            "description": "United States",
+            "geographical_area_id": "US"
+          },
+          {
+            "id": "UY",
+            "description": "Uruguay",
+            "geographical_area_id": "UY"
+          },
+          {
+            "id": "UZ",
+            "description": "Uzbekistan",
+            "geographical_area_id": "UZ"
+          },
+          {
+            "id": "VA",
+            "description": "Vatican City",
+            "geographical_area_id": "VA"
+          },
+          {
+            "id": "VC",
+            "description": "St Vincent",
+            "geographical_area_id": "VC"
+          },
+          {
+            "id": "VE",
+            "description": "Venezuela",
+            "geographical_area_id": "VE"
+          },
+          {
+            "id": "VG",
+            "description": "British Virgin Islands",
+            "geographical_area_id": "VG"
+          },
+          {
+            "id": "VI",
+            "description": "United States Virgin Islands",
+            "geographical_area_id": "VI"
+          },
+          {
+            "id": "VN",
+            "description": "Vietnam",
+            "geographical_area_id": "VN"
+          },
+          {
+            "id": "VU",
+            "description": "Vanuatu",
+            "geographical_area_id": "VU"
+          },
+          {
+            "id": "WF",
+            "description": "Wallis and Futuna",
+            "geographical_area_id": "WF"
+          },
+          {
+            "id": "WS",
+            "description": "Samoa",
+            "geographical_area_id": "WS"
+          },
+          {
+            "id": "XC",
+            "description": "Ceuta",
+            "geographical_area_id": "XC"
+          },
+          {
+            "id": "XK",
+            "description": "Kosovo",
+            "geographical_area_id": "XK"
+          },
+          {
+            "id": "XL",
+            "description": "Melilla",
+            "geographical_area_id": "XL"
+          },
+          {
+            "id": "XS",
+            "description": "Serbia",
+            "geographical_area_id": "XS"
+          },
+          {
+            "id": "YE",
+            "description": "Yemen",
+            "geographical_area_id": "YE"
+          },
+          {
+            "id": "ZA",
+            "description": "South Africa",
+            "geographical_area_id": "ZA"
+          },
+          {
+            "id": "ZB",
+            "description": "Belgian Continental Shelf",
+            "geographical_area_id": "ZB"
+          },
+          {
+            "id": "ZD",
+            "description": "Danish Continental Shelf",
+            "geographical_area_id": "ZD"
+          },
+          {
+            "id": "ZE",
+            "description": "Irish Continental Shelf",
+            "geographical_area_id": "ZE"
+          },
+          {
+            "id": "ZF",
+            "description": "French Continental Shelf",
+            "geographical_area_id": "ZF"
+          },
+          {
+            "id": "ZG",
+            "description": "German Continental Shelf",
+            "geographical_area_id": "ZG"
+          },
+          {
+            "id": "ZH",
+            "description": "Netherlands Continental Shelf",
+            "geographical_area_id": "ZH"
+          },
+          {
+            "id": "ZM",
+            "description": "Zambia",
+            "geographical_area_id": "ZM"
+          },
+          {
+            "id": "ZN",
+            "description": "Norwegian Continental Shelf",
+            "geographical_area_id": "ZN"
+          },
+          {
+            "id": "ZU",
+            "description": "United Kingdom Continental Shelf",
+            "geographical_area_id": "ZU"
+          },
+          {
+            "id": "ZW",
+            "description": "Zimbabwe",
+            "geographical_area_id": "ZW"
+          }
+        ]
+      },
+      "excluded_countries": [
+
+      ],
+      "footnotes": [
+        {
+          "code": "CD808",
+          "description": "If goods bear a reference to organic production in the labelling, advertising or accompanying documents, the declarant has to present the certificate of inspection C644 as referred to in the Article 33(1)(d) of the Regulation (EC) No 834/2007 (equivalent products). If the goods are not equivalent products, code Y929 must be declared.<br>Without prejudice to any measures or actions taken in accordance with Article 30 of Regulation (EC) No 834/2007 and/or Article 85 of Regulation (EC) No 889/2008, the release for free circulation in the Community of products not in conformity with the requirements of that Regulation shall be conditional on the removal of references to organic production from the labelling, advertising and accompanying documents.<br>",
+          "formatted_description": "If goods bear a reference to organic production in the labelling, advertising or accompanying documents, the declarant has to present the certificate of inspection C644 as referred to in the Article 33(1)(d) of the Regulation (EC) No 834/2007 (equivalent products). If the goods are not equivalent products, code Y929 must be declared.<br>Without prejudice to any measures or actions taken in accordance with Article 30 of Regulation (EC) No 834/2007 and/or Article 85 of Regulation (EC) No 889/2008, the release for free circulation in the Community of products not in conformity with the requirements of that Regulation shall be conditional on the removal of references to organic production from the labelling, advertising and accompanying documents.<br>"
+        }
+      ],
+      "order_number": null,
+      "resolved_measure_components": [
+
+      ],
+      "resolved_duty_expression": ""
+    },
+    {
+      "meta": {
+        "duty_calculator": {
+          "source": "uk"
+        }
+      },
+      "id": 20097836,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "duty_expression": {
+        "base": "",
+        "formatted_base": ""
+      },
+      "measure_type": {
+        "description": "Import control of organic products",
+        "national": null,
+        "measure_type_series_id": "B",
+        "id": "105"
+      },
+      "legal_acts": [
+        {
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2019-03-26",
+          "regulation_code": "X0693/19",
+          "regulation_url": "http://eur-lex.europa.eu/search.html?whOJ=NO_OJ%3D,YEAR_OJ%3D2019,PAGE_FIRST%3D0001&DB_COLL_OJ=oj-1&type=advanced&lang=en"
+        }
+      ],
+      "measure_conditions": [
+        {
+          "condition_code": "B",
+          "condition": "B: Presentation of a certificate/licence/document",
           "document_code": "C644",
           "requirement": "Other certificates: Certificate of inspection for organic products",
           "action": "Import/export allowed after control",

--- a/spec/services/applicable_document_codes_service_spec.rb
+++ b/spec/services/applicable_document_codes_service_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe ApplicableDocumentCodesService, :user_session do
           'uk' => {
             '105' => [
               { code: 'C644', description: 'C644 - ' },
+              { code: 'C655', description: 'C655 - ' },
               { code: 'Y929', description: 'Y929 - ' },
               { code: 'None', description: 'None of the above' },
             ],
@@ -34,6 +35,7 @@ RSpec.describe ApplicableDocumentCodesService, :user_session do
           'xi' => {
             '105' => [
               { code: 'C644', description: 'C644 - ' },
+              { code: 'C655', description: 'C655 - ' },
               { code: 'Y929', description: 'Y929 - ' },
               { code: 'None', description: 'None of the above' },
             ],
@@ -85,6 +87,7 @@ RSpec.describe ApplicableDocumentCodesService, :user_session do
           'xi' => {
             '105' => [
               { code: 'C644', description: 'C644 - ' },
+              { code: 'C655', description: 'C655 - ' },
               { code: 'Y929', description: 'Y929 - ' },
               { code: 'None', description: 'None of the above' },
             ],
@@ -136,6 +139,7 @@ RSpec.describe ApplicableDocumentCodesService, :user_session do
           'uk' => {
             '105' => [
               { code: 'C644', description: 'C644 - ' },
+              { code: 'C655', description: 'C655 - ' },
               { code: 'Y929', description: 'Y929 - ' },
               { code: 'None', description: 'None of the above' },
             ],


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1109

### What?

I have added/removed/altered:

- [x] Altered the document codes service to make sure document codes for a given measure type id are unique, ordered and with the last option always being 'None'
- [x] Updated the specs to reflect this

**Before**

![Screenshot from 2021-11-30 11-23-15](https://user-images.githubusercontent.com/8156884/144038761-9c855bab-02cf-40cb-bd0d-13329b5741ad.png)

**After**

![Screenshot from 2021-11-30 11-28-01](https://user-images.githubusercontent.com/8156884/144039377-66916f3b-d802-4b21-94ae-fcb7f671f9ce.png)

### Why?

I am doing this because:

- This commodity for Norway https://staging.trade-tariff.service.gov.uk/xi/commodities/1905320500?country=NO#import
shows up two None options that aren't at the end of the list and presents incorrectly in the UI
