### PR TITLE
HOTT-1909: Refactor compound measure unit evaluator abstraction

### DIFF
--- a/app/models/api/base_component.rb
+++ b/app/models/api/base_component.rb
@@ -1,12 +1,12 @@
 module Api
   class BaseComponent < Api::Base
     CONJUNCTION_OPERATORS = %w[MAX MIN].freeze
-    COMPOUND_MEASURE_UNITS = %w[ASVX].freeze
     MATHEMATICAL_OPERATORS = %w[+ -].freeze
 
+    ALCOHOL_UNIT = 'ASV'.freeze
+    ALCOHOL_VOLUME_UNIT = 'ASVX'.freeze
     RETAIL_PRICE_UNIT = 'RET'.freeze
     VOLUME_UNIT = 'HLT'.freeze
-    ALCOHOL_UNIT = 'ASV'.freeze
 
     attributes :id,
                :duty_expression_id,
@@ -49,8 +49,8 @@ module Api
       "#{measurement_unit_code}#{measurement_unit_qualifier_code}"
     end
 
-    def compound_measure_unit?
-      unit.in?(COMPOUND_MEASURE_UNITS)
+    def alcohol_volume?
+      unit == ALCOHOL_VOLUME_UNIT
     end
 
     def conjunction_operator?

--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -43,8 +43,10 @@ module Api
         ExpressionEvaluators::AdValorem.new(self, component)
       elsif retail_price?
         ExpressionEvaluators::RetailPrice.new(self, component)
-      elsif specific_duty? && component.compound_measure_unit?
-        ExpressionEvaluators::CompoundMeasureUnit.new(self, component)
+      elsif specific_duty? && component.alcohol_volume?
+        ExpressionEvaluators::AlcoholVolumeMeasureUnit.new(self, component)
+      # elsif specific_duty? && component.brix?
+      #   ExpressionEvaluators::BrixMeasureUnit.new(self, component)
       elsif specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, component)
       else
@@ -58,8 +60,10 @@ module Api
         ExpressionEvaluators::AdValorem.new(self, component)
       elsif component.retail_price?
         ExpressionEvaluators::RetailPrice.new(self, component)
-      elsif component.compound_measure_unit?
-        ExpressionEvaluators::CompoundMeasureUnit.new(self, component)
+      elsif component.alcohol_volume?
+        ExpressionEvaluators::AlcoholVolumeMeasureUnit.new(self, component)
+      # elsif component.brix?
+      #   ExpressionEvaluators::BrixMeasureUnit.new(self, component)
       elsif component.specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, component)
       end

--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -45,8 +45,6 @@ module Api
         ExpressionEvaluators::RetailPrice.new(self, component)
       elsif specific_duty? && component.alcohol_volume?
         ExpressionEvaluators::AlcoholVolumeMeasureUnit.new(self, component)
-      # elsif specific_duty? && component.brix?
-      #   ExpressionEvaluators::BrixMeasureUnit.new(self, component)
       elsif specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, component)
       else
@@ -62,8 +60,6 @@ module Api
         ExpressionEvaluators::RetailPrice.new(self, component)
       elsif component.alcohol_volume?
         ExpressionEvaluators::AlcoholVolumeMeasureUnit.new(self, component)
-      # elsif component.brix?
-      #   ExpressionEvaluators::BrixMeasureUnit.new(self, component)
       elsif component.specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, component)
       end

--- a/app/services/expression_evaluators/alcohol_volume_measure_unit.rb
+++ b/app/services/expression_evaluators/alcohol_volume_measure_unit.rb
@@ -1,5 +1,5 @@
 module ExpressionEvaluators
-  class CompoundMeasureUnit < ExpressionEvaluators::Base
+  class AlcoholVolumeMeasureUnit < ExpressionEvaluators::Base
     include MeasureUnitPresentable
 
     def call

--- a/spec/factories/api/duty_expression.rb
+++ b/spec/factories/api/duty_expression.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     base { '144.10 GBP / 1000 kg/biodiesel' }
     formatted_base { "<span>144.10</span> GBP / <abbr title='Tonne'>1000 kg/biodiesel</abbr>" }
 
-    trait :compound_measure_unit do
+    trait :alcohol_volume_measure_unit do
       base { '0.50 GBP / % vol/hl + 2.60 GBP / hl' }
       formatted_base do
         "<span>0.50</span> GBP / <abbr title='%vol'>% vol/hl</abbr> + <span>2.60</span> GBP / <abbr title='Hectolitre'>hl</abbr>"

--- a/spec/factories/api/measure.rb
+++ b/spec/factories/api/measure.rb
@@ -145,13 +145,13 @@ FactoryBot.define do
 
     trait :with_compound_measure_components do
       duty_expression do
