### PR TITLE
HOTT-1182: Handle compound measure units

### DIFF
--- a/app/models/api/base_component.rb
+++ b/app/models/api/base_component.rb
@@ -1,7 +1,11 @@
 module Api
   class BaseComponent < Api::Base
     CONJUNCTION_OPERATORS = %w[MAX MIN].freeze
+    COMPOUND_MEASURE_UNITS = %w[ASVX].freeze
     MATHEMATICAL_OPERATORS = %w[+ -].freeze
+
+    VOLUME_UNIT = 'HLT'.freeze
+    ALCOHOL_UNIT = 'ASV'.freeze
 
     attributes :id,
                :duty_expression_id,
@@ -15,6 +19,11 @@ module Api
 
     enum :measurement_unit_code, {
       retail_price: %w[RET],
+    }
+
+    enum :monetary_unit_code, {
+      euros: %w[EUR],
+      pounds: %w[GBP],
     }
 
     enum :duty_expression_id, {
@@ -37,6 +46,10 @@ module Api
       return nil if measurement_unit_code.blank?
 
       "#{measurement_unit_code}#{measurement_unit_qualifier_code}"
+    end
+
+    def compound_measure_unit?
+      unit.in?(COMPOUND_MEASURE_UNITS)
     end
 
     def conjunction_operator?

--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -42,6 +42,8 @@ module Api
         ExpressionEvaluators::AdValorem.new(self, component)
       elsif retail_price?
         ExpressionEvaluators::RetailPrice.new(self, component)
+      elsif specific_duty? && component.compound_measure_unit?
+        ExpressionEvaluators::CompoundMeasureUnit.new(self, component)
       elsif specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, component)
       else
@@ -55,9 +57,10 @@ module Api
         ExpressionEvaluators::AdValorem.new(self, component)
       elsif component.retail_price?
         ExpressionEvaluators::RetailPrice.new(self, component)
+      elsif component.compound_measure_unit?
+        ExpressionEvaluators::CompoundMeasureUnit.new(self, component)
       elsif component.specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, component)
-
       end
     end
 

--- a/app/services/applicable_measure_unit_merger.rb
+++ b/app/services/applicable_measure_unit_merger.rb
@@ -2,7 +2,6 @@ class ApplicableMeasureUnitMerger
   include CommodityHelper
 
   UNHANDLED_MEASURE_UNITS = %w[
-    ASV
     FC1X
   ].freeze
 

--- a/app/services/concerns/measure_unit_presentable.rb
+++ b/app/services/concerns/measure_unit_presentable.rb
@@ -9,6 +9,12 @@ module MeasureUnitPresentable
   end
 
   def applicable_unit
-    ApplicableMeasureUnitMerger.new.call[component.unit]
+    applicable_units[component.unit]
+  end
+
+  private
+
+  def applicable_units
+    ApplicableMeasureUnitMerger.new.call
   end
 end

--- a/app/services/expression_evaluators/compound_measure_unit.rb
+++ b/app/services/expression_evaluators/compound_measure_unit.rb
@@ -1,0 +1,76 @@
+module ExpressionEvaluators
+  class CompoundMeasureUnit < ExpressionEvaluators::Base
+    include MeasureUnitPresentable
+
+    def call
+      {
+        calculation: calculation_duty_expression,
+        value: value,
+        formatted_value: number_to_currency(value),
+      }
+    end
+
+    private
+
+    def calculation_duty_expression
+      expression =
+        if measure_condition.present?
+          measure_condition.duty_expression
+        else
+          measure.duty_expression.formatted_base
+        end
+
+      sanitize(expression, tags: %w[span abbr], attributes: %w[title])
+    end
+
+    def value
+      return component.duty_amount * alcohol_quantity * volume_quantity * euro_exchange_rate if component.euros?
+
+      component.duty_amount * alcohol_quantity * volume_quantity
+    end
+
+    def alcohol_quantity
+      presented_alcohol_unit[:answer].to_f
+    end
+
+    def volume_quantity
+      presented_volume_unit[:answer].to_f
+    end
+
+    def alcohol_unit
+      applicable_units[Api::BaseComponent::ALCOHOL_UNIT]
+    end
+
+    def volume_unit
+      applicable_units[Api::BaseComponent::VOLUME_UNIT]
+    end
+
+    def presented_alcohol_unit
+      @presented_alcohol_unit ||= {
+        answer: user_session.measure_amount[Api::BaseComponent::ALCOHOL_UNIT.downcase],
+        unit: alcohol_unit['unit'],
+      }
+    end
+
+    def presented_volume_unit
+      @presented_volume_unit ||= {
+        answer: user_session.measure_amount[Api::BaseComponent::VOLUME_UNIT.downcase],
+        unit: volume_unit['unit'],
+      }
+    end
+
+    def measure_condition
+      return nil if component.is_a?(Api::MeasureComponent)
+
+      measure.measure_conditions.find do |measure_condition|
+        measure_condition.measure_condition_components.any? do |measure_condition_component|
+          measure_condition_component.eql?(component)
+        end
+      end
+    end
+
+    def euro_exchange_rate
+      Api::MonetaryExchangeRate.for('GBP').exchange_rate
+    end
+  end
+end

