### PR TITLE
HOTT-1520 Always use latest v1 Ruby orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
   cloudfoundry: circleci/cloudfoundry@1.0
   cypress: cypress-io/cypress@1.27.0
   node: circleci/node@2
-  ruby: circleci/ruby@1.4.0
+  ruby: circleci/ruby@1
   slack: circleci/slack@4.3.0
   queue: eddiewebb/queue@1.6.4
 


### PR DESCRIPTION
### Jira link

[HOTT-1520](https://transformuk.atlassian.net/browse/HOTT-1520)

### What?

I have added/removed/altered:

- [x] Change the CI config to always use the latest v1 version of the Ruby orb

### Why?

I am doing this because:

- Orbs follow semantic versioning, so it should be safe to upgrade minor and patch releases automatically since they wont include
breaking changes.
- There are known problems with specs not being run for the old v1.4.0 version of the ruby orb we currently use.