### PR TITLE
Make the rubocop config match brakemans requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: Brakeman
           # See https://github.com/presidentbeef/brakeman/issues/1664
-          command:  bundle exec brakeman -o brakeman_results.html --no-exit-on-error
+          command:  bundle exec brakeman -o brakeman_results.html
       - store_artifacts:
           path: brakeman_results.html
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,8 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GuardClause:
   MinBodyLength: 2
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 

--- a/app/helpers/excise_helper.rb
+++ b/app/helpers/excise_helper.rb
@@ -5,14 +5,14 @@ module ExciseHelper
     t(
       'excise_page.hint_html',
       small_brewers_relief_hint_text: extra_brewers_hint,
-      excise_link:,
+      excise_link: excise_link,
     )
   end
 
   private
 
   def small_brewers_relief_hint_text
-    t('excise_page.small_brewers_relief_hint_text_html', small_brewers_relief_link:)
+    t('excise_page.small_brewers_relief_hint_text_html', small_brewers_relief_link: small_brewers_relief_link)
   end
 
   def excise_link

--- a/app/models/steps/additional_code.rb
+++ b/app/models/steps/additional_code.rb
@@ -24,7 +24,7 @@ module Steps
     end
 
     def options_for_select_for(source:)
-      available_additional_codes_for(source:).map { |ac| build_option(ac['code'], ac['overlay']) }
+      available_additional_codes_for(source: source).map { |ac| build_option(ac['code'], ac['overlay']) }
     end
 
     def measure_type_description_for(source:)

--- a/app/services/duty_options/base.rb
+++ b/app/services/duty_options/base.rb
@@ -19,7 +19,7 @@ module DutyOptions
           footnote: localised_footnote,
           warning_text: nil,
           values: option_values,
-          value:,
+          value: value,
           measure_sid: measure.id,
           source: measure.source,
           priority: self.class::PRIORITY,
@@ -57,7 +57,7 @@ module DutyOptions
       presented_rows << I18n.t(
         'duty_calculations.options.import_duty_html',
         commodity_source: presented_commodity_source,
-        option_type:,
+        option_type: option_type,
         additional_code: formatted_additional_code,
       ).html_safe
       presented_rows.concat(duty_evaluation.slice(:calculation, :formatted_value).values)

--- a/app/services/number_with_high_precision_formatter.rb
+++ b/app/services/number_with_high_precision_formatter.rb
@@ -10,9 +10,9 @@ class NumberWithHighPrecisionFormatter
   def call
     number_with_precision(
       @quantity,
-      precision:,
+      precision: precision,
       significant: false,
-      strip_insignificant_zeros:,
+      strip_insignificant_zeros: strip_insignificant_zeros,
     )
   end
 

--- a/spec/controllers/steps/additional_code_controller_spec.rb
+++ b/spec/controllers/steps/additional_code_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Steps::AdditionalCodesController, :user_session do
     let(:answers) do
       {
         steps_additional_code: {
-          additional_code_uk:,
-          additional_code_xi:,
+          additional_code_uk: additional_code_uk,
+          additional_code_xi: additional_code_xi,
         },
       }
     end

--- a/spec/controllers/steps/certificate_of_origin_controller_spec.rb
+++ b/spec/controllers/steps/certificate_of_origin_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Steps::CertificateOfOriginController, :user_session do
     let(:answers) do
       {
         steps_certificate_of_origin: {
-          certificate_of_origin:,
+          certificate_of_origin: certificate_of_origin,
         },
       }
     end

--- a/spec/controllers/steps/country_of_origin_controller_spec.rb
+++ b/spec/controllers/steps/country_of_origin_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Steps::CountryOfOriginController, :user_session do
     let(:answers) do
       {
         steps_country_of_origin: {
-          country_of_origin:,
-          other_country_of_origin:,
+          country_of_origin: country_of_origin,
+          other_country_of_origin: other_country_of_origin,
         },
       }
     end

--- a/spec/controllers/steps/document_codes_controller_spec.rb
+++ b/spec/controllers/steps/document_codes_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Steps::DocumentCodesController, :user_session do
     let(:answers) do
       {
         steps_document_code: {
-          document_code_uk:,
-          document_code_xi:,
+          document_code_uk: document_code_uk,
+          document_code_xi: document_code_xi,
         },
       }
     end

