### PR TITLE
Enable dependabot for Docker and JS dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,11 @@ workflows:
           name: build_dev
           context: trade-tariff
           dev-build: true
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^dependabot\/.*/
           requires:
             - test
       - deploy_dev:
@@ -266,6 +271,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^dependabot\/.*/
           requires:
             - build_dev
       - build:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  versioning-strategy: lockfile-only
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [ ] Updated dependabot config to match frontend and cover javascript and docker dependencies
- [ ] Changed the circle config to not deploy the dependabot PRs

### Why?

I am doing this because:

- we should be prompted for dependency updates
