### PR TITLE
HOTT-1481: Normalise user inputs with multipliers

### DIFF
--- a/app/services/concerns/measure_unit_presentable.rb
+++ b/app/services/concerns/measure_unit_presentable.rb
@@ -5,6 +5,7 @@ module MeasureUnitPresentable
     @presented_unit ||= {
       answer: user_session.measure_amount[component.unit.downcase.to_s],
       unit: applicable_unit['unit'],
+      multiplier: applicable_unit['multiplier'].presence || 1,
     }
   end
 
@@ -15,6 +16,6 @@ module MeasureUnitPresentable
   private
 
   def applicable_units
-    ApplicableMeasureUnitMerger.new.call
+    @applicable_units ||= ApplicableMeasureUnitMerger.new.call
   end
 end

--- a/app/services/expression_evaluators/compound_measure_unit.rb
+++ b/app/services/expression_evaluators/compound_measure_unit.rb
@@ -34,7 +34,7 @@ module ExpressionEvaluators
     end
 
     def volume_quantity
-      presented_volume_unit[:answer].to_f
+      presented_volume_unit[:answer].to_f * presented_volume_unit[:multiplier].to_f
     end
 
     def alcohol_unit
@@ -56,7 +56,12 @@ module ExpressionEvaluators
       @presented_volume_unit ||= {
         answer: user_session.measure_amount[Api::BaseComponent::VOLUME_UNIT.downcase],
         unit: volume_unit['unit'],
+        multiplier: volume_unit_multiplier,
       }
+    end
+
+    def volume_unit_multiplier
+      volume_unit['multiplier'].presence || 1
     end
   end
 end

--- a/app/services/expression_evaluators/measure_unit.rb
+++ b/app/services/expression_evaluators/measure_unit.rb
@@ -41,7 +41,11 @@ module ExpressionEvaluators
     end
 
     def total_quantity
-      presented_unit[:answer].to_f
+      presented_unit[:answer].to_f * multiplier
+    end
+
+    def multiplier
+      presented_unit[:multiplier].to_f
     end
   end
 end

--- a/spec/factories/api/commodity.rb
+++ b/spec/factories/api/commodity.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  sequence(:goods_nomenclature_sid)
+  sequence(:goods_nomenclature_sid, &:to_s)
 
   factory :commodity, class: 'Api::Commodity' do
     transient do
@@ -30,7 +30,7 @@ FactoryBot.define do
       }
     end
 
-    id { generate(:measure_sid) }
+    id { generate(:goods_nomenclature_sid) }
     producline_suffix { '80' }
     number_indents { 4 }
     description { 'Cherry tomatoes' }
@@ -75,6 +75,72 @@ FactoryBot.define do
 
     trait :without_measures do
       import_measures { [] }
+    end
+
+    trait :with_compound_measure_units do
+      import_measures do
+        [
+          attributes_for(
+            :measure,
+            :third_country_tariff,
+            :with_compound_measure_components,
+          ),
+        ]
+      end
+
+      applicable_measure_units do
+        {
+          'ASV' => { 'unit' => 'percent', 'multiplier' => nil },
+          'HLT' => { 'unit' => 'litres', "multiplier": '0.01' },
+        }
+      end
+    end
+
+    trait :with_compound_measure_units_no_multiplier do
+      import_measures do
+        [
+          attributes_for(
+            :measure,
+            :third_country_tariff,
+            :with_compound_measure_components,
+          ),
+        ]
+      end
+
+      applicable_measure_units do
+        {
+          'ASV' => { 'unit' => 'percent' },
+          'HLT' => { 'unit' => 'x 100 litres' },
+        }
+      end
+    end
+
+    trait :with_measure_units_with_multiplier do
+      import_measures { [attributes_for(:measure, :third_country_tariff, :with_pounds_measure_unit_measure_component)] }
+
+      applicable_measure_units { { 'DTN' => { 'unit' => 'kilogrammes', 'multiplier' => '0.01' } } }
+    end
+
+    trait :with_retail_price_measure_units do
+      applicable_measure_units { { 'RET' => { 'unit' => '£', 'multiplier' => nil } } }
+    end
+
+    trait :with_euro_measure_unit_measure_component do
+      import_measures { [attributes_for(:measure, :third_country_tariff, :with_euro_measure_unit_measure_component)] }
+
+      applicable_measure_units { { 'DTN' => { 'unit' => 'x 100 kg', 'multiplier' => nil } } }
+    end
+
+    trait :with_pounds_measure_unit_measure_component do
+      import_measures { [attributes_for(:measure, :third_country_tariff, :with_pounds_measure_unit_measure_component)] }
+
+      applicable_measure_units { { 'DTN' => { 'unit' => 'x 100 kg', 'multiplier' => nil } } }
+    end
+
+    trait :with_condition_measure_units do
+      import_measures { [attributes_for(:measure, :third_country_tariff, :with_condition_measure_units)] }
+
+      applicable_measure_units { { 'DTN' => { 'unit' => 'x 100 kg', 'multiplier' => nil } } }
     end
   end
 end

