### PR TITLE
HOTT-2989: Adds support for broken additional codes

### DIFF
--- a/app/models/api/base.rb
+++ b/app/models/api/base.rb
@@ -9,6 +9,10 @@ module Api
       @attributes = ActiveSupport::HashWithIndifferentAccess.new(attributes.fetch('attributes', attributes))
     end
 
+    def [](key)
+      attributes[key]
+    end
+
     class << self
       def inherited(child)
         super

--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -90,10 +90,6 @@ module Api
       additional_code.code
     end
 
-    def additional_code_answer
-      user_session.additional_code_for(measure_type, source) if measure_type.excise?
-    end
-
     # Measures are always applicable unless they have a condition which makes them conditionally applicable.
     def applicable?
       return true if applicable_document_condition.blank?

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -102,10 +102,12 @@ class UserSession
     }
   end
 
-  def additional_code_for(measure_type, source = 'uk')
-    return excise_additional_code[measure_type.id] if measure_type.excise?
+  def additional_code_for(measure_type_id, source = 'uk')
+    public_send("additional_code_#{source}")[measure_type_id]
+  end
 
-    public_send("additional_code_#{source}")[measure_type.id]
+  def excise_additional_code_for(measure_type_id)
+    excise_additional_code[measure_type_id]
   end
 
   def document_code_for(measure_type_id, source)

--- a/app/services/duty_options/additional_duty/excise.rb
+++ b/app/services/duty_options/additional_duty/excise.rb
@@ -32,7 +32,7 @@ module DutyOptions
 
       def additional_code
         applicable_additional_codes.find do |code|
-          code['code'] == "X#{user_session.additional_code_for(measure.measure_type)}"
+          code['code'] == "X#{user_session.excise_additional_code_for(measure.measure_type.id)}"
         end
       end
 

--- a/spec/factories/api/commodity.rb
+++ b/spec/factories/api/commodity.rb
@@ -362,5 +362,55 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :with_none_additional_code_measures do
+      applicable_additional_codes do
+        {
+          '103' => {
+            'measure_type_description' => 'Foo',
+            'heading' => {
+              'overlay' => 'Bar',
+              'hint' => 'Baz',
+            },
+            'additional_codes' => [
+              {
+                'code' => 'B107',
+                'overlay' => 'BIOX Corporation, Oakville, Ontario, Canada<br>',
+                'hint' => '',
+                'measure_sid' => 20_041_389,
+              },
+              {
+                'code' => 'none',
+                'overlay' => 'Pick the none option',
+                'hint' => '',
+                'measure_sid' => 20_041_402,
+              },
+            ],
+          },
+        }
+      end
+
+      import_measures do
+        [
+          attributes_for(
+            :measure,
+            :third_country_tariff,
+            id: 20_041_389,
+            additional_code: attributes_for(:api_additional_code, code: 'B107'),
+          ),
+          attributes_for(
+            :measure,
+            :third_country_tariff,
+            id: 20_041_402,
+            additional_code: nil,
+          ),
+          attributes_for(
+            :measure,
+            :autonomous,
+            id: 20_041_462,
+          ),
+        ]
+      end
+    end
   end
 end

--- a/spec/models/api/commodity_spec.rb
+++ b/spec/models/api/commodity_spec.rb
@@ -113,6 +113,12 @@ RSpec.describe Api::Commodity, :user_session, type: :model do
       it { expect(commodity.formatted_commodity_code(additional_code)).to eq('0702 00 00 07 (B787)') }
     end
 
+    context 'when an additional_code is passed that is `none`' do
+      let(:additional_code) { 'none' }
+
+      it { expect(commodity.formatted_commodity_code(additional_code)).to eq('0702 00 00 07 (No additional code)') }
+    end
+
     context 'when a nil additional_code is passed' do
       let(:additional_code) { nil }
 
@@ -136,14 +142,52 @@ RSpec.describe Api::Commodity, :user_session, type: :model do
     end
 
     context 'when there are additional code answers on the session' do
-      let(:user_session) { build(:user_session, additional_code: { 'uk' => { '552' => 'C114' } }) }
-      let(:targeted_measure_sid) {  20_041_415 } # Definitive anti-dumping
+      let(:commodity) { build(:commodity, :with_none_additional_code_measures) }
+      let(:user_session) { build(:user_session, additional_code: { 'uk' => { '103' => picked_additional_code } }) }
 