--- a/spec/controllers/steps/excise_controller_spec.rb
+++ b/spec/controllers/steps/excise_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Steps::ExciseController, :user_session do
     let(:answers) do
       {
         steps_excise: {
-          additional_code:,
+          additional_code: additional_code,
         },
       }
     end

--- a/spec/controllers/steps/import_date_controller_spec.rb
+++ b/spec/controllers/steps/import_date_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::ImportDateController, :user_session do
   let(:referred_service) { 'uk' }
 
   describe 'GET #show' do
-    subject(:response) { get :show, params: { commodity_code:, referred_service: } }
+    subject(:response) { get :show, params: { commodity_code: commodity_code, referred_service: referred_service } }
 
     it 'assigns the correct step' do
       response
@@ -20,7 +20,7 @@ RSpec.describe Steps::ImportDateController, :user_session do
   end
 
   describe 'POST #create' do
-    subject(:response) { post :create, params: { commodity_code:, referred_service: }.merge(answers) }
+    subject(:response) { post :create, params: { commodity_code: commodity_code, referred_service: referred_service }.merge(answers) }
 
     let(:answers) do
       {

--- a/spec/controllers/steps/import_destination_controller_spec.rb
+++ b/spec/controllers/steps/import_destination_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Steps::ImportDestinationController, :user_session do
     let(:answers) do
       {
         steps_import_destination: {
-          import_destination:,
+          import_destination: import_destination,
         },
       }
     end

--- a/spec/controllers/steps/meursing_additional_code_controller_spec.rb
+++ b/spec/controllers/steps/meursing_additional_code_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Steps::MeursingAdditionalCodesController, :user_session do
   describe 'POST #create' do
     subject(:response) { post :create, params: answers }
 
-    let(:answers) { { steps_meursing_additional_code: { meursing_additional_code: } } }
+    let(:answers) { { steps_meursing_additional_code: { meursing_additional_code: meursing_additional_code } } }
 
     context 'when the step answers are valid' do
       let(:meursing_additional_code) { '000' }

--- a/spec/decorators/confirmation_decorator_spec.rb
+++ b/spec/decorators/confirmation_decorator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ConfirmationDecorator, :user_session do
       :with_meursing_additional_code,
       :with_vat,
       :with_document_codes,
-      commodity_code:,
+      commodity_code: commodity_code,
     )
   end
 

--- a/spec/factories/steps/country_of_origin.rb
+++ b/spec/factories/steps/country_of_origin.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     trade_defence { '' }
 
     initialize_with do
-      parameters = ActionController::Parameters.new(country_of_origin:).permit(:country_of_origin)
+      parameters = ActionController::Parameters.new(country_of_origin: country_of_origin).permit(:country_of_origin)
       opts = {}
       opts[:zero_mfn_duty] = zero_mfn_duty unless zero_mfn_duty.nil?
       opts[:trade_defence] = trade_defence unless trade_defence.nil?

--- a/spec/helpers/commodity_helper_spec.rb
+++ b/spec/helpers/commodity_helper_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe CommodityHelper, :user_session do
   let(:user_session) do
     build(
       :user_session,
-      import_destination:,
+      import_destination: import_destination,
       country_of_origin: 'GB',
-      commodity_source:,
-      commodity_code:,
+      commodity_source: commodity_source,
+      commodity_code: commodity_code,
     )
   end
 
@@ -50,10 +50,10 @@ RSpec.describe CommodityHelper, :user_session do
       let(:user_session) do
         build(
           :user_session,
-          import_destination:,
+          import_destination: import_destination,
           country_of_origin: 'OTHER',
-          commodity_source:,
-          commodity_code:,
+          commodity_source: commodity_source,
+          commodity_code: commodity_code,
           other_country_of_origin: 'AR',
         )
       end
@@ -128,9 +128,9 @@ RSpec.describe CommodityHelper, :user_session do
     let(:user_session) do
       build(
         :user_session,
-        import_destination:,
-        commodity_source:,
-        commodity_code:,
+        import_destination: import_destination,
+        commodity_source: commodity_source,
+        commodity_code: commodity_code,
       )
     end
 

--- a/spec/helpers/excise_helper_spec.rb
+++ b/spec/helpers/excise_helper_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ExciseHelper do
   describe '#excise_hint' do
-    subject(:excise_hint) { helper.excise_hint(small_brewers_relief:) }
+    subject(:excise_hint) { helper.excise_hint(small_brewers_relief: small_brewers_relief) }
 
     context 'when the excise additional codes do not have small brewers relief' do
       let(:small_brewers_relief) { false }

