### PR TITLE
HOTT-1909: Handle compound sucrose measurement units

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,5 @@
-API_SERVICE_BACKEND_URL_OPTIONS={"uk":"https://tariff-frontend-staging.london.cloudapps.digital/","xi":"https://tariff-frontend-staging.london.cloudapps.digital/xi"}
+API_SERVICE_BACKEND_URL_OPTIONS={"uk":"https://tariff-frontend-dev.london.cloudapps.digital/","xi":"https://tariff-frontend-dev.london.cloudapps.digital/xi"}
 DUTY_CALCULATOR_HOST=http://test.host
 PORT=3002
 ROUTE_THROUGH_FRONTEND=true
 TRADE_TARIFF_FRONTEND_URL="https://dev.trade-tariff.service.gov.uk"
-UPDATED_NAVIGATION=true

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,3 @@
 API_SERVICE_BACKEND_URL_OPTIONS={"uk":"https://dev.trade-tariff.service.gov.uk","xi":"https://dev.trade-tariff.service.gov.uk/xi"}
 FRONTEND_HOST=http://test.host
 TRADE_TARIFF_FRONTEND_URL='https://dev.trade-tariff.service.gov.uk'
-UPDATED_NAVIGATION=true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/trade-tariff/uktt.git
-  revision: 66ff55eeee024939267113a458d4b8c982f2fa12
+  revision: a443ca8ec5e567a0000b46ffd0360a4d601b143c
   specs:
-    uktt (2.5.0)
+    uktt (2.6.0)
       faraday
       faraday-net_http_persistent
       faraday_middleware
@@ -102,7 +102,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.10.0)
+    faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -118,8 +118,8 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -197,7 +197,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.3)
     msgpack (1.5.4)
-    multipart-post (2.1.1)
+    multipart-post (2.2.3)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     net-imap (0.2.3)

--- a/app/models/api/base_component.rb
+++ b/app/models/api/base_component.rb
@@ -4,8 +4,9 @@ module Api
     MATHEMATICAL_OPERATORS = %w[+ -].freeze
 
     ALCOHOL_UNIT = 'ASV'.freeze
-    ALCOHOL_VOLUME_UNIT = 'ASVX'.freeze
+    DECITONNE_UNIT = 'DTN'.freeze
     RETAIL_PRICE_UNIT = 'RET'.freeze
+    SUCROSE_UNIT = 'BRX'.freeze
     VOLUME_UNIT = 'HLT'.freeze
 
     attributes :id,
@@ -31,6 +32,11 @@ module Api
       amount_or_percentage: %w[01 04 19 20],
     }
 
+    enum :unit, {
+      alcohol_volume: %w[ASVX],
+      sucrose: %w[DTNZ],
+    }
+
     def ad_valorem?
       no_specific_duty?
     end
@@ -47,10 +53,6 @@ module Api
       return nil if measurement_unit_code.blank?
 
       "#{measurement_unit_code}#{measurement_unit_qualifier_code}"
-    end
-
-    def alcohol_volume?
-      unit == ALCOHOL_VOLUME_UNIT
     end
 
     def conjunction_operator?

--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -45,6 +45,8 @@ module Api
         ExpressionEvaluators::RetailPrice.new(self, component)
       elsif specific_duty? && component.alcohol_volume?
         ExpressionEvaluators::AlcoholVolumeMeasureUnit.new(self, component)
+      elsif specific_duty? && component.sucrose?
+        ExpressionEvaluators::SucroseMeasureUnit.new(self, component)
       elsif specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, component)
       else
@@ -60,6 +62,8 @@ module Api
         ExpressionEvaluators::RetailPrice.new(self, component)
       elsif component.alcohol_volume?
         ExpressionEvaluators::AlcoholVolumeMeasureUnit.new(self, component)
+      elsif component.sucrose?
+        ExpressionEvaluators::SucroseMeasureUnit.new(self, component)
       elsif component.specific_duty?
         ExpressionEvaluators::MeasureUnit.new(self, component)
       end

