### PR TITLE
Disable RSpec dsl in main

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.example_status_persistence_file_path = 'rspec.txt'
+  config.expose_dsl_globally = false
   config.include FactoryBot::Syntax::Methods
   config.include Rails.application.routes.url_helpers, :step
   config.before do


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Avoid monkey patched rspec dsl

### Why?

I am doing this because:

- This is consistent with the rails generators and it is generally more desirable to do things in one way, only: https://github.com/rspec/rspec-rails/commit/ca0d249858903949052e06884e8e7f9d596cdc79