--- a/spec/models/api/base_component_spec.rb
+++ b/spec/models/api/base_component_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Api::BaseComponent do
   end
 
   describe '#specific_duty?' do
-    subject(:component) { described_class.new(measurement_unit_code:) }
+    subject(:component) { described_class.new(measurement_unit_code: measurement_unit_code) }
 
     context 'when measurement_unit_code is present' do
       let(:measurement_unit_code) { 'DTN' }
@@ -80,7 +80,7 @@ RSpec.describe Api::BaseComponent do
   end
 
   describe '#no_specific_duty?' do
-    subject(:component) { described_class.new(measurement_unit_code:) }
+    subject(:component) { described_class.new(measurement_unit_code: measurement_unit_code) }
 
     context 'when measurement_unit_code is present' do
       let(:measurement_unit_code) { 'DTN' }

--- a/spec/models/api/measure_condition_spec.rb
+++ b/spec/models/api/measure_condition_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Api::MeasureCondition do
   subject(:measure_condition) do
     described_class.new(
-      condition_measurement_unit_code:,
-      condition_monetary_unit_code:,
+      condition_measurement_unit_code: condition_measurement_unit_code,
+      condition_monetary_unit_code: condition_monetary_unit_code,
     )
   end
 
@@ -46,7 +46,7 @@ RSpec.describe Api::MeasureCondition do
   end
 
   describe '#expresses_document?' do
-    subject(:measure_condition) { described_class.new(condition_code:) }
+    subject(:measure_condition) { described_class.new(condition_code: condition_code) }
 
     context 'when the condition_code is a document condition code' do
       let(:condition_code) { 'I' }
@@ -63,7 +63,7 @@ RSpec.describe Api::MeasureCondition do
 
   describe '#applicable?' do
     shared_examples 'an applicable measure condition' do |action_code|
-      subject(:measure_condition) { described_class.new(action_code:) }
+      subject(:measure_condition) { described_class.new(action_code: action_code) }
 
       context 'when the measure condition has an action code which requires we apply the duty amount' do
         it { is_expected.to be_applicable }

--- a/spec/models/api/measure_spec.rb
+++ b/spec/models/api/measure_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Api::Measure, :user_session do
                                                     resolved_duty_expression: ''
 
   describe '#evaluator' do
-    subject(:measure) { build(:measure, :third_country_tariff, source: 'xi', measure_components:) }
+    subject(:measure) { build(:measure, :third_country_tariff, source: 'xi', measure_components: measure_components) }
 
     shared_examples_for 'a measure evaluator' do |expected_evaluator|
       it 'instantiates the correct evaluator' do
@@ -640,9 +640,9 @@ RSpec.describe Api::Measure, :user_session do
     subject(:measure) do
       build(
         :measure,
-        measure_components:,
-        resolved_measure_components:,
-        measure_conditions:,
+        measure_components: measure_components,
+        resolved_measure_components: resolved_measure_components,
+        measure_conditions: measure_conditions,
       )
     end
 

--- a/spec/models/api/measure_type_spec.rb
+++ b/spec/models/api/measure_type_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::MeasureType do
   }
 
   describe '#call' do
-    subject(:measure_type) { described_class.new(id:) }
+    subject(:measure_type) { described_class.new(id: id) }
 
     context 'when there is a corresponding option for the id' do
       let(:id) { '142' }
@@ -31,7 +31,7 @@ RSpec.describe Api::MeasureType do
   end
 
   describe '#additional_duty_option' do
-    subject(:measure_type) { described_class.new(id:) }
+    subject(:measure_type) { described_class.new(id: id) }
 
     context 'when there is a corresponding option for the id' do
       let(:id) { '551' }
@@ -47,7 +47,7 @@ RSpec.describe Api::MeasureType do
   end
 
   describe '#additional_option?' do
-    subject(:measure_type) { described_class.new(id:) }
+    subject(:measure_type) { described_class.new(id: id) }
 
     context 'when there is a corresponding option for the id' do
       let(:id) { '551' }

--- a/spec/models/steps/additional_code_spec.rb
+++ b/spec/models/steps/additional_code_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
   subject(:step) do
     build(
       :additional_code,
-      user_session:,
+      user_session: user_session,
     )
   end
 
