### PR TITLE
HOTT-2989: Fixes issue with source of additional code

### DIFF
--- a/app/models/api/commodity.rb
+++ b/app/models/api/commodity.rb
@@ -103,7 +103,7 @@ module Api
         answer = if measure.measure_type.excise?
                    "X#{user_session.excise_additional_code_for(measure.measure_type.id)}"
                  else
-                   user_session.additional_code_for(measure.measure_type.id)
+                   user_session.additional_code_for(measure.measure_type.id, source)
                  end
 
         code = measure.additional_code.presence&.code || 'none'

--- a/spec/models/api/commodity_spec.rb
+++ b/spec/models/api/commodity_spec.rb
@@ -142,12 +142,12 @@ RSpec.describe Api::Commodity, :user_session, type: :model do
     end
 
     context 'when there are additional code answers on the session' do
-      let(:commodity) { build(:commodity, :with_none_additional_code_measures) }
+      let(:commodity) { build(:commodity, :with_none_additional_code_measures, source: 'xi') }
 
       let(:user_session) do
         build(
           :user_session,
-          additional_code: { 'uk' => { '103' => picked_additional_code } },
+          additional_code: { 'xi' => { '103' => picked_additional_code } },
           excise: { '306' => '419' },
         )
       end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2989

### What?

I have added/removed/altered:

- [x] Added source for the additional code answer with coverage

### Why?

I am doing this because:

- On some of our more complex routes we store answers for either the XI/UK measures which are independent and can be different
