### PR TITLE
HOTT-1523: Adjust the way retail price measure amounts are presented

### DIFF
--- a/app/decorators/confirmation_decorator.rb
+++ b/app/decorators/confirmation_decorator.rb
@@ -75,9 +75,18 @@ class ConfirmationDecorator < SimpleDelegator
   def format_measure_amount(value, _key)
     return if applicable_measure_units.blank?
 
-    value.map { |k, v| "#{v} #{applicable_measure_units[k.upcase]['unit']}" }
-         .join('<br>')
-         .html_safe
+    formatted_values = value.map do |measure_unit_key, answer|
+      abbreviation = applicable_measure_units[measure_unit_key.upcase]['abbreviation']
+      unit = applicable_measure_units[measure_unit_key.upcase]['unit']
+
+      if measure_unit_key.upcase == Api::BaseComponent::RETAIL_PRICE_UNIT
+        "<span title='#{abbreviation}'>#{number_to_currency(answer, unit:)}</span>"
+      else
+        "<span title='#{abbreviation}'>#{answer} #{unit}</span>"
+      end
+    end
+
+    formatted_values.join('<br>').html_safe
   end
 
   def format_customs_value(_value, _key)

--- a/app/models/api/base_component.rb
+++ b/app/models/api/base_component.rb
@@ -4,6 +4,7 @@ module Api
     COMPOUND_MEASURE_UNITS = %w[ASVX].freeze
     MATHEMATICAL_OPERATORS = %w[+ -].freeze
 
+    RETAIL_PRICE_UNIT = 'RET'.freeze
     VOLUME_UNIT = 'HLT'.freeze
     ALCOHOL_UNIT = 'ASV'.freeze
 

--- a/app/views/steps/excise/show.html.erb
+++ b/app/views/steps/excise/show.html.erb
@@ -8,7 +8,7 @@
   <%=
     f.govuk_radio_buttons_fieldset(
       :additional_code,
-      legend: { text: '' },
+      legend: { text: '', hidden: true },
       hint: {
         text: excise_hint(small_brewers_relief: @step.small_brewers_relief?),
       },

--- a/app/views/steps/measure_amount/show.html.erb
+++ b/app/views/steps/measure_amount/show.html.erb
@@ -15,7 +15,11 @@
   </p>
 
   <% f.object.applicable_measure_units.each do |key, values| %>
-    <%= f.govuk_text_field key.downcase.to_sym, width: 'one-quarter', label: { text: values['unit_question'], class: 'govuk-label govuk-label--s' }, hint: { text: values['unit_hint'] }, suffix_text: values['unit']  %>
+    <% if key.upcase == Api::BaseComponent::RETAIL_PRICE_UNIT %>
+      <%= f.govuk_text_field key.downcase.to_sym, width: 'one-quarter', label: { text: values['unit_question'], class: 'govuk-label govuk-label--s' }, hint: { text: values['unit_hint'] }, prefix_text: values['unit']  %>
+    <% else %>
+      <%= f.govuk_text_field key.downcase.to_sym, width: 'one-quarter', label: { text: values['unit_question'], class: 'govuk-label govuk-label--s' }, hint: { text: values['unit_hint'] }, suffix_text: values['unit']  %>
+    <% end %>
   <% end %>
 
   <%= f.govuk_submit %>

--- a/spec/decorators/confirmation_decorator_spec.rb
+++ b/spec/decorators/confirmation_decorator_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ConfirmationDecorator, :user_session do
         { key: 'certificate_of_origin', label: 'Certificate of origin', value: 'Yes' },
         { key: 'meursing_additional_code', label: 'Meursing Code', value: '000' },
         { key: 'customs_value', label: 'Customs value', value: '£1,200.00' },
-        { key: 'measure_amount', label: 'Import quantity', value: '100 x 100 kg' },
+        { key: 'measure_amount', label: 'Import quantity', value: "<span title='100 kg'>100 x 100 kg</span>" },
         { key: 'excise', label: 'Excise additional code', value: '444, 369' },
         { key: 'vat', label: 'Applicable VAT rate', value: 'VAT zero rate (0.0)' },
       ]
@@ -85,6 +85,26 @@ RSpec.describe ConfirmationDecorator, :user_session do
       end
 
       it 'returns n/a for documents line' do
+        expect(confirmation_decorator.user_answers).to eq(expected)
+      end
+    end
+
+    context 'when the measure amount is retail price' do
+      let(:user_session) do
+        build(
+          :user_session,
+          :with_retail_price_measure_amount,
+          commodity_code:,
+        )
+      end
+
+      let(:expected) do
+        [
+          { key: 'measure_amount', label: 'Import quantity', value: "<span title='GBP'>£1,000.00</span>" },
+        ]
+      end
+
+      it 'reverses the unit and the answer' do
         expect(confirmation_decorator.user_answers).to eq(expected)
       end
     end

--- a/spec/fixtures/confirmation_page.html
+++ b/spec/fixtures/confirmation_page.html
@@ -73,7 +73,7 @@
 </div>
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key">Import quantity</dt>
-  <dd class="govuk-summary-list__value">100 x 100 kg</dd>
+  <dd class="govuk-summary-list__value"><span title='100 kg'>100 x 100 kg</span></dd>
   <dd class="govuk-summary-list__actions">
     <a class="govuk-link" href="/duty-calculator/measure-amount">Change</a>
   </dd>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1523

### What?

I have added/removed/altered:

- [x] Updated presentation of the retail price measure unit
- [x] Added abbreviations to span titles of all measure units on confirmation decorator
- [x] Hide legend for excise additional code

### Why?

I am doing this because:

- This was noticed when reviewing the new normalised units feature
