### PR TITLE
Bump UKTT to handle join entities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/trade-tariff/uktt.git
-  revision: 20c4ce5e18871cfb09c4f27652f89b906e72ac4d
+  revision: 66ff55eeee024939267113a458d4b8c982f2fa12
   specs:
     uktt (2.5.0)
       faraday


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Bumped the version of the UKTT gem

### Why?

I am doing this because:

- the new version handles join entities in JSONAPI correctly

### Deployment risks (optional)

- New version of UKTT now raises a custom error on parsing problems. This _shouldn't_ make a difference since there's no custom code for parsing errors in DC anyway AFAICT

### Testing done

- enabled Permutations API, verified that running main on Dev failed smoke tests
- deployed this PR, verified smoke tests passed