--- a/app/services/expression_evaluators/measure_unit.rb
+++ b/app/services/expression_evaluators/measure_unit.rb
@@ -34,7 +34,7 @@ module ExpressionEvaluators
 
     def value
       @value ||= begin
-        return total_quantity * component.duty_amount * eur_to_gbp_rate if duty_amount_in_eur?
+        return total_quantity * component.duty_amount * euro_exchange_rate if component.euros?
 
         total_quantity * component.duty_amount
       end
@@ -42,14 +42,6 @@ module ExpressionEvaluators
 
     def total_quantity
       presented_unit[:answer].to_f
-    end
-
-    def applicable_unit
-      ApplicableMeasureUnitMerger.new.call[component.unit]
-    end
-
-    def eur_to_gbp_rate
-      Api::MonetaryExchangeRate.for('GBP').exchange_rate
     end
 
     def duty_amount_in_eur?
@@ -64,6 +56,10 @@ module ExpressionEvaluators
           measure_condition_component.eql?(component)
         end
       end
+    end
+
+    def euro_exchange_rate
+      Api::MonetaryExchangeRate.for('GBP').euro_exchange_rate
     end
   end
 end

--- a/spec/factories/api/measure_component.rb
+++ b/spec/factories/api/measure_component.rb
@@ -27,6 +27,16 @@ FactoryBot.define do
       duty_expression_id { '01' }
     end
 
+    trait :single_measure_unit do
+      measurement_unit_code { 'DTN' }
+      measurement_unit_qualifier_code {}
+    end
+
+    trait :compound_measure_unit do
+      measurement_unit_code { 'ASV' }
+      measurement_unit_qualifier_code { 'X' }
+    end
+
     trait :with_retail_price_measure_units do
       duty_amount { 16.5 }
       measurement_unit_code { 'RET' }

--- a/spec/factories/user_session.rb
+++ b/spec/factories/user_session.rb
@@ -94,6 +94,10 @@ FactoryBot.define do
     measure_amount { { 'dtn' => '100' } }
   end
 
+  trait :with_compound_measure_amount do
+    measure_amount { { 'hlt' => '45', 'asv' => '40' } }
+  end
+
   trait :with_retail_price_measure_amount do
     measure_amount { { 'ret' => '1000' } }
   end