--- a/app/services/expression_evaluators/alcohol_volume_measure_unit.rb
+++ b/app/services/expression_evaluators/alcohol_volume_measure_unit.rb
@@ -4,7 +4,7 @@ module ExpressionEvaluators
 
     def call
       {
-        calculation: calculation_duty_expression,
+        calculation: sanitized_duty_expression,
         value:,
         formatted_value: number_to_currency(value),
       }
@@ -12,7 +12,7 @@ module ExpressionEvaluators
 
     private
 
-    def calculation_duty_expression
+    def sanitized_duty_expression
       expression =
         if measure_condition.present?
           measure_condition.duty_expression

--- a/app/services/expression_evaluators/compound.rb
+++ b/app/services/expression_evaluators/compound.rb
@@ -2,7 +2,7 @@ module ExpressionEvaluators
   class Compound < ExpressionEvaluators::Base
     def call
       {
-        calculation: calculation_duty_expression,
+        calculation: sanitized_duty_expression,
         value: evaluation_result,
         formatted_value: number_to_currency(evaluation_result),
       }
@@ -10,7 +10,7 @@ module ExpressionEvaluators
 
     private
 
-    def calculation_duty_expression
+    def sanitized_duty_expression
       sanitize(duty_expression, tags: %w[span abbr strong br], attributes: %w[title])
     end
 

