### PR TITLE
HOTT-2237: Handle session integrity issues when fetching schemes

### DIFF
--- a/app/models/api/commodity.rb
+++ b/app/models/api/commodity.rb
@@ -61,6 +61,8 @@ module Api
     end
 
     def rules_of_origin_schemes
+      raise Errors::SessionIntegrityError, 'origin_country_code' if user_session.origin_country_code.blank?
+
       RulesOfOriginScheme.build_collection(
         source,
         nil,

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ require "action_controller/railtie"
 require "action_view/railtie"
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
+require "errors"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,20 +1,20 @@
-require_relative "boot"
+require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
+require 'active_model/railtie'
 # require "active_job/railtie"
 require 'active_record/attribute_assignment'
 # require "active_record/railtie"
 # require "active_storage/engine"
-require "action_controller/railtie"
+require 'action_controller/railtie'
 # require "action_mailer/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
-require "action_view/railtie"
+require 'action_view/railtie'
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
-require "errors"
+require 'errors'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -33,9 +33,9 @@ module TradeTariffDutyCalculator
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.middleware.use Rack::Deflater
-    config.time_zone                 = "London"
+    config.time_zone                 = 'London'
     config.exceptions_app            = routes
-    config.trade_tariff_frontend_url = ENV["TRADE_TARIFF_FRONTEND_URL"]
-    config.duty_calculator_host      = ENV.fetch("DUTY_CALCULATOR_HOST", "http://localhost")
+    config.trade_tariff_frontend_url = ENV['TRADE_TARIFF_FRONTEND_URL']
+    config.duty_calculator_host      = ENV.fetch('DUTY_CALCULATOR_HOST', 'http://localhost')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,8 @@ require 'action_controller/railtie'
 require 'action_view/railtie'
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
-require 'errors'
+
+require_relative '../lib/errors'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,0 +1,13 @@
+module Errors
+  class SessionIntegrityError < StandardError
+    def initialize(expected_attribute)
+      super
+
+      @expected_attribute = expected_attribute
+    end
+
+    def message
+      "User session state error. You are missing #{@expected_attribute}. Do you have multiple tabs open?"
+    end
+  end
+end

--- a/spec/controllers/steps/duty_controller_spec.rb
+++ b/spec/controllers/steps/duty_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::DutyController, :user_session do
     allow(Api::MonetaryExchangeRate).to receive(:for).with('GBP').and_call_original
   end
 
-  let(:user_session) { build(:user_session, import_destination: 'XI', commodity_code: '0103921100') }
+  let(:user_session) { build(:user_session, import_destination: 'XI', commodity_code: '0103921100', country_of_origin: 'AF') }
   let(:duty_calculator) { instance_double('DutyCalculator', options: []) }
 
   describe 'GET #show' do

--- a/spec/models/api/commodity_spec.rb
+++ b/spec/models/api/commodity_spec.rb
@@ -197,16 +197,24 @@ RSpec.describe Api::Commodity, :user_session, type: :model do
       allow(Api::RulesOfOriginScheme).to receive(:build_collection).and_call_original
     end
 
-    let(:user_session) { build(:user_session, :with_row_to_gb_route) }
+    context 'when the user session has no origin country code in it' do
+      let(:user_session) { build(:user_session) }
 
-    it 'passes the correct arguments to the RulesOfOriginScheme collection builder' do
-      commodity.rules_of_origin_schemes
-
-      expect(Api::RulesOfOriginScheme).to have_received(:build_collection).with('uk', nil, { country_code: 'AR', heading_code: '070200' })
+      it { expect { commodity.rules_of_origin_schemes }.to raise_error(Errors::SessionIntegrityError, /origin_country_code/) }
     end
 
-    it 'returns a collection of RulesOfOriginScheme records' do
-      expect(commodity.rules_of_origin_schemes.first).to be_a(Api::RulesOfOriginScheme)
+    context 'when the user session has an origin country code in it' do
+      let(:user_session) { build(:user_session, :with_row_to_gb_route) }
+
+      it 'passes the correct arguments to the RulesOfOriginScheme collection builder' do
+        commodity.rules_of_origin_schemes
+
+        expect(Api::RulesOfOriginScheme).to have_received(:build_collection).with('uk', nil, { country_code: 'AR', heading_code: '070200' })
+      end
+
+      it 'returns a collection of RulesOfOriginScheme records' do
+        expect(commodity.rules_of_origin_schemes.first).to be_a(Api::RulesOfOriginScheme)
+      end
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2237

### What?

I have added/removed/altered:

- [x] Added handling for session integrity issues when rendering rules of origin schemes
- [x] Added test coverage for the new behaviour

### Why?

I am doing this because:

- This is required to properly handle https://sentry.io/organizations/engine-le/issues/3089605005/events/6c7e1d78eefe42b29e862a7ac3db6627/?project=5557005