-      it 'filters in measures which match the additional_code' do
-        has_measure = commodity.applicable_measures.any? { |measure| measure.id == targeted_measure_sid }
+      context 'when the user picks `none`' do
+        let(:picked_additional_code) { 'none' }
 
-        expect(has_measure).to be(true)
+        it 'filters in measures which match the measure_sid' do
+          expect(commodity.applicable_measures.pluck(:id)).to eq([20_041_462, 20_041_402])
+        end
+
+        it 'filters in measures which match the additional_code' do
+          expect(commodity.applicable_measures.pluck(:additional_code)).to eq([nil, nil])
+        end
       end
+
+      context 'when the user picks `B107`' do
+        let(:picked_additional_code) { 'B107' }
+
+        it 'filters in measures which match the measure_sid' do
+          expect(commodity.applicable_measures.pluck(:id)).to eq([20_041_462, 20_041_389])
+        end
+
+        it 'filters in measures which match the additional_code' do
+          expect(commodity.applicable_measures.pluck(:additional_code))
+            .to include(
+              nil,
+              {
+                'code' => 'B107',
+                'description' => nil,
+                'formatted_description' => nil,
+                'id' => anything,
+              },
+            )
+        end
+      end
+
+      context 'when the user has not answered' do
+        let(:picked_additional_code) { nil }
+
+        it 'returns just the no additional code measures' do
+          expect(commodity.applicable_measures.pluck(:id)).to eq([20_041_462])
+        end
+      end
+    end
+
+    context 'when there are `none` additional code measures' do
     end
   end
 

--- a/spec/models/api/measure_spec.rb
+++ b/spec/models/api/measure_spec.rb
@@ -553,20 +553,6 @@ RSpec.describe Api::Measure, :user_session do
     end
   end
 
-  describe '#additional_code_answer' do
-    context 'when the measure type is excise' do
-      subject(:measure) { build(:measure, :excise) }
-
-      it { expect(measure.additional_code_answer).to eq('444') }
-    end
-
-    context 'when the measure type is not excise' do
-      subject(:measure) { build(:measure) }
-
-      it { expect(measure.additional_code_answer).to be_nil }
-    end
-  end
-
   describe '#applicable?' do
     subject(:measure) do
       described_class.new(

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -580,46 +580,26 @@ RSpec.describe UserSession do
   end
 
   describe '#additional_code_for' do
-    subject(:user_session) do
-      build(
-        :user_session,
-        :with_additional_codes,
-        :with_excise_additional_codes,
-      )
+    subject(:user_session) { build(:user_session, :with_additional_codes) }
+
+    context 'with a corresponding answer on the session' do
+      it { expect(user_session.additional_code_for('103', 'uk')).to eq('2600') }
     end
 
-    let(:measure_type) { Api::MeasureType.new(id:, measure_type_series_id:) }
+    context 'with no corresponding answer on the session' do
+      it { expect(user_session.additional_code_for('117', 'uk')).to be_nil }
+    end
+  end
 
-    context 'when the measure type is an excise measure type' do
-      let(:measure_type_series_id) { 'Q' }
+  describe '#excise_additional_code_for' do
+    subject(:user_session) { build(:user_session, :with_excise_additional_codes) }
 
-      context 'with a corresponding answer on the session' do
-        let(:id) { '306' }
-
-        it { expect(user_session.additional_code_for(measure_type, 'uk')).to eq('444') }
-      end
-
-      context 'with no corresponding answer on the session' do
-        let(:id) { 'LGJ' }
-
-        it { expect(user_session.additional_code_for(measure_type, 'uk')).to be_nil }
-      end
+    context 'with a corresponding answer on the session' do
+      it { expect(user_session.excise_additional_code_for('306')).to eq('444') }
     end
 
-    context 'when the measure type is not an excise measure type' do
-      let(:measure_type_series_id) { 'C' }
-
-      context 'with a corresponding answer on the session' do
-        let(:id) { '103' }
-
-        it { expect(user_session.additional_code_for(measure_type, 'uk')).to eq('2600') }
-      end
-
-      context 'with no corresponding answer on the session' do
-        let(:id) { '117' }
-
-        it { expect(user_session.additional_code_for(measure_type, 'uk')).to be_nil }
-      end
+    context 'with no corresponding answer on the session' do
+      it { expect(user_session.excise_additional_code_for('LGJ')).to be_nil }
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2989

### What?

I have added/removed/altered:

- [x] Enable pluck on Base model
- [x] Removes unused method and spec
- [x] Adds support for broken additional codes

### Why?

I am doing this because:

- This is to make the duty calculator make more sense to users in the interim