@@ -88,7 +88,7 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
       subject(:step) do
         build(
           :additional_code,
-          user_session:,
+          user_session: user_session,
           measure_type_id: nil,
         )
       end
@@ -110,7 +110,7 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
       subject(:step) do
         build(
           :additional_code,
-          user_session:,
+          user_session: user_session,
           additional_code_uk: nil,
         )
       end
@@ -134,7 +134,7 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
       subject(:step) do
         build(
           :additional_code,
-          user_session:,
+          user_session: user_session,
           additional_code_xi: nil,
         )
       end
@@ -201,7 +201,7 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
       subject(:step) do
         build(
           :additional_code,
-          user_session:,
+          user_session: user_session,
           additional_code_uk: nil,
         )
       end
@@ -233,7 +233,7 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
       subject(:step) do
         build(
           :additional_code,
-          user_session:,
+          user_session: user_session,
           additional_code_xi: nil,
         )
       end
@@ -327,8 +327,8 @@ RSpec.describe Steps::AdditionalCode, :step, :user_session do
       subject(:step) do
         build(
           :additional_code,
-          user_session:,
-          measure_type_id:,
+          user_session: user_session,
+          measure_type_id: measure_type_id,
         )
       end
 

--- a/spec/models/steps/annual_turnover_spec.rb
+++ b/spec/models/steps/annual_turnover_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Steps::AnnualTurnover, :step, :user_session do
-  subject(:step) { build(:annual_turnover, user_session:, annual_turnover:) }
+  subject(:step) { build(:annual_turnover, user_session: user_session, annual_turnover: annual_turnover) }
 
   let(:user_session) { build(:user_session) }
   let(:annual_turnover) { '' }

--- a/spec/models/steps/certificate_of_origin_spec.rb
+++ b/spec/models/steps/certificate_of_origin_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Steps::CertificateOfOrigin, :step, :user_session do
   subject(:step) do
     build(
       :certificate_of_origin,
-      user_session:,
-      certificate_of_origin:,
+      user_session: user_session,
+      certificate_of_origin: certificate_of_origin,
     )
   end
 

--- a/spec/models/steps/confirmation_spec.rb
+++ b/spec/models/steps/confirmation_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Steps::Confirmation, :step, :user_session do
   let(:filtered_commodity) do
     instance_double(
       'Api::Commodity',
-      applicable_additional_codes:,
-      applicable_vat_options:,
+      applicable_additional_codes: applicable_additional_codes,
+      applicable_vat_options: applicable_vat_options,
     )
   end
 

--- a/spec/models/steps/country_of_origin_spec.rb
+++ b/spec/models/steps/country_of_origin_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe Steps::CountryOfOrigin, :step, :user_session do
   subject(:step) do
     build(
       :country_of_origin,
-      user_session:,
-      country_of_origin:,
-      other_country_of_origin:,
-      trade_defence:,
-      zero_mfn_duty:,
+      user_session: user_session,
+      country_of_origin: country_of_origin,
+      other_country_of_origin: other_country_of_origin,
+      trade_defence: trade_defence,
+      zero_mfn_duty: zero_mfn_duty,
     )
   end
 

--- a/spec/models/steps/customs_value_spec.rb
+++ b/spec/models/steps/customs_value_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Steps::CustomsValue, :step, :user_session do
   subject(:step) do
     build(
       :customs_value,
-      user_session:,
-      monetary_value:,
-      insurance_cost:,
-      shipping_cost:,
+      user_session: user_session,
+      monetary_value: monetary_value,
+      insurance_cost: insurance_cost,
+      shipping_cost: shipping_cost,
     )
   end
 

--- a/spec/models/steps/document_code_spec.rb
+++ b/spec/models/steps/document_code_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Steps::DocumentCode, :user_session do
-  subject(:step) { build(:document_code, measure_type_id:) }
+  subject(:step) { build(:document_code, measure_type_id: measure_type_id) }
 
   let(:user_session) { build(:user_session, :with_commodity_information) }
   let(:commodity_source) { :uk }
@@ -76,9 +76,9 @@ RSpec.describe Steps::DocumentCode, :user_session do
       subject(:step) do
         build(
           :document_code,
-          user_session:,
+          user_session: user_session,
           document_code_uk: nil,
-          measure_type_id:,
+          measure_type_id: measure_type_id,
         )
       end
 