--- a/spec/factories/api/duty_expression.rb
+++ b/spec/factories/api/duty_expression.rb
@@ -5,5 +5,22 @@ FactoryBot.define do
     id { generate(:duty_expression_id) }
     base { '144.10 GBP / 1000 kg/biodiesel' }
     formatted_base { "<span>144.10</span> GBP / <abbr title='Tonne'>1000 kg/biodiesel</abbr>" }
+
+    trait :compound_measure_unit do
+      base { '0.50 GBP / % vol/hl + 2.60 GBP / hl' }
+      formatted_base do
+        "<span>0.50</span> GBP / <abbr title='%vol'>% vol/hl</abbr> + <span>2.60</span> GBP / <abbr title='Hectolitre'>hl</abbr>"
+      end
+    end
+
+    trait :euro_measure_unit do
+      base { '35.10 EUR / 100 kg' }
+      formatted_base { "<span>35.10</span> EUR / <abbr title='Hectokilogram'>100 kg</abbr>" }
+    end
+
+    trait :pounds_measure_unit do
+      base { '35.10 GBP / 100 kg' }
+      formatted_base { "<span>35.10</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr>" }
+    end
   end
 end

--- a/spec/factories/api/measure.rb
+++ b/spec/factories/api/measure.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  sequence(:measure_sid)
+  sequence(:measure_sid, &:to_s)
 
   factory :measure, class: 'Api::Measure' do
     transient do
@@ -139,6 +139,51 @@ FactoryBot.define do
         [
           attributes_for(:measure_condition, :stopping_document),
           attributes_for(:measure_condition, :stopping_negative),
+        ]
+      end
+    end
+
+    trait :with_compound_measure_components do
+      duty_expression do
+        attributes_for(:duty_expression, :compound_measure_unit)
+      end
+
+      measure_components do
+        [
+          attributes_for(:measure_component, :compound_measure_unit),
+          attributes_for(:measure_component, :compound_measure_unit),
+        ]
+      end
+    end
+
+    trait :with_euro_measure_unit_measure_component do
+      duty_expression do
+        attributes_for(:duty_expression, :euro_measure_unit)
+      end
+
+      measure_components do
+        [
+          attributes_for(:measure_component, :with_measure_units, :euros),
+        ]
+      end
+    end
+
+    trait :with_pounds_measure_unit_measure_component do
+      duty_expression do
+        attributes_for(:duty_expression, :pounds_measure_unit)
+      end
+
+      measure_components do
+        [
+          attributes_for(:measure_component, :with_measure_units, :pounds),
+        ]
+      end
+    end
+
+    trait :with_condition_measure_units do
+      measure_conditions do
+        [
+          attributes_for(:measure_condition, :with_measure_units),
         ]
       end
     end

--- a/spec/factories/api/measure_component.rb
+++ b/spec/factories/api/measure_component.rb
@@ -41,6 +41,7 @@ FactoryBot.define do
     end
 
     trait :compound_measure_unit do