--- a/app/services/expression_evaluators/measure_unit.rb
+++ b/app/services/expression_evaluators/measure_unit.rb
@@ -5,7 +5,7 @@ module ExpressionEvaluators
 
     def call
       {
-        calculation: calculation_duty_expression,
+        calculation: sanitized_duty_expression,
         value:,
         formatted_value: number_to_currency(value),
         unit: presented_unit[:unit],
@@ -16,7 +16,7 @@ module ExpressionEvaluators
 
     private
 
-    def calculation_duty_expression
+    def sanitized_duty_expression
       expression =
         if measure_condition.present?
           measure_condition.duty_expression

--- a/app/services/expression_evaluators/retail_price.rb
+++ b/app/services/expression_evaluators/retail_price.rb
@@ -4,7 +4,7 @@ module ExpressionEvaluators
 
     def call
       {
-        calculation: calculation_duty_expression,
+        calculation: sanitized_duty_expression,
         value:,
         formatted_value: number_to_currency(value),
       }
@@ -12,7 +12,7 @@ module ExpressionEvaluators
 
     private
 
-    def calculation_duty_expression
+    def sanitized_duty_expression
       "#{number_to_percentage(component.duty_amount)} * #{number_to_currency(total_amount)}"
     end
 

--- a/app/services/expression_evaluators/sucrose_measure_unit.rb
+++ b/app/services/expression_evaluators/sucrose_measure_unit.rb
@@ -4,7 +4,7 @@ module ExpressionEvaluators
 
     def call
       {
-        calculation: calculation_duty_expression,
+        calculation: sanitized_duty_expression,
         value:,
         formatted_value: number_to_currency(value),
       }
@@ -12,19 +12,14 @@ module ExpressionEvaluators
 
     private
 
-    def calculation_duty_expression
-      expression =
-        if measure_condition.present?
-          measure_condition.duty_expression
-        else
-          measure.duty_expression.formatted_base
-        end
+    def sanitized_duty_expression
+      expression = measure_condition&.duty_expression || measure.duty_expression.formatted_base
 
       sanitize(expression, tags: %w[span abbr], attributes: %w[title])
     end
 
     def value
-      candidate_value = component.duty_amount * decitonne_quantity * sucrose_quantity
+      candidate_value = component.duty_amount * quantity_in_decitonnes * sucrose_quantity
 
       if component.euros?
         candidate_value * euro_exchange_rate
@@ -33,7 +28,7 @@ module ExpressionEvaluators
       end
     end
 
-    def decitonne_quantity
+    def quantity_in_decitonnes
       presented_decitonne_unit[:answer].to_f * presented_decitonne_unit[:multiplier].to_f
     end
 

--- a/app/services/expression_evaluators/sucrose_measure_unit.rb
+++ b/app/services/expression_evaluators/sucrose_measure_unit.rb
@@ -1,0 +1,71 @@
+module ExpressionEvaluators
+  class SucroseMeasureUnit < ExpressionEvaluators::Base
+    include MeasureUnitPresentable
+
+    def call
+      {
+        calculation: calculation_duty_expression,
+        value:,
+        formatted_value: number_to_currency(value),
+      }
+    end
+
+    private
+
+    def calculation_duty_expression
+      expression =
+        if measure_condition.present?
+          measure_condition.duty_expression
+        else
+          measure.duty_expression.formatted_base
+        end
+
+      sanitize(expression, tags: %w[span abbr], attributes: %w[title])
+    end
+
+    def value
+      candidate_value = component.duty_amount * decitonne_quantity * sucrose_quantity
+
+      if component.euros?
+        candidate_value * euro_exchange_rate
+      else
+        candidate_value
+      end
+    end
+
+    def decitonne_quantity
+      presented_decitonne_unit[:answer].to_f * presented_decitonne_unit[:multiplier].to_f
+    end
+
+    def sucrose_quantity
+      presented_sucrose_unit[:answer].to_f
+    end
+
+    def decitonne_unit
+      applicable_units[Api::BaseComponent::DECITONNE_UNIT]
+    end
+
+    def sucrose_unit
+      applicable_units[Api::BaseComponent::SUCROSE_UNIT]
+    end
+
+    def presented_decitonne_unit
+      @presented_decitonne_unit ||= {
+        answer: unit_answer_for(decitonne_unit),
+        unit: decitonne_unit['unit'],
+        multiplier: decitonne_unit_multiplier,
+      }
+    end
+
+    def presented_sucrose_unit
+      @presented_sucrose_unit ||= {
+        answer: unit_answer_for(sucrose_unit),
+        unit: sucrose_unit['unit'],
+      }
+    end
+
+    def decitonne_unit_multiplier
+      decitonne_unit['multiplier'].presence || 1
+    end
+  end
+end

--- a/spec/factories/api/commodity.rb
+++ b/spec/factories/api/commodity.rb
@@ -118,6 +118,42 @@ FactoryBot.define do
       end
     end
 
+    trait :with_sucrose_measure_units do
+      import_measures do
+        [
+          attributes_for(
+            :measure,
+            :third_country_tariff,
+            :with_sucrose_measure_components,
+          ),
+        ]
+      end
+
+      applicable_measure_units do
+        {
+          'DTN' => {
+            'measurement_unit_code' => 'DTN',
+            'measurement_unit_qualifier_code' => nil,
+            'abbreviation' => '100 kg',
+            'unit_question' => 'What is the weight of the goods you will be importing?',
+            'unit_hint' => 'Enter the value in kilograms',
+            'unit' => 'kilograms',
+            'multiplier' => '0.01',
+            'coerced_measurement_unit_code' => 'KGM',
+            'original_unit' => 'x 100 kg',
+          },
+          'BRX' => {
+            'measurement_unit_code' => 'BRX',
+            'measurement_unit_qualifier_code' => '',
+            'abbreviation' => '% sucrose',
+            'unit_question' => 'What is the percentage of sucrose (Brix) in your goods?',
+            'unit_hint' => 'If you do not know the percentage sucrose content (Brix value), check the footnotes for the commodity code to identify how to calculate it.',
+            'unit' => '% sucrose',
+          },
+        }
+      end
+    end
+
     trait :with_compound_measure_units_no_multiplier do
       import_measures do
         [

--- a/spec/factories/api/duty_expression.rb
+++ b/spec/factories/api/duty_expression.rb
@@ -13,6 +13,11 @@ FactoryBot.define do
       end
     end
 
+    trait :sucrose_measure_unit do
+      base { '0.30 GBP / 100 kg/net/%sacchar.' }
+      formatted_base { "<span>0.30</span> GBP / <abbr title='Hectokilogram'>100 kg/net/%sacchar.</abbr>" }
+    end
+
     trait :euro_measure_unit do
       base { '35.10 EUR / 100 kg' }
       formatted_base { "<span>35.10</span> EUR / <abbr title='Hectokilogram'>100 kg</abbr>" }

--- a/spec/factories/api/measure.rb
+++ b/spec/factories/api/measure.rb
@@ -156,6 +156,18 @@ FactoryBot.define do
       end
     end
 
+    trait :with_sucrose_measure_components do
+      duty_expression do
+        attributes_for(:duty_expression, :sucrose_measure_unit)
+      end
+
+      measure_components do
+        [
+          attributes_for(:measure_component, :sucrose),
+        ]
+      end
+    end
+
     trait :with_euro_measure_unit_measure_component do
       duty_expression do
         attributes_for(:duty_expression, :euro_measure_unit)

--- a/spec/factories/api/measure_component.rb
+++ b/spec/factories/api/measure_component.rb
@@ -46,6 +46,12 @@ FactoryBot.define do
       measurement_unit_qualifier_code { 'X' }
     end
 
+    trait :sucrose do
+      duty_amount { 0.3 }
+      measurement_unit_code { 'DTN' }
+      measurement_unit_qualifier_code { 'Z' }
+    end
+
     trait :with_retail_price_measure_units do
       duty_amount { 16.5 }
       measurement_unit_code { 'RET' }

--- a/spec/factories/user_session.rb
+++ b/spec/factories/user_session.rb
@@ -107,6 +107,10 @@ FactoryBot.define do
     measure_amount { { 'ltr' => '45', 'asv' => '40' } }
   end
 
+  trait :with_sucrose_measure_amount do
+    measure_amount { { 'kgm' => '16320', 'brx' => '80' } }
+  end
+
   trait :with_retail_price_measure_amount do
     measure_amount { { 'ret' => '1000' } }
   end

--- a/spec/models/api/base_component_spec.rb
+++ b/spec/models/api/base_component_spec.rb
@@ -126,14 +126,14 @@ RSpec.describe Api::BaseComponent do
       )
     end
 
-    context 'when the unit is an sucrose volume unit' do
+    context 'when the unit is sucrose' do
       let(:measurement_unit_code) { 'DTN' }
       let(:measurement_unit_qualifier_code) { 'Z' }
 
       it { is_expected.to be_sucrose }
     end
 
-    context 'when the unit is not an sucrose volume unit' do
+    context 'when the unit is `not` sucrose' do
       let(:measurement_unit_code) { 'DTN' }
       let(:measurement_unit_qualifier_code) { '' }
 

--- a/spec/models/api/base_component_spec.rb
+++ b/spec/models/api/base_component_spec.rb
@@ -118,6 +118,29 @@ RSpec.describe Api::BaseComponent do
     end
   end
 
+  describe '#sucrose?' do
+    subject(:component) do
+      described_class.new(
+        'measurement_unit_code' => measurement_unit_code,
+        'measurement_unit_qualifier_code' => measurement_unit_qualifier_code,
+      )
+    end
+
+    context 'when the unit is an sucrose volume unit' do
+      let(:measurement_unit_code) { 'DTN' }
+      let(:measurement_unit_qualifier_code) { 'Z' }
+
+      it { is_expected.to be_sucrose }
+    end
+
+    context 'when the unit is not an sucrose volume unit' do
+      let(:measurement_unit_code) { 'DTN' }
+      let(:measurement_unit_qualifier_code) { '' }
+
+      it { is_expected.not_to be_sucrose }
+    end
+  end
+
   describe '#conjunction_operator?' do
     subject(:component) do
       described_class.new(

--- a/spec/models/api/measure_spec.rb
+++ b/spec/models/api/measure_spec.rb
@@ -77,6 +77,10 @@ RSpec.describe Api::Measure, :user_session do
       let(:measure_components) { [attributes_for(:measure_component, :with_measure_units, :alcohol_volume)] }
     end
 
+    it_behaves_like 'a measure evaluator', ExpressionEvaluators::SucroseMeasureUnit do
+      let(:measure_components) { [attributes_for(:measure_component, :with_measure_units, :sucrose)] }
+    end
+
     it_behaves_like 'a measure evaluator', ExpressionEvaluators::RetailPrice do
       let(:measure_components) { [attributes_for(:measure_component, :with_retail_price_measure_units)] }
     end
@@ -94,12 +98,14 @@ RSpec.describe Api::Measure, :user_session do
     let(:specific_duty) { false }
     let(:retail_price) { false }
     let(:alcohol_volume) { false }
+    let(:sucrose) { false }
 
     before do
       allow(component).to receive(:ad_valorem?).and_return(ad_valorem)
       allow(component).to receive(:specific_duty?).and_return(specific_duty)
       allow(component).to receive(:retail_price?).and_return(retail_price)
       allow(component).to receive(:alcohol_volume?).and_return(alcohol_volume)
+      allow(component).to receive(:sucrose?).and_return(sucrose)
     end
 
     shared_examples_for 'a compound measure evaluator' do |expected_evaluator|
@@ -123,6 +129,11 @@ RSpec.describe Api::Measure, :user_session do
     it_behaves_like 'a compound measure evaluator', ExpressionEvaluators::AlcoholVolumeMeasureUnit do
       let(:specific_duty) { true }
       let(:alcohol_volume) { true }
+    end
+
+    it_behaves_like 'a compound measure evaluator', ExpressionEvaluators::SucroseMeasureUnit do
+      let(:specific_duty) { true }
+      let(:sucrose) { true }
     end
 
     it_behaves_like 'a compound measure evaluator', ExpressionEvaluators::RetailPrice do

--- a/spec/services/expression_evaluators/sucrose_measure_unit_spec.rb
+++ b/spec/services/expression_evaluators/sucrose_measure_unit_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe ExpressionEvaluators::SucroseMeasureUnit, :user_session do
+  subject(:evaluator) { described_class.new(measure, measure.component) }
+
+  include_context 'with a fake commodity'
+
+  let(:measure) { commodity.import_measures.first }
+  let(:measure_component) { measure.measure_components.first }
+
+  let(:user_session) do
+    build(
+      :user_session,
+      :with_commodity_information,
+      :with_customs_value,
+      :with_sucrose_measure_amount,
+    )
+  end
+  let(:commodity) { build(:commodity, :with_sucrose_measure_units) }
+
+  let(:expected_evaluation) do
+    {
+      calculation: '<span>0.30</span> GBP / <abbr title="Hectokilogram">100 kg/net/%sacchar.</abbr>',
+      value: 3916.8,
+      formatted_value: '£3,916.80',
+    }
+  end
+
+  it { expect(evaluator.call).to eq(expected_evaluation) }
+
+  it_behaves_like 'an evaluation that uses the measure unit merger'
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1909

### What?

We evaluate (read calculate based on inputs from different places) the expressions of measure components of various kinds. Sometimes these components are expressed as a simple percentage (ad valorem) where the inputs come from the backend measure component itself (the duty amount) and sometimes they take account of the input measurement units from the user (stored in the user session).

We've recently discovered that the DTNZ type of measurement unit measure component needed to be special cased/evaluated using slightly different rules to a normal/simple measurement unit and that it actually required the input answers of two questions: What is the weight, and what is the percent sucrose content?

After updating the backend to make the relevant changes to what questions need to be answered when we encounter these measurement units, we now have to update the duty calculator to reflect the change to how these unit components get calculated (which is the result of plumbing the sucrose evaluator together when we encounter these measure components).

I have added/removed/altered:

- [x] Tidy dotenv files
- [x] Bump uktt to support basic auth locally
- [x] Adds enum for base component unit
- [x] Plumb sucrose evaluator in measure factory
- [x] Adds sucrose evaluator for DTNZ

**BEFORE**

![image](https://user-images.githubusercontent.com/8156884/186711645-3a8a6d7b-2d74-45a8-b276-82ab846fa34e.png)

**AFTER**

![image](https://user-images.githubusercontent.com/8156884/186711803-24ca4e0c-d660-46cd-85e8-9807960428f9.png)

### Why?

I am doing this because:

- We're currently doing the wrong calculations for DTNZ and are treating DTNZ as a simple coerced KGM unit.