-        attributes_for(:duty_expression, :compound_measure_unit)
+        attributes_for(:duty_expression, :alcohol_volume_measure_unit)
       end
 
       measure_components do
         [
-          attributes_for(:measure_component, :compound_measure_unit),
-          attributes_for(:measure_component, :compound_measure_unit),
+          attributes_for(:measure_component, :alcohol_volume),
+          attributes_for(:measure_component, :alcohol_volume),
         ]
       end
     end

--- a/spec/factories/api/measure_component.rb
+++ b/spec/factories/api/measure_component.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
       measurement_unit_qualifier_code {}
     end
 
-    trait :compound_measure_unit do
+    trait :alcohol_volume do
       duty_amount { 0.5 }
       measurement_unit_code { 'ASV' }
       measurement_unit_qualifier_code { 'X' }

--- a/spec/models/api/base_component_spec.rb
+++ b/spec/models/api/base_component_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Api::BaseComponent do
     end
   end
 
-  describe '#compound_measure_unit?' do
+  describe '#alcohol_volume?' do
     subject(:component) do
       described_class.new(
         'measurement_unit_code' => measurement_unit_code,
@@ -103,18 +103,18 @@ RSpec.describe Api::BaseComponent do
       )
     end
 
-    context 'when the unit is a compound unit' do
+    context 'when the unit is an alcohol volume unit' do
       let(:measurement_unit_code) { 'ASV' }
       let(:measurement_unit_qualifier_code) { 'X' }
 
-      it { expect(component).to be_compound_measure_unit }
+      it { expect(component).to be_alcohol_volume }
     end
 
-    context 'when the unit is not a compound unit' do
+    context 'when the unit is not an alcohol volume unit' do
       let(:measurement_unit_code) { 'ASV' }
       let(:measurement_unit_qualifier_code) { '' }
 
-      it { expect(component).not_to be_compound_measure_unit }
+      it { expect(component).not_to be_alcohol_volume }
     end
   end
 

--- a/spec/models/api/measure_spec.rb
+++ b/spec/models/api/measure_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Api::Measure, :user_session do
       let(:measure_components) { [attributes_for(:measure_component, :with_measure_units, :single_measure_unit)] }
     end
 
-    it_behaves_like 'a measure evaluator', ExpressionEvaluators::CompoundMeasureUnit do
-      let(:measure_components) { [attributes_for(:measure_component, :with_measure_units, :compound_measure_unit)] }
+    it_behaves_like 'a measure evaluator', ExpressionEvaluators::AlcoholVolumeMeasureUnit do
+      let(:measure_components) { [attributes_for(:measure_component, :with_measure_units, :alcohol_volume)] }
     end
 
     it_behaves_like 'a measure evaluator', ExpressionEvaluators::RetailPrice do
@@ -93,13 +93,13 @@ RSpec.describe Api::Measure, :user_session do
     let(:ad_valorem) { false }
     let(:specific_duty) { false }
     let(:retail_price) { false }
-    let(:compound_measure_unit) { false }
+    let(:alcohol_volume) { false }
 
     before do
       allow(component).to receive(:ad_valorem?).and_return(ad_valorem)
       allow(component).to receive(:specific_duty?).and_return(specific_duty)
       allow(component).to receive(:retail_price?).and_return(retail_price)
-      allow(component).to receive(:compound_measure_unit?).and_return(compound_measure_unit)
+      allow(component).to receive(:alcohol_volume?).and_return(alcohol_volume)
     end
 
     shared_examples_for 'a compound measure evaluator' do |expected_evaluator|
@@ -120,9 +120,9 @@ RSpec.describe Api::Measure, :user_session do
       let(:specific_duty) { true }
     end
 
-    it_behaves_like 'a compound measure evaluator', ExpressionEvaluators::CompoundMeasureUnit do
+    it_behaves_like 'a compound measure evaluator', ExpressionEvaluators::AlcoholVolumeMeasureUnit do
       let(:specific_duty) { true }
-      let(:compound_measure_unit) { true }
+      let(:alcohol_volume) { true }
     end
 
     it_behaves_like 'a compound measure evaluator', ExpressionEvaluators::RetailPrice do

--- a/spec/services/expression_evaluators/alcohol_volume_measure_unit_spec.rb
+++ b/spec/services/expression_evaluators/alcohol_volume_measure_unit_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ExpressionEvaluators::CompoundMeasureUnit, :user_session do
+RSpec.describe ExpressionEvaluators::AlcoholVolumeMeasureUnit, :user_session do
   subject(:evaluator) { described_class.new(measure, measure.component) }
 
   include_context 'with a fake commodity'


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1909

### What?

I have added/removed/altered:

- [x] Rename compound measure unit to alcohol volume unit
- [x] Update all of the corresponding specs

### Why?

I am doing this because:

- This is required because there is no good/consistent abstraction for the measure units that need multiple inputs but have different calculations applied as part of evaluation