+      duty_amount { 0.5 }
       measurement_unit_code { 'ASV' }
       measurement_unit_qualifier_code { 'X' }
     end

--- a/spec/factories/api/measure_condition.rb
+++ b/spec/factories/api/measure_condition.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  sequence(:measure_condition_sid)
+  sequence(:measure_condition_sid, &:to_s)
 
   factory :measure_condition, class: 'Api::MeasureCondition' do
     id { generate(:measure_condition_sid) }
@@ -18,10 +18,20 @@ FactoryBot.define do
     requirement {}
     measure_condition_components { [] }
 
-    trait :with_trigger_measure_units do
+    trait :with_measure_units do
       condition_duty_amount { 35.1 }
       condition_measurement_unit_code { 'DTN' }
       duty_expression { "<span>35.10</span> GBP / <abbr title='Hectokilogram'>100 kg</abbr>" }
+
+      measure_condition_components do
+        [
+          attributes_for(
+            :measure_condition_component,
+            :with_measure_units,
+            measure_condition_sid: id,
+          ),
+        ]
+      end
     end
 
     trait :stopping_negative do

--- a/spec/factories/api/measure_condition_component.rb
+++ b/spec/factories/api/measure_condition_component.rb
@@ -2,7 +2,11 @@ FactoryBot.define do
   sequence(:measure_condition_component_sid)
 
   factory :measure_condition_component, class: 'Api::MeasureConditionComponent' do
-    id { generate(:measure_condition_component_sid) }
+    transient do
+      measure_condition_sid {}
+    end
+
+    id { "#{measure_condition_sid}-#{generate(:measure_condition_component_sid)}" }
     duty_expression_id {}
     duty_amount {}
     monetary_unit_code {}

--- a/spec/services/expression_evaluators/retail_price_spec.rb
+++ b/spec/services/expression_evaluators/retail_price_spec.rb
@@ -9,9 +9,19 @@ RSpec.describe ExpressionEvaluators::RetailPrice, :user_session do
   let(:measure_component) { measure.measure_components.first }
 
   let(:commodity) do
-    measure = attributes_for(:measure, :excise, measure_components: [attributes_for(:measure_component, :with_retail_price_measure_units)])
-
-    build(:commodity, :with_retail_price_measure_units, import_measures: [measure])
+    build(
+      :commodity,
+      :with_retail_price_measure_units,
+      import_measures: [
+        attributes_for(
+          :measure,
+          :excise,
+          measure_components: [
+            attributes_for(:measure_component, :with_retail_price_measure_units),
+          ]
+        )
+      ]
+    )
   end
 
   let(:expected_evaluation) do

--- a/spec/services/expression_evaluators/retail_price_spec.rb
+++ b/spec/services/expression_evaluators/retail_price_spec.rb
@@ -1,9 +1,18 @@
 RSpec.describe ExpressionEvaluators::RetailPrice, :user_session do
   subject(:evaluator) { described_class.new(measure, measure_component) }
 
-  let(:measure) { build(:measure, :excise) }
-  let(:measure_component) { build(:measure_component, :with_retail_price_measure_units) }
-  let(:user_session) { build(:user_session, :with_retail_price_measure_amount, commodity_code: '0103921100') }
+  include_context 'with a fake commodity'
+
+  let(:user_session) { build(:user_session, :with_retail_price_measure_amount, commodity_code: commodity.code) }
+
+  let(:measure) { commodity.import_measures.first }
+  let(:measure_component) { measure.measure_components.first }
+
+  let(:commodity) do
+    measure = attributes_for(:measure, :excise, measure_components: [attributes_for(:measure_component, :with_retail_price_measure_units)])
+
+    build(:commodity, :with_retail_price_measure_units, import_measures: [measure])
+  end
 
   let(:expected_evaluation) do
     {
@@ -14,4 +23,23 @@ RSpec.describe ExpressionEvaluators::RetailPrice, :user_session do
   end
 
   it { expect(evaluator.call).to eq(expected_evaluation) }
+
+  it_behaves_like 'a measure unit presentable' do
+    let(:expected_presented_unit) do
+      {
+        answer: '1000',
+        multiplier: 1,
+        unit: '£',
+      }
+    end
+
+    let(:expected_applicable_unit) do
+      {
+        'unit' => '£',
+        'multiplier' => nil,
+      }
+    end
+  end
+
+  it_behaves_like 'an evaluation that uses the measure unit merger'
 end

--- a/spec/services/expression_evaluators/retail_price_spec.rb
+++ b/spec/services/expression_evaluators/retail_price_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe ExpressionEvaluators::RetailPrice, :user_session do
           :excise,
           measure_components: [
             attributes_for(:measure_component, :with_retail_price_measure_units),
-          ]
-        )
-      ]
+          ],
+        ),
+      ],
     )
   end
 

