### PR TITLE
HOTT-1143: Upgrade to supported sentry-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'logstash-event'
 gem 'newrelic_rpm'
 gem 'puma'
 gem 'railties', '~> 6'
-gem 'sentry-raven'
+gem 'sentry-rails'
 gem 'uktt', git: 'https://github.com/trade-tariff/uktt.git'
 gem 'webpacker'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,8 +212,12 @@ GEM
     scss_lint-govuk (0.2.0)
       scss_lint
     semantic_range (3.0.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (4.8.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.8.1)
+    sentry-ruby-core (4.8.1)
+      concurrent-ruby
+      faraday
     shoulda-matchers (5.0.0)
       activesupport (>= 5.2.0)
     simplecov (0.21.2)
@@ -270,7 +274,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-govuk
   scss_lint-govuk
-  sentry-raven
+  sentry-rails
   shoulda-matchers
   simplecov
   spring

--- a/app/controllers/steps/base_controller.rb
+++ b/app/controllers/steps/base_controller.rb
@@ -53,7 +53,7 @@ module Steps
     end
 
     def handle_exception(exception)
-      Raven.user_context(user_session.session.to_h.except('_csrf_token'))
+      Sentry.set_user(user_session.session.to_h.except('_csrf_token'))
       track_session
 
       raise exception

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+Sentry.init do |config|
+  config.rails.report_rescued_exceptions = true
+
+  config.breadcrumbs_logger = [:active_support_logger]
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  config.rails.report_rescued_exceptions = true
+  config.rails.report_rescued_exceptions = false
 
   config.breadcrumbs_logger = [:active_support_logger]
 end

--- a/lib/sentry/rails/background_worker.rb
+++ b/lib/sentry/rails/background_worker.rb
@@ -1,0 +1,7 @@
+module Sentry
+  class BackgroundWorker
+    def _perform(&block)
+      block.call
+    end
+  end
+end

--- a/spec/controllers/steps/base_controller_spec.rb
+++ b/spec/controllers/steps/base_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Steps::BaseController, :user_session do
 
   before do
     allow(NewRelic::Agent).to receive(:add_custom_attributes).and_call_original
-    allow(Raven).to receive(:user_context)
+    allow(Sentry).to receive(:set_user)
     allow(Rails.configuration).to receive(:trade_tariff_frontend_url).and_return(trade_tariff_host)
   end
 
@@ -61,7 +61,7 @@ RSpec.describe Steps::BaseController, :user_session do
     it 'adds session context for the user on error' do
       response
     rescue ArgumentError
-      expect(Raven).to have_received(:user_context).with(user_session.session.to_h.except('_csrf_token'))
+      expect(Sentry).to have_received(:set_user).with(user_session.session.to_h.except('_csrf_token'))
     end
 
     it 'sends custom attributes to NewRelic' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1143

### What?

I have added/removed/altered:

- [x] Move from the old sentry-raven gem to the sentry-rails gem

### Why?

I am doing this because:

- The old one is out of support even for bug fixes
