### PR TITLE
HOTT-2570: Prevent url manipulation

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,4 +1,9 @@
 module ServiceHelper
+  UK_SERVICE = 'uk'.freeze
+  XI_SERVICE = 'xi'.freeze
+
+  DEFAULT_REFERRED_SERVICE = UK_SERVICE.freeze
+
   def title
     t("title.#{referred_service}")
   end
@@ -55,6 +60,10 @@ module ServiceHelper
     xi_only_service_url_for('/meursing_lookup/steps/start')
   end
 
+  def referred_service
+    params_referred_service.presence || session_referred_service.presence || DEFAULT_REFERRED_SERVICE
+  end
+
   private
 
   def service_url_for(path)
@@ -66,14 +75,28 @@ module ServiceHelper
   def xi_only_service_url_for(path)
     return '#' if trade_tariff_frontend_url.blank?
 
-    File.join(trade_tariff_frontend_url, 'xi', path)
+    File.join(trade_tariff_frontend_url, XI_SERVICE, path)
   end
 
   def referred_service_url
-    referred_service == 'uk' ? '' : referred_service.to_s
+    referred_service == UK_SERVICE ? '' : referred_service.to_s
   end
 
-  def referred_service
-    params[:referred_service] || session['referred_service'] || 'uk'
+  def params_referred_service
+    case params[:referred_service]
+    when UK_SERVICE
+      UK_SERVICE
+    when XI_SERVICE
+      XI_SERVICE
+    end
+  end
+
+  def session_referred_service
+    case UserSession.get.referred_service
+    when UK_SERVICE
+      UK_SERVICE
+    when XI_SERVICE
+      XI_SERVICE
+    end
   end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -133,4 +133,60 @@ RSpec.describe ServiceHelper, :user_session do
       end
     end
   end
+
+  describe '#referred_service' do
+    subject(:result) { helper.referred_service }
+
+    context 'when the service comes from the url params' do
+      let(:params) { ActionController::Parameters.new(referred_service:).permit(:referred_service) }
+
+      context 'when the url params value is the exact uk service' do
+        let(:referred_service) { 'uk' }
+
+        it { is_expected.to eq('uk') }
+      end
+
+      context 'when the url params value is the exact xi service' do
+        let(:referred_service) { 'xi' }
+
+        it { is_expected.to eq('xi') }
+      end
+
+      context 'when the url params value is anything but the xi or uk service' do
+        let(:referred_service) { 'https://redirect.here/phishing' }
+
+        it { is_expected.to eq('uk') }
+      end
+    end
+
+    context 'when the service comes from the session' do
+      let(:params) { ActionController::Parameters.new(referred_service: nil).permit(:referred_service) }
+      let(:user_session) { build(:user_session, referred_service:) }
+
+      context 'when the session value is the exact uk service' do
+        let(:referred_service) { 'uk' }
+
+        it { is_expected.to eq('uk') }
+      end
+
+      context 'when the session value is the exact xi service' do
+        let(:referred_service) { 'xi' }
+
+        it { is_expected.to eq('xi') }
+      end
+
+      context 'when the session value is anything but the xi or uk service' do
+        let(:referred_service) { 'https://redirect.here/phishing' }
+
+        it { is_expected.to eq('uk') }
+      end
+    end
+
+    context 'when the service is not present on the url params or the session' do
+      let(:params) { ActionController::Parameters.new(referred_service: nil).permit(:referred_service) }
+      let(:user_session) { build(:user_session, referred_service: nil) }
+
+      it { is_expected.to eq('uk') }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2570

![image](https://user-images.githubusercontent.com/8156884/214015393-4e54bc18-836c-42ed-967d-7f88f6de0db5.png)


### What?

I have added/removed/altered:

- [x] Added safer handling of user session and params when redirecting the user to the OTT

### Why?

I am doing this because:

- This is required to remedy https://github.com/trade-tariff/trade-tariff-duty-calculator/security/code-scanning/1