--- a/spec/fixtures/uk/commodities/2208403900.json
+++ b/spec/fixtures/uk/commodities/2208403900.json
@@ -1,0 +1,181 @@
+{
+  "id": "69078",
+  "producline_suffix": "80",
+  "description": "Other",
+  "number_indents": 4,
+  "goods_nomenclature_item_id": "2208403900",
+  "bti_url": "https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code",
+  "formatted_description": "Other",
+  "description_plain": "Other",
+  "consigned": false,
+  "consigned_from": null,
+  "basic_duty_rate": null,
+  "meursing_code": false,
+  "declarable": true,
+  "footnotes": [],
+  "section": {
+  },
+  "chapter": {
+  },
+  "heading": {
+  },
+  "ancestors": [
+  ],
+  "import_measures": [
+    {
+      "id": 20002828,
+      "origin": "eu",
+      "effective_start_date": "2021-01-01T00:00:00.000Z",
+      "effective_end_date": null,
+      "import": true,
+      "excise": false,
+      "vat": false,
+      "reduction_indicator": null,
+      "meursing": false,
+      "resolved_duty_expression": "",
+      "duty_expression": {
+        "id": "20002828-duty_expression",
+        "base": "0.50 GBP / % vol/hl + 2.60 GBP / hl",
+        "formatted_base": "<span>0.50</span> GBP / <abbr title='%vol'>% vol/hl</abbr> + <span>2.60</span> GBP / <abbr title='Hectolitre'>hl</abbr>",
+        "meta": null
+      },
+      "measure_type": {
+        "id": "103",
+        "description": "Third country duty",
+        "national": null,
+        "measure_type_series_id": "C",
+        "meta": null
+      },
+      "legal_acts": [
+        {
+          "id": "C2100001",
+          "validity_start_date": "2021-01-01T00:00:00.000Z",
+          "validity_end_date": null,
+          "officialjournal_number": "1",
+          "officialjournal_page": 1,
+          "published_date": "2021-01-01",
+          "regulation_code": "C0000/21",
+          "regulation_url": "",
+          "description": null,
+          "meta": null
+        }
+      ],
+      "measure_conditions": [
+
+      ],
+      "measure_components": [
+        {
+          "id": "20002828-01",
+          "duty_expression_id": "01",
+          "duty_amount": 0.5,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "ASV",
+          "measurement_unit_qualifier_code": "X",
+          "duty_expression_description": "% or amount",
+          "duty_expression_abbreviation": "%",
+          "measurement_unit": {
+            "id": "ASV",
+            "description": "%vol",
+            "measurement_unit_code": "ASV",
+            "meta": null
+          },
+          "meta": null
+        },
+        {
+          "id": "20002828-04",
+          "duty_expression_id": "04",
+          "duty_amount": 2.6,
+          "monetary_unit_code": "GBP",
+          "monetary_unit_abbreviation": null,
+          "measurement_unit_code": "HLT",
+          "measurement_unit_qualifier_code": null,
+          "duty_expression_description": "+ % or amount",
+          "duty_expression_abbreviation": "+",
+          "measurement_unit": {
+            "id": "HLT",
+            "description": "Hectolitre",
+            "measurement_unit_code": "HLT",
+            "meta": null
+          },
+          "meta": null
+        }
+      ],
+      "resolved_measure_components": [
+
+      ],
+      "national_measurement_units": [
+
+      ],
+      "geographical_area": {
+        "id": "1011",
+        "description": "ERGA OMNES",
+        "geographical_area_id": "1011",
+        "children_geographical_areas": [
+        ],
+        "meta": null
+      },
+      "excluded_countries": [ ],
+      "footnotes": [ ],
+      "order_number": null,
+      "meta": {
+        "duty_calculator": {
+          "source": "uk"
+        }
+      }
+    }
+  ],
+  "export_measures": [],
+  "meta": {
+    "duty_calculator": {
+      "applicable_additional_codes": {
+        "306": {
+          "measure_type_description": "Excises",
+          "heading": null,
+          "additional_codes": [
+            {
+              "code": "X451",
+              "overlay": "451 - Spirits other than UK-produced whisky",
+              "hint": "",
+              "measure_sid": -493334
+            }
+          ]
+        }
+      },
+      "applicable_measure_units": {
+        "ASV": {
+          "measurement_unit_code": "ASV",
+          "measurement_unit_qualifier_code": "",
+          "abbreviation": "% vol",
+          "unit_question": "What is the alcohol percentage (%) of the goods you are importing?",
+          "unit_hint": "Enter the alcohol by volume (ABV) percentage",
+          "unit": "percent"
+        },
+        "HLT": {
+          "measurement_unit_code": "HLT",
+          "measurement_unit_qualifier_code": "",
+          "abbreviation": "hl",
+          "unit_question": "What is the volume of the goods that you will be importing?",
+          "unit_hint": "Enter the value in hectolitres (100 litres)",
+          "unit": "x 100 litres"
+        },
+        "LPA": {
+          "measurement_unit_code": "LPA",
+          "measurement_unit_qualifier_code": "",
+          "abbreviation": "l alc. 100%",
+          "unit_question": "What is the volume of pure alcohol in the goods you will be importing?",
+          "unit_hint": "Enter the value in litres",
+          "unit": "litres"
+        }
+      },
+      "applicable_vat_options": {
+        "VAT": "Value added tax (20.0%)"
+      },
+      "entry_price_system": false,
+      "meursing_code": false,
+      "source": "uk",
+      "trade_defence": false,
+      "zero_mfn_duty": false
+    }
+  }
+}

--- a/spec/models/api/base_component_spec.rb
+++ b/spec/models/api/base_component_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Api::BaseComponent do
                   duty_expression_abbreviation: '%',
                   measurement_unit_qualifier_code: nil
 
+  it_behaves_like 'a resource that has an enum', :monetary_unit_code, {
+    euros: %w[EUR],
+    pounds: %w[GBP],
+  }
+
   it_behaves_like 'a resource that has an enum', :measurement_unit_code, {
     retail_price: %w[RET],
   }