@@ -107,9 +107,9 @@ RSpec.describe Steps::DocumentCode, :user_session do
       subject(:step) do
         build(
           :document_code,
-          user_session:,
+          user_session: user_session,
           document_code_xi: nil,
-          measure_type_id:,
+          measure_type_id: measure_type_id,
         )
       end
 
@@ -340,8 +340,8 @@ RSpec.describe Steps::DocumentCode, :user_session do
       subject(:step) do
         build(
           :document_code,
-          user_session:,
-          measure_type_id:,
+          user_session: user_session,
+          measure_type_id: measure_type_id,
         )
       end
 
@@ -379,8 +379,8 @@ RSpec.describe Steps::DocumentCode, :user_session do
       subject(:step) do
         build(
           :document_code,
-          user_session:,
-          measure_type_id:,
+          user_session: user_session,
+          measure_type_id: measure_type_id,
         )
       end
 

--- a/spec/models/steps/excise_spec.rb
+++ b/spec/models/steps/excise_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Steps::Excise, :step, :user_session do
       subject(:step) do
         build(
           :excise,
-          user_session:,
+          user_session: user_session,
           measure_type_id: nil,
         )
       end
@@ -107,7 +107,7 @@ RSpec.describe Steps::Excise, :step, :user_session do
       subject(:step) do
         build(
           :excise,
-          user_session:,
+          user_session: user_session,
           additional_code: nil,
         )
       end
@@ -201,7 +201,7 @@ RSpec.describe Steps::Excise, :step, :user_session do
       subject(:step) do
         build(
           :excise,
-          user_session:,
+          user_session: user_session,
           additional_code: nil,
         )
       end

--- a/spec/models/steps/final_use_spec.rb
+++ b/spec/models/steps/final_use_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Steps::FinalUse, :step, :user_session do
-  subject(:step) { build(:final_use, user_session:, final_use:) }
+  subject(:step) { build(:final_use, user_session: user_session, final_use: final_use) }
 
   let(:session_attributes) { {} }
   let(:user_session) { build(:user_session, session_attributes) }

--- a/spec/models/steps/import_date_spec.rb
+++ b/spec/models/steps/import_date_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe Steps::ImportDate, :step, :user_session do
   subject(:step) do
     build(
       :import_date,
-      user_session:,
-      day:,
-      month:,
-      year:,
+      user_session: user_session,
+      day: day,
+      month: month,
+      year: year,
     )
   end
 

--- a/spec/models/steps/import_destination_spec.rb
+++ b/spec/models/steps/import_destination_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Steps::ImportDestination, :step, :user_session do
-  subject(:step) { build(:import_destination, import_destination:) }
+  subject(:step) { build(:import_destination, import_destination: import_destination) }
 
   let(:user_session) { build(:user_session, commodity_source: nil) }
   let(:import_destination) { '' }

--- a/spec/models/steps/measure_amount_spec.rb
+++ b/spec/models/steps/measure_amount_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Steps::MeasureAmount, :step, :user_session do
   subject(:step) do
     build(
       :measure_amount,
-      user_session:,
-      measure_amount:,
+      user_session: user_session,
+      measure_amount: measure_amount,
     )
   end
 

--- a/spec/models/steps/meursing_additional_code_spec.rb
+++ b/spec/models/steps/meursing_additional_code_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Steps::MeursingAdditionalCode, :step, :user_session do
-  subject(:step) { build(:meursing_additional_code, meursing_additional_code:) }
+  subject(:step) { build(:meursing_additional_code, meursing_additional_code: meursing_additional_code) }
 
   let(:meursing_additional_code) { nil }
 

--- a/spec/models/steps/planned_processing_spec.rb
+++ b/spec/models/steps/planned_processing_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Steps::PlannedProcessing, :step, :user_session do
-  subject(:step) { build(:planned_processing, user_session:, planned_processing:) }
+  subject(:step) { build(:planned_processing, user_session: user_session, planned_processing: planned_processing) }
 
   let(:session_attributes) { {} }
   let(:user_session) { build(:user_session, session_attributes) }

--- a/spec/models/steps/trader_scheme_spec.rb
+++ b/spec/models/steps/trader_scheme_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Steps::TraderScheme, :step, :user_session do
-  subject(:step) { build(:trader_scheme, user_session:, trader_scheme:) }
+  subject(:step) { build(:trader_scheme, user_session: user_session, trader_scheme: trader_scheme) }
 
   let(:user_session) { build(:user_session, session_attributes) }
   let(:session_attributes) { {} }

