### PR TITLE
HOTT-2311: Quota duty options exclude safeguards

### DIFF
--- a/app/models/duty_calculator.rb
+++ b/app/models/duty_calculator.rb
@@ -11,7 +11,7 @@ class DutyCalculator
 
       next if option_klass.nil?
 
-      acc << option_klass.new(measure, additional_duty_rows, vat_measure).call
+      acc << option_klass.new(measure, additional_duty_rows_for(option_klass), vat_measure).call
     end
 
     options.sort_by(&:priority)
@@ -21,14 +21,15 @@ class DutyCalculator
 
   attr_reader :commodity
 
-  def additional_duty_rows
+  def additional_duty_rows_for(option_klass)
     rows = AdditionalDutyApplicableMeasuresMerger.new.call.each_with_object([]) do |measure, acc|
-      option_klass = measure.measure_type.additional_duty_option
+      additional_duty_option_klass = measure.measure_type.additional_duty_option
 
-      next if option_klass.nil?
+      next if additional_duty_option_klass.nil?
+      next if option_klass.excludes?(additional_duty_option_klass)
       next if measure.all_duties_zero?
 
-      acc << option_klass.new(measure, [], nil).call
+      acc << additional_duty_option_klass.new(measure, [], nil).call
     end
 
     rows.sort_by(&:priority)

--- a/app/services/duty_options/base.rb
+++ b/app/services/duty_options/base.rb
@@ -2,6 +2,7 @@ module DutyOptions
   class Base
     CATEGORY = :default
     PRIORITY = 5
+    EXCLUDED_ADDITIONAL_DUTIES = [].freeze
 
     include ActionView::Helpers::NumberHelper
     include ServiceHelper
@@ -31,6 +32,10 @@ module DutyOptions
 
     def self.id
       name.split('::').last.underscore
+    end
+
+    def self.excludes?(additional_duty_option)
+      additional_duty_option.in?(self::EXCLUDED_ADDITIONAL_DUTIES)
     end
 
     protected

--- a/app/services/duty_options/quota/base.rb
+++ b/app/services/duty_options/quota/base.rb
@@ -3,6 +3,7 @@ module DutyOptions
     class Base < DutyOptions::Base
       PRIORITY = 3
       CATEGORY = :quota
+      EXCLUDED_ADDITIONAL_DUTIES = [DutyOptions::AdditionalDuty::AdditionalDutiesSafeguard].freeze
 
       def call
         result = super

--- a/spec/models/duty_calculator_spec.rb
+++ b/spec/models/duty_calculator_spec.rb
@@ -82,11 +82,11 @@ RSpec.describe DutyCalculator, :user_session do
           values: [
             ['Valuation for import', 'Value of goods + freight + insurance costs', '£1,260.89'],
             ['Import duty<br><span class="govuk-green govuk-body-xs"> Non Preferential Quota (UK)</span>', '20.00% * £1,260.89', '£252.18'],
-            ['Import duty<br><span class="govuk-green govuk-body-xs"> Additional duties (safeguard) (UK)</span>', '25.00% * £1,260.89', '£315.22'],
+            # ['Import duty<br><span class="govuk-green govuk-body-xs"> Additional duties (safeguard) (UK)</span>', '25.00% * £1,260.89', '£315.22'], Excluded safeguard
             ['Import duty<br><span class="govuk-green govuk-body-xs"> Additional Duties (UK)</span>', '25.00% * £1,260.89', '£315.22'],
             ['Import duty (C490)<br><span class="govuk-green govuk-body-xs"> Definitive anti-dumping duty (UK)</span>', '<span>144.10</span> GBP / <abbr title="Tonne">1000 kg/biodiesel</abbr>', '£288.20'],
-            ['VAT <br><span class="govuk-green govuk-body-xs"> Standard rate</span>', '20.00% * £2,431.71', '£486.34'],
-            ['<strong>Duty Total</strong>', nil, '<strong>£1,657.17</strong>'],
+            ['VAT <br><span class="govuk-green govuk-body-xs"> Standard rate</span>', '20.00% * £2,116.49', '£423.30'],
+            ['<strong>Duty Total</strong>', nil, '<strong>£1,278.90</strong>'],
           ],
           value: 252.17799999999997,
           footnote: I18n.t('measure_type_footnotes.122'),

--- a/spec/services/duty_options/quota/non_preferential_end_use_spec.rb
+++ b/spec/services/duty_options/quota/non_preferential_end_use_spec.rb
@@ -25,4 +25,6 @@ RSpec.describe DutyOptions::Quota::NonPreferentialEndUse, :user_session do
 
     it { expect(service.call.attributes.deep_symbolize_keys).to eq(expected_table) }
   end
+
+  it_behaves_like 'a duty option that excludes safeguard additional duties'
 end

--- a/spec/services/duty_options/quota/non_preferential_spec.rb
+++ b/spec/services/duty_options/quota/non_preferential_spec.rb
@@ -25,4 +25,6 @@ RSpec.describe DutyOptions::Quota::NonPreferential, :user_session do
 
     it { expect(service.call.attributes.deep_symbolize_keys).to eq(expected_table) }
   end
+
+  it_behaves_like 'a duty option that excludes safeguard additional duties'
 end

--- a/spec/services/duty_options/quota/preferential_end_use_spec.rb
+++ b/spec/services/duty_options/quota/preferential_end_use_spec.rb
@@ -25,4 +25,6 @@ RSpec.describe DutyOptions::Quota::PreferentialEndUse, :user_session do
 
     it { expect(service.call.attributes.deep_symbolize_keys).to eq(expected_table) }
   end
+
+  it_behaves_like 'a duty option that excludes safeguard additional duties'
 end

--- a/spec/services/duty_options/quota/preferential_spec.rb
+++ b/spec/services/duty_options/quota/preferential_spec.rb
@@ -25,4 +25,6 @@ RSpec.describe DutyOptions::Quota::Preferential, :user_session do
 
     it { expect(service.call.attributes.deep_symbolize_keys).to eq(expected_table) }
   end
+
+  it_behaves_like 'a duty option that excludes safeguard additional duties'
 end

--- a/spec/support/shared_examples/a_duty_option_that_excludes_safeguard_additional_duties.rb
+++ b/spec/support/shared_examples/a_duty_option_that_excludes_safeguard_additional_duties.rb
@@ -1,0 +1,17 @@
+RSpec.shared_examples_for 'a duty option that excludes safeguard additional duties' do
+  describe '#excludes?' do
+    subject(:excludes?) { described_class.excludes?(additional_duty_option) }
+
+    context 'when the additional duty option is excluded' do
+      let(:additional_duty_option) { DutyOptions::AdditionalDuty::AdditionalDutiesSafeguard }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the additional duty option is not excluded' do
+      let(:additional_duty_option) { DutyOptions::AdditionalDuty::AdditionalDuties }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2311

### What?

I have added/removed/altered:

- [x] Added handling of safeguards for quota duty options. Quotas now exclude safeguard additional duties
- [x] Added coverage for this new feature.

### Why?

I am doing this because:

- Quotas are meant to bypass additional duty safeguards and this needs to be reflected in the duty calculator options that are presented to the user
