### PR TITLE
HOTT-1321 Convert navbar markup to new pattern

### DIFF
--- a/app/views/navbar/_main.html.erb
+++ b/app/views/navbar/_main.html.erb
@@ -2,9 +2,9 @@
   <a href="<%= sections_url %>" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
     <%= header %>
   </a>
-  <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="proposition-links" aria-label="Show or hide Top Level Navigation">Menu</button>
-  <nav id="proposition-menu"  aria-label="Top Level Navigation">
-    <ul id="proposition-links" class="govuk-header__navigation ">
+  <nav id="proposition-menu" class="govuk-header__navigation" aria-label="Top Level Navigation">
+    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="proposition-links" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <ul id="proposition-links" class="govuk-header__navigation-list">
       <li class="govuk-header__navigation-item">
         <%= link_to 'Search', search_url, class: "govuk-header__link" %>
       </li>


### PR DESCRIPTION
### Jira link

[HOTT-1321](https://transformuk.atlassian.net/browse/HOTT-1321)

### What?

I have added/removed/altered:

- [x] Updated the navbar markup for GovukFrontend v4

### Why?

I am doing this because:

We upgraded one of our v4 of govuk frontend requires changes to the html markup. This caused a subtle breakage in headers - the header started rendering indented on desktop, and broke the collapsing feature on mobile.