--- a/spec/models/steps/vat_spec.rb
+++ b/spec/models/steps/vat_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Steps::Vat, :step, :user_session do
-  subject(:step) { build(:vat, user_session:, vat:) }
+  subject(:step) { build(:vat, user_session: user_session, vat: vat) }
 
   let(:vat) { nil }
 

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe UserSession do
   end
 
   describe '#import_into_gb?' do
-    subject(:user_session) { build(:user_session, import_destination:) }
+    subject(:user_session) { build(:user_session, import_destination: import_destination) }
 
     context 'when the import_destination is UK' do
       let(:import_destination) { 'UK' }
@@ -497,9 +497,9 @@ RSpec.describe UserSession do
     let(:params) do
       ActionController::Parameters.new(
         commodity_code: '0702000007',
-        country_of_origin:,
+        country_of_origin: country_of_origin,
         import_date: '2021-01-01',
-        import_destination:,
+        import_destination: import_destination,
       )
     end
 
@@ -588,7 +588,7 @@ RSpec.describe UserSession do
       )
     end
 
-    let(:measure_type) { Api::MeasureType.new(id:, measure_type_series_id:) }
+    let(:measure_type) { Api::MeasureType.new(id: id, measure_type_series_id: measure_type_series_id) }
 
     context 'when the measure type is an excise measure type' do
       let(:measure_type_series_id) { 'Q' }

--- a/spec/services/expression_evaluators/compound_measure_unit_spec.rb
+++ b/spec/services/expression_evaluators/compound_measure_unit_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExpressionEvaluators::CompoundMeasureUnit, :user_session do
     build(
       :measure,
       :third_country_tariff,
-      measure_components:,
+      measure_components: measure_components,
       duty_expression: {
         'formatted_base' => "<span>0.50</span> GBP / <abbr title='%vol'>% vol/hl</abbr> + <span>2.60</span> GBP / <abbr title='Hectolitre'>hl</abbr>",
       },

--- a/spec/services/expression_evaluators/compound_spec.rb
+++ b/spec/services/expression_evaluators/compound_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ExpressionEvaluators::Compound, :user_session do
       :measure,
       :third_country_tariff,
       id: 3_211_138,
-      measure_components:,
+      measure_components: measure_components,
     )
   end
 
@@ -82,7 +82,7 @@ RSpec.describe ExpressionEvaluators::Compound, :user_session do
         :third_country_tariff,
         :with_resolved_duty_expression,
         id: 3_211_138,
-        measure_components:,
+        measure_components: measure_components,
       )
     end
 

--- a/spec/views/errors/internal_server_error_spec.rb
+++ b/spec/views/errors/internal_server_error_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'errors/internal_server_error', type: :view do
   let(:user_session) { build(:user_session, :with_commodity_information) }
 
   it 'renders a link to the import_date_path' do
-    render template: 'errors/internal_server_error', locals: { user_session: }
+    render template: 'errors/internal_server_error', locals: { user_session: user_session }
 
     expected_path = import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code)
 

--- a/spec/views/errors/not_found_spec.rb
+++ b/spec/views/errors/not_found_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'errors/not_found', type: :view do
   let(:user_session) { build(:user_session, :with_commodity_information) }
 
   it 'renders a link to the import_date_path' do
-    render template: 'errors/not_found', locals: { user_session: }
+    render template: 'errors/not_found', locals: { user_session: user_session }
 
     expected_path = import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code)
 

--- a/spec/views/errors/unprocessable_entity_spec.rb
+++ b/spec/views/errors/unprocessable_entity_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'errors/unprocessable_entity', type: :view do
   let(:user_session) { build(:user_session, :with_commodity_information) }
 
   it 'renders a link to the import_date_path' do
-    render template: 'errors/unprocessable_entity', locals: { user_session: }
+    render template: 'errors/unprocessable_entity', locals: { user_session: user_session }
 
     expected_path = import_date_path(referred_service: user_session.referred_service, commodity_code: user_session.commodity_code)
 


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Re-enabled Brakeman security scanning
- [x] Changed rubocop to prevent rather then require Ruby 3.1 short hash literals
- [x] Removed usage of short hash literals from existing code

### Why?

I am doing this because:

- Brakeman is more important than utilising Ruby 3.1 hash syntax
- its trivial to convert back at a future point
- for now it reduces noise in PRs because rubocop isn't insisting on an syntax change to existing code

