### PR TITLE
HOTT-1203: Handle no MFN duties

### DIFF
--- a/app/views/steps/duty/calculations/_options_summary.html.erb
+++ b/app/views/steps/duty/calculations/_options_summary.html.erb
@@ -10,11 +10,13 @@
     </ul>
   </nav>
 <% else %>
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-warning-text__assistive">Information</span>
-      <%= @duty_options.third_country_tariff_option.warning_text %>
-    </strong>
-  </div>
+  <% if @duty_options.third_country_tariff_option.present? %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Information</span>
+        <%= @duty_options.third_country_tariff_option.warning_text %>
+      </strong>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1222

### What?

In the example of this commodity: https://staging.trade-tariff.service.gov.uk/commodities/1508101000?country=IN we have no option that does not exclude the third country measure. We need to make sure that in this scenario (which is technically valid) we do not explode when calculating and rendering calculated duties.

I have added/removed/altered:

- [x] Alter option summary such that the mfn option is optional.

### Why?

I am doing this because:

- We can expect there to be no MFN option in some scenarios
