### PR TITLE
HOTT-1140: Revert to default govuk frontend width

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -9,7 +9,6 @@
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 $govuk-global-styles: true;
-$govuk-page-width: 1140px;
 
 @import "~govuk-frontend/govuk/all";
 @import "accessible-autocomplete";


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1140

### What?

See related PR for the frontend: 

I have added/removed/altered:

- [x] Revert to bundled default width specified by govuk-frontend

### Why?

I am doing this because:

- This is to be aligned with a recent change in the frontend project https://github.com/trade-tariff/trade-tariff-frontend/pull/450
