### PR TITLE
HOTT-2494 Use Secure cookies in production

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,37 +14,60 @@ AllCops:
     - 'tmp/**/*'
     - 'config/**/*'
     - 'node_modules/**/*'
+
 Layout/LineLength:
   Max: 120
+
 Layout/AccessModifierIndentation:
   Enabled: false
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Exclude:
+    - config/initializers/*.rb
+    - config/environments/*.rb
+
 Lint/AmbiguousBlockAssociation:
   Enabled: false
+
 Metrics/AbcSize:
   Max: 20
+
 Metrics/BlockLength:
   Enabled: false
+
 Metrics/ModuleLength:
   Enabled: false
+
 RSpec/ExampleLength:
   Enabled: false
+
 RSpec/MultipleMemoizedHelpers:
   Max: 11
+
 RSpec/NestedGroups:
   Enabled: false
+
 Rails/SaveBang:
   Enabled: false
+
 RSpec/FilePath:
   Enabled: false
+
 RSpec/VerifiedDoubles:
   Enabled: false
+
 Style/Documentation:
   Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: never
+
 Style/GuardClause:
   MinBodyLength: 2
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
-
+  Exclude:
+    - config/initializers/*.rb
+    - config/environments/*.rb

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = (ENV['SKIP_FORCE_SSL'] != 'true')
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
### Jira link

HOTT-2494

### What?

I have added/removed/altered:

- [x] Use secure cookies in production environments

### Why?

I am doing this because:

- it prevents the cookies being included in redirects from non SSL urls

### Deployment risks (optional)

- Low

### Screenshot

![Screenshot from 2023-01-18 09-53-21](https://user-images.githubusercontent.com/10818/213140491-c5f28c31-3c41-449e-8772-3685f039ed2a.png)