--- a/spec/support/shared_contexts/a_fake_commodity.rb
+++ b/spec/support/shared_contexts/a_fake_commodity.rb
@@ -1,0 +1,5 @@
+RSpec.shared_context 'with a fake commodity' do
+  before do
+    Thread.current[:commodity_context_service] = instance_double('CommodityContextService', call: commodity)
+  end
+end

--- a/spec/support/shared_examples/a_measure_unit_presentable.rb
+++ b/spec/support/shared_examples/a_measure_unit_presentable.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples_for 'a measure unit presentable' do
+  describe '#presented_unit' do
+    it 'returns the properly presented unit' do
+      expect(evaluator.presented_unit).to eq(expected_presented_unit) if expected_presented_unit
+    end
+  end
+
+  describe '#applicable_unit' do
+    it 'returns the merged units from the ApplicableMeasureUnitMerger service' do
+      expect(evaluator.applicable_unit).to eq(expected_applicable_unit)
+    end
+  end
+end

--- a/spec/support/shared_examples/an_evaluation_that_uses_the_measure_unit_merger.rb
+++ b/spec/support/shared_examples/an_evaluation_that_uses_the_measure_unit_merger.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples_for 'an evaluation that uses the measure unit merger' do |config|
+  describe '#call' do
+    before do
+      allow(ApplicableMeasureUnitMerger).to receive(:new).and_call_original
+    end
+
+    it 'calls the ApplicableMeasureUnitMerger service to merge units' do
+      evaluator.call
+
+      expect(ApplicableMeasureUnitMerger).to have_received(:new)
+    end
+  end
+end

--- a/spec/support/shared_examples/an_evaluation_that_uses_the_measure_unit_merger.rb
+++ b/spec/support/shared_examples/an_evaluation_that_uses_the_measure_unit_merger.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples_for 'an evaluation that uses the measure unit merger' do |config|
+RSpec.shared_examples_for 'an evaluation that uses the measure unit merger' do
   describe '#call' do
     before do
       allow(ApplicableMeasureUnitMerger).to receive(:new).and_call_original


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1481

### What?

When the user enters a unit who's input type is different from the type
used in the calculator we need to use the multiplier to coerce the input answer
to a normalised value (e.g. convert liters back into hectoliters). This enables
the calculator to accurately fill in the unit answers required by the current component.

We've also migrated away from a dependence on massive fixture files with
difficult-to-configure attributes and are now instead using a commodity
factory.

When the multiplier isn't present we do no coercion of input answers.

Finally, we introduce a whole bunch of orchestrating factory traits that
make simulation of various conditions in the evaluators more straightforward

I have added/removed/altered:

- [x] Added application of multipliers in measure unit, compound measure unit evaluators
- [x] Added coverage for missing/present multiplier behaviour
- [x] Altered existing specs to use a commodity factory
- [x] Added codification of measure unit presentable behaviour in shared examples
- [x] Added a bunch of traits for easier control of different fixture inputs driving different behaviours

### Why?

I am doing this because:

- This is all required because we're simplifying the interface of the duty
calculator for the user such that they have a limited number of more
commonly known unit types to enter as part of the duty calculator
process.


### NB

I've actually not supported normalised retail price measure units since this is just a value in pounds that is unlikely to ever
require normalising with a multiplier.
