### PR TITLE
HOTT-1206 Fix queuing in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
   node: circleci/node@2
   ruby: circleci/ruby@1.1.4
   slack: circleci/slack@4.3.0
-  queue: eddiewebb/queue@1.6.1
+  queue: eddiewebb/queue@1.6.4
 
 commands:
   cf_deploy_docker:


### PR DESCRIPTION
### Jira link

[HOTT-1206](https://transformuk.atlassian.net/browse/HOTT-1206)

### What?

I have added/removed/altered:

- [x] Fix for deploy step in CI not queueing correctly

### Why?

I am doing this because:

- CI does not queue and concurrent downloads can result in the deletion of the server being deployed to