@@ -87,6 +92,29 @@ RSpec.describe Api::BaseComponent do
       let(:measurement_unit_code) { nil }
 
       it { expect(component).to be_no_specific_duty }
+    end
+  end
+
+  describe '#compound_measure_unit?' do
+    subject(:component) do
+      described_class.new(
+        'measurement_unit_code' => measurement_unit_code,
+        'measurement_unit_qualifier_code' => measurement_unit_qualifier_code,
+      )
+    end
+
+    context 'when the unit is a compound unit' do
+      let(:measurement_unit_code) { 'ASV' }
+      let(:measurement_unit_qualifier_code) { 'X' }
+
+      it { expect(component).to be_compound_measure_unit }
+    end
+
+    context 'when the unit is not a compound unit' do
+      let(:measurement_unit_code) { 'ASV' }
+      let(:measurement_unit_qualifier_code) { '' }
+
+      it { expect(component).not_to be_compound_measure_unit }
     end
   end
 

--- a/spec/services/applicable_measure_unit_merger_spec.rb
+++ b/spec/services/applicable_measure_unit_merger_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe ApplicableMeasureUnitMerger, :user_session do
 
       let(:expected_units) do
         {
+          'ASV' => {
+            'measurement_unit_code' => 'ASV',
+            'measurement_unit_qualifier_code' => '',
+            'abbreviation' => '% vol',
+            'unit_question' => 'What is the alcohol percentage (%) of the goods you are importing?',
+            'unit_hint' => 'Enter the alcohol by volume (ABV) percentage',
+            'unit' => 'percent',
+          },
           'DTN' => {
             'measurement_unit_code' => 'DTN',
             'measurement_unit_qualifier_code' => '',
@@ -154,6 +162,14 @@ RSpec.describe ApplicableMeasureUnitMerger, :user_session do
 
       let(:expected_units) do
         {
+          'ASV' => {
+            'measurement_unit_code' => 'ASV',
+            'measurement_unit_qualifier_code' => '',
+            'abbreviation' => '% vol',
+            'unit_question' => 'What is the alcohol percentage (%) of the goods you are importing?',
+            'unit_hint' => 'Enter the alcohol by volume (ABV) percentage',
+            'unit' => 'percent',
+          },
           'DTN' => {
             'measurement_unit_code' => 'DTN',
             'measurement_unit_qualifier_code' => '',

--- a/spec/services/expression_evaluators/compound_measure_unit_spec.rb
+++ b/spec/services/expression_evaluators/compound_measure_unit_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe ExpressionEvaluators::CompoundMeasureUnit, :user_session do
+  subject(:evaluator) { described_class.new(measure, measure.component) }
+
+  let(:measure) do
+    build(
+      :measure,
+      :third_country_tariff,
+      measure_components: measure_components,
+      duty_expression: {
+        'formatted_base' => "<span>0.50</span> GBP / <abbr title='%vol'>% vol/hl</abbr> + <span>2.60</span> GBP / <abbr title='Hectolitre'>hl</abbr>",
+      },
+    )
+  end
+
+  let(:measure_components) do
+    [
+
+      {
+        'duty_amount' => 0.5,
+        'monetary_unit_code' => 'GBP',
+        'measurement_unit_code' => 'ASV',
+        'measurement_unit_qualifier_code' => 'X',
+      },
+    ]
+  end
+
+  let(:user_session) do
+    build(
+      :user_session,
+      :with_commodity_information,
+      :with_customs_value,
+      :with_compound_measure_amount,
+      commodity_code: '2208403900',
+    )
+  end
+
+  let(:expected_evaluation) do
+    {
+      calculation: '<span>0.50</span> GBP / <abbr title="%vol">% vol/hl</abbr> + <span>2.60</span> GBP / <abbr title="Hectolitre">hl</abbr>',
+      formatted_value: '£900.00',
+      value: 900.0,
+    }
+  end
+
+  it { expect(evaluator.call).to eq(expected_evaluation) }
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1182

### What?

When ASVX measure units are encountered in the backend they are replaced
by two measure units for volume and alcohol percentage.

We need these to be handled in the duty calculator slightly differently.

This maybe extended later if we're calculating other measure units
differently.


I have added/removed/altered:

- [x] Added a compound measure unit evaluator to handle compound measure units
- [x] Extended evaluator factory specs to include the CompoundMeasureUnit evaluator in the single and compound component case
- [x] Simplified current evaluator factory specs with a shared example

### Why?

I am doing this because:

- We were doing measure unit calculations on ASVX incorrectly
