### PR TITLE
HOTT-3621: Add healthcheckz to duty calculator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,17 +331,6 @@ workflows:
             branches:
               ignore: /.*/
 
-      - smoketest_staging:
-          name: smoketest_release_to_staging
-          context: trade-tariff
-          filters:
-            tags:
-              only: /^release-202[\d-]+/
-            branches:
-              ignore: /.*/
-          requires:
-            - deploy_release_to_staging
-
       - hold_deploy_production:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ orbs:
 commands:
   cf_deploy_docker:
     parameters:
-      docker_image_tag:
+      docker_tag:
         type: string
       space:
         type: string
@@ -22,6 +22,7 @@ commands:
         type: string
       app_domain_prefix:
         type: string
+
     steps:
       - checkout
       - tariff/cf-install:
@@ -30,8 +31,8 @@ commands:
       - tariff/deploy-dark-app:
           aws_access_key_id: "$AWS_ACCESS_KEY_ID"
           aws_secret_access_key: "$AWS_SECRET_ACCESS_KEY"
-          cf_app: tariff-frontend
-          docker_image: tariff-frontend
+          cf_app: tariff-duty-calculator
+          docker_image: tariff-dutycalculator
           docker_tag: << parameters.docker_tag >>
           ecr_repo: "$ECR_REPO"
           environment_key: << parameters.environment_key >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,23 +78,6 @@ commands:
           event: pass
           template: basic_success_1
 
-  sentry-release:
-    steps:
-      - checkout
-      - run:
-          name: Create release and notify Sentry of deploy
-          command: |
-            sudo curl -sL \
-                      -o /usr/local/bin/sentry-cli \
-                      https://github.com/getsentry/sentry-cli/releases/download/1.74.3/sentry-cli-Linux-x86_64
-            sudo chmod 0755 /usr/local/bin/sentry-cli
-            export SENTRY_RELEASE=$(sentry-cli releases propose-version)
-            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE &&
-              sentry-cli releases set-commits $SENTRY_RELEASE --auto &&
-              sentry-cli releases finalize $SENTRY_RELEASE &&
-              sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT ||
-              /usr/bin/true # prevent sentry outage from blocking deploys - see HOTT-1570
-
 jobs:
   checking:
     docker:
@@ -180,11 +163,12 @@ jobs:
           consider-branch: false
           dont-quit: true
       - cf_deploy_docker:
-          docker_image_tag: dev-$CIRCLE_SHA1
+          docker_tag: dev-$CIRCLE_SHA1
           space: "development"
           environment_key: "dev"
           app_domain_prefix: "dev"
-      - sentry-release
+      - tariff/sentry-release:
+          environment: development
 
   deploy_main_to_staging:
     docker:
@@ -196,18 +180,19 @@ jobs:
           time: "10"
           dont-quit: true
       - cf_deploy_docker:
-          docker_image_tag: $CIRCLE_SHA1
+          docker_tag: $CIRCLE_SHA1
           space: "staging"
           environment_key: "staging"
           app_domain_prefix: "staging"
-      - sentry-release
+      - tariff/sentry-release:
+          environment: staging
 
   deploy_release_to_staging:
     docker:
       - image: cimg/ruby:3.2.2
     steps:
       - cf_deploy_docker:
-          docker_image_tag: $CIRCLE_TAG
+          docker_tag: $CIRCLE_TAG
           space: "staging"
           environment_key: "staging"
           app_domain_prefix: "staging"
@@ -219,11 +204,12 @@ jobs:
       SENTRY_ENVIRONMENT: "production"
     steps:
       - cf_deploy_docker:
-          docker_image_tag: $CIRCLE_TAG
+          docker_tag: $CIRCLE_TAG
           space: "production"
           environment_key: "production"
           app_domain_prefix: "www"
-      - sentry-release
+      - tariff/sentry-release:
+          environment: production
       - tariff/notify-production-release:
           app-name: Duty Calculator
           slack-channel: trade_tariff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
       - tariff/test-dark-app:
           cf_app: tariff-duty-calculator
           environment_key: << parameters.environment_key >>
-          healthcheck_path: "/duty-calculator/healthcheck"
+          healthcheck_path: "/healthcheckz"
 
       - tariff/pivot-dark-app:
           app_domain_prefix: << parameters.app_domain_prefix >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,8 @@ commands:
 
             cf map-route \
               "$CF_APP-<< parameters.environment_key >>-dark" \
-              london.cloudapps.digital \
-              -n "$CF_APP-<< parameters.environment_key >>-dark" \
-              --path /duty-calculator
+                << parameters.environment_key >>.trade-tariff.service.gov.uk \
+                --path "/duty-calculator"
 
             cf add-network-policy \
               "$CF_APP-<< parameters.environment_key >>-dark" \
@@ -75,14 +74,14 @@ commands:
           environment_key: << parameters.environment_key >>
           space: << parameters.space >>
 
-      - run:
-          name: 'Custom pivot dark app'
-          command: |
-            app_name="tariff-duty-calculator-<< parameters.environment_key >>"
-            cf unmap-route \
-              $app_name \
-              "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk \
-              --path "/duty-calculator"
+      # - run:
+      #     name: 'Custom pivot dark app'
+      #     command: |
+      #       app_name="tariff-duty-calculator-<< parameters.environment_key >>"
+      #       cf unmap-route \
+      #         $app_name \
+      #         "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk \
+      #         --path "/duty-calculator"
 
       - slack/notify:
           channel: deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
       - tariff/test-dark-app:
           cf_app: tariff-duty-calculator
           environment_key: << parameters.environment_key >>
-          healthcheck_path: "healthcheckz"
+          healthcheck_path: "/duty-calculator/healthcheck"
 
       - tariff/pivot-dark-app:
           app_domain_prefix: << parameters.app_domain_prefix >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
               --port 8080
 
       - tariff/test-dark-app:
-          cf_app: tariff-dutycalculator
+          cf_app: tariff-duty-calculator
           environment_key: << parameters.environment_key >>
           healthcheck_path: "healthcheckz"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,12 @@ commands:
               london.cloudapps.digital \
               -n "$CF_APP-<< parameters.environment_key >>-dark"
 
+            cf map-route \
+              "$CF_APP-<< parameters.environment_key >>-dark" \
+              london.cloudapps.digital \
+              -n "$CF_APP-<< parameters.environment_key >>-dark" \
+              --path /duty-calculator
+
             cf add-network-policy \
               "$CF_APP-<< parameters.environment_key >>-dark" \
               "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" \
@@ -68,6 +74,15 @@ commands:
           cf_app: tariff-duty-calculator
           environment_key: << parameters.environment_key >>
           space: << parameters.space >>
+
+      - run:
+          name: 'Custom pivot dark app'
+          command: |
+            app_name="tariff-duty-calculator-<< parameters.environment_key >>"
+            cf unmap-route \
+              $app_name \
+              "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk \
+              --path "/duty-calculator"
 
       - slack/notify:
           channel: deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
   ruby: circleci/ruby@2
   slack: circleci/slack@4.3.0
   queue: eddiewebb/queue@1.6.4
-  tariff: trade-tariff/trade-tariff-ci-orb@0 # can also change to @dev:<gitsha> for specific version or @dev:alpha to test dev branches
+  tariff: trade-tariff/trade-tariff-ci-orb@0
 
 commands:
   cf_deploy_docker:
@@ -73,15 +73,6 @@ commands:
           cf_app: tariff-duty-calculator
           environment_key: << parameters.environment_key >>
           space: << parameters.space >>
-
-      # - run:
-      #     name: 'Custom pivot dark app'
-      #     command: |
-      #       app_name="tariff-duty-calculator-<< parameters.environment_key >>"
-      #       cf unmap-route \
-      #         $app_name \
-      #         "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk \
-      #         --path "/duty-calculator"
 
       - slack/notify:
           channel: deployments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,60 +26,48 @@ commands:
       - checkout
       - tariff/cf-install:
           space: << parameters.space >>
+
+      - tariff/deploy-dark-app:
+          aws_access_key_id: "$AWS_ACCESS_KEY_ID"
+          aws_secret_access_key: "$AWS_SECRET_ACCESS_KEY"
+          cf_app: tariff-frontend
+          docker_image: tariff-frontend
+          docker_tag: << parameters.docker_tag >>
+          ecr_repo: "$ECR_REPO"
+          environment_key: << parameters.environment_key >>
+          space: << parameters.space >>
+
       - run:
-          name: "Fetch existing manifest"
+          name: Map dark routes
           command: |
-            cf create-app-manifest "$CF_APP-<< parameters.environment_key >>" -p deploy_manifest.yml
-      - run:
-          name: "Push new app in dark mode"
-          command: |
-            export DOCKER_IMAGE=tariff-dutycalculator
-            export DOCKER_TAG="<< parameters.docker_image_tag >>"
+            cf map-route \
+              "$CF_APP-<< parameters.environment_key >>-dark" \
+              london.cloudapps.digital \
+              -n "$CF_APP-<< parameters.environment_key >>-dark"
 
-            # Push as "dark" instance
-            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push  "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
+            cf add-network-policy \
+              "$CF_APP-<< parameters.environment_key >>-dark" \
+              "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" \
+              --protocol tcp \
+              --port 8080
 
-            # Map dark route
-            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
-            # Enable routing from this service to the backend applications which are private
-            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" --protocol tcp --port 8080
-            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_UK-<< parameters.environment_key >>" --protocol tcp --port 8080
-      - run:
-          name: "Verify new version is working on dark URL."
-          command: |
-            sleep 15
-            # Verify new version is working on dark URL.
-            HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-<< parameters.environment_key >>-dark.london.cloudapps.digital/duty-calculator/ping`
+            cf add-network-policy \
+              "$CF_APP-<< parameters.environment_key >>-dark" \
+              "$CF_BACKEND_APP_UK-<< parameters.environment_key >>" \
+              --protocol tcp
+              --port 8080
 
-            if [ "$HTTPCODE" -ne 200 ];then
-              echo "dark route not available, failing deploy ($HTTPCODE)"
-              cf logs "$CF_APP-<< parameters.environment_key >>-dark" --recent
-              cf delete -f  "$CF_APP-<< parameters.environment_key >>-dark"
-              exit 1
-            fi
-      - run:
-          name: "Switch dark app to live"
-          command: |
-            # Send "real" url to new version
-            cf unmap-route "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
+      - tariff/test-dark-app:
+          cf_app: tariff-dutycalculator
+          environment_key: << parameters.environment_key >>
+          healthcheck_path: "healthcheckz"
 
-            # Start sending traffic to new version
-            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
-            # TODO: Update when we remove referring service from the path
-            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk --path "/duty-calculator"
+      - tariff/pivot-dark-app:
+          app_domain_prefix: << parameters.app_domain_prefix >>
+          cf_app: tariff-duty-calculator
+          environment_key: << parameters.environment_key >>
+          space: << parameters.space >>
 
-            # Stop sending traffic to previous version
-            cf unmap-route  "$CF_APP-<< parameters.environment_key >>" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
-            cf unmap-route  "$CF_APP-<< parameters.environment_key >>" "<< parameters.app_domain_prefix >>".trade-tariff.service.gov.uk --path "/duty-calculator"
-
-            # stop previous version
-            cf stop "$CF_APP-<< parameters.environment_key >>"
-
-            # delete previous version
-            cf delete "$CF_APP-<< parameters.environment_key >>" -f
-
-            # Switch name of "dark" version to claim correct name
-            cf rename "$CF_APP-<< parameters.environment_key >>-dark" "$CF_APP-<< parameters.environment_key >>"
       - slack/notify:
           channel: deployments
           event: fail
@@ -88,34 +76,6 @@ commands:
           channel: deployments
           event: pass
           template: basic_success_1
-
-  smoketest:
-    parameters:
-      url:
-        type: string
-      space:
-        type: string
-    steps:
-      - run:
-          name: "Checkout tests repo"
-          command: git clone --depth=1 "https://github.com/trade-tariff/trade-tariff-testing/"
-      - restore_cache:
-          keys:
-            - v2-smoketest-deps-{{ checksum "trade-tariff-testing/yarn.lock" }}
-      - run:
-          name: "Install NPM packages"
-          command: "cd trade-tariff-testing && yarn install"
-      - save_cache:
-          key: v2-smoketest-deps-{{ checksum "trade-tariff-testing/yarn.lock" }}
-          paths:
-            - trade-tariff-testing/node_modules
-            - /root/.cache/Cypress
-      - run:
-          name: "Cypress Smoke tests"
-          command: |
-            cd trade-tariff-testing
-
-            yarn run << parameters.space >>-tariff-duty-calculator-smoketests
 
   sentry-release:
     steps:
@@ -135,22 +95,6 @@ commands:
               /usr/bin/true # prevent sentry outage from blocking deploys - see HOTT-1570
 
 jobs:
-  smoketest_dev:
-    docker:
-      - image: "cypress/base:16.5.0"
-    steps:
-      - smoketest:
-          url: https://dev.trade-tariff.service.gov.uk
-          space: dev
-
-  smoketest_staging:
-    docker:
-      - image: "cypress/base:16.5.0"
-    steps:
-      - smoketest:
-          url: https://staging.trade-tariff.service.gov.uk
-          space: staging
-
   checking:
     docker:
       - image: cimg/ruby:3.2.2-node
@@ -289,12 +233,14 @@ workflows:
   build_and_test:
     jobs:
       - checking
+
       - test:
           context: trade-tariff
           filters:
             branches:
               ignore:
                 - main
+
       - build:
           name: build_dev
           context: trade-tariff
@@ -307,6 +253,7 @@ workflows:
                 - /^dependabot/(?!docker/).*/
           requires:
             - test
+
       - deploy_dev:
           context: trade-tariff
           filters:
@@ -317,17 +264,20 @@ workflows:
                 - /^dependabot/(?!docker/).*/
           requires:
             - build_dev
-      - smoketest_dev:
+
+      - tariff/smoketests:
           name: smoketest_dev
           context: trade-tariff
+          url: https://dev.trade-tariff.service.gov.uk
+          yarn_run: dev-tariff-duty-calculator-smoketests
+          requires:
+            - deploy_dev
           filters:
             branches:
               ignore:
-                - main
-                - /^hotfix\/.+/
                 - /^dependabot/(?!docker/).*/
-          requires:
-            - deploy_dev
+                - /^hotfix\/.+/
+
       - build:
           name: build_live
           context: trade-tariff
@@ -336,6 +286,7 @@ workflows:
               only:
                 - main
                 - /^hotfix\/.+/
+
       - deploy_main_to_staging:
           context: trade-tariff
           filters:
@@ -345,15 +296,20 @@ workflows:
                 - /^hotfix\/.+/
           requires:
             - build_live
-      - smoketest_staging:
+
+      - tariff/smoketests:
+          name: smoketest_staging
           context: trade-tariff
-          filters:
-            branches:
-              only:
-                - main
-                - /^hotfix\/.+/
+          url: https://staging.trade-tariff.service.gov.uk
+          yarn_run: staging-tariff-duty-calculator-smoketests
           requires:
             - deploy_main_to_staging
+          filters:
+            branches:
+              ignore:
+                - /^dependabot/(?!docker/).*/
+                - /^hotfix\/.+/
+
       - hold_create_release:
           type: approval
           filters:
@@ -363,6 +319,7 @@ workflows:
                 - /^hotfix\/.+/
           requires:
             - deploy_main_to_staging
+
       - tariff/create-production-release:
           context: trade-tariff
           image-name: tariff-dutycalculator
@@ -373,13 +330,20 @@ workflows:
                 - /^hotfix\/.+/
           requires:
             - hold_create_release
-      - deploy_release_to_staging:
+
+      - tariff/smoketests:
+          name: smoketest_release_to_staging
           context: trade-tariff
+          url: https://staging.trade-tariff.service.gov.uk
+          yarn_run: staging-tariff-duty-calculator-smoketests
+          requires:
+            - deploy_main_to_staging
           filters:
             tags:
               only: /^release-202[\d-]+/
             branches:
               ignore: /.*/
+
       - smoketest_staging:
           name: smoketest_release_to_staging
           context: trade-tariff
@@ -390,6 +354,7 @@ workflows:
               ignore: /.*/
           requires:
             - deploy_release_to_staging
+
       - hold_deploy_production:
           type: approval
           filters:
@@ -397,6 +362,7 @@ workflows:
               only: /^release-202[\d-]+/
             branches:
               ignore: /.*/
+
       - deploy_production:
           context: trade-tariff
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
             cf add-network-policy \
               "$CF_APP-<< parameters.environment_key >>-dark" \
               "$CF_BACKEND_APP_UK-<< parameters.environment_key >>" \
-              --protocol tcp
+              --protocol tcp \
               --port 8080
 
       - tariff/test-dark-app:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
       - tariff/test-dark-app:
           cf_app: tariff-duty-calculator
           environment_key: << parameters.environment_key >>
-          healthcheck_path: "healthcheckz"
+          healthcheck_path: "/duty-calculator/healthcheckz"
 
       - tariff/pivot-dark-app:
           app_domain_prefix: << parameters.app_domain_prefix >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
       - tariff/test-dark-app:
           cf_app: tariff-duty-calculator
           environment_key: << parameters.environment_key >>
-          healthcheck_path: "/duty-calculator/healthcheckz"
+          healthcheck_path: "healthcheckz"
 
       - tariff/pivot-dark-app:
           app_domain_prefix: << parameters.app_domain_prefix >>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+---
+files: (^terraform\/\S+)|(.pre\-commit\-config.yaml)|(.circleci\/\S+)
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.81.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_tflint
+      - id: terraform_tfsec
+      - id: terraform_docs
+        args:
+          - --hook-config=--add-to-existing-file=true
+          - --hook-config=--path-to-file=README.md
+          - --hook-config=--create-file-if-not-exist=true
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,6 +1,6 @@
 class HealthcheckController < ApplicationController
-  def ping
-    render status: :ok, body: 'PONG'
+  def checkz
+    render json: { git_sha1: CURRENT_REVISION }
   end
 
   def healthcheck

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,6 +1,6 @@
 class HealthcheckController < ApplicationController
   def checkz
-    render json: { git_sha1: CURRENT_REVISION }
+    head :ok  
   end
 
   def healthcheck

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,6 +1,6 @@
 class HealthcheckController < ApplicationController
   def checkz
-    head :ok  
+    head :ok
   end
 
   def healthcheck

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,9 +31,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = (ENV['SKIP_FORCE_SSL'] != 'true')
-
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = :info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,14 @@
 Rails.application.routes.draw do
   root to: proc { [404, {}, ['Not found.']] }
 
+  get 'healthcheckz', to: 'healthcheck#checkz'
+  
   scope path: '/duty-calculator/:referred_service/:commodity_code/' do
     get 'import-date', to: 'steps/import_date#show'
     post 'import-date', to: 'steps/import_date#create'
   end
 
   scope path: '/duty-calculator/' do
-    get 'ping', to: 'healthcheck#ping'
     get 'healthcheck', to: 'healthcheck#healthcheck'
 
     get 'import-destination', to: 'steps/import_destination#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root to: proc { [404, {}, ['Not found.']] }
 
+  get 'healthcheckz', to: 'healthcheck#checkz'
+
   scope path: '/duty-calculator/:referred_service/:commodity_code/' do
     get 'import-date', to: 'steps/import_date#show'
     post 'import-date', to: 'steps/import_date#create'
@@ -8,7 +10,6 @@ Rails.application.routes.draw do
 
   scope path: '/duty-calculator/' do
     get 'healthcheck', to: 'healthcheck#healthcheck'
-    get 'healthcheckz', to: 'healthcheck#checkz'
 
     get 'import-destination', to: 'steps/import_destination#show'
     post 'import-destination', to: 'steps/import_destination#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 Rails.application.routes.draw do
   root to: proc { [404, {}, ['Not found.']] }
 
-  get 'healthcheckz', to: 'healthcheck#checkz'
-  
   scope path: '/duty-calculator/:referred_service/:commodity_code/' do
     get 'import-date', to: 'steps/import_date#show'
     post 'import-date', to: 'steps/import_date#create'
@@ -10,6 +8,7 @@ Rails.application.routes.draw do
 
   scope path: '/duty-calculator/' do
     get 'healthcheck', to: 'healthcheck#healthcheck'
+    get 'healthcheckz', to: 'healthcheck#checkz'
 
     get 'import-destination', to: 'steps/import_destination#show'
     post 'import-destination', to: 'steps/import_destination#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root to: proc { [404, {}, ['Not found.']] }
 
+  get 'healthcheckz', to: 'healthcheck#checkz'
+  
   scope path: '/duty-calculator/:referred_service/:commodity_code/' do
     get 'import-date', to: 'steps/import_date#show'
     post 'import-date', to: 'steps/import_date#create'
@@ -8,7 +10,6 @@ Rails.application.routes.draw do
 
   scope path: '/duty-calculator/' do
     get 'healthcheck', to: 'healthcheck#healthcheck'
-    get 'healthcheckz', to: 'healthcheck#checkz'
 
     get 'import-destination', to: 'steps/import_destination#show'
     post 'import-destination', to: 'steps/import_destination#create'

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,15 +1,12 @@
-RSpec.describe HealthcheckController do
+RSpec.describe HealthcheckController, type: :controller do
   describe 'GET #healthcheck' do
     subject(:response) { get :healthcheck }
-
     it { expect(response.body).to eq('{"git_sha1":"test"}') }
     it { expect(response).to have_http_status(:ok) }
   end
 
   describe 'GET #checkz' do
-    subject(:response) { get :healthcheckz }
-
-    it { expect(response.body).to eq('{"git_sha1":"test"}') }
+    subject(:response) { get :checkz }
     it { expect(response).to have_http_status(:ok) }
   end
 end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,12 +1,14 @@
 RSpec.describe HealthcheckController, type: :controller do
   describe 'GET #healthcheck' do
     subject(:response) { get :healthcheck }
+
     it { expect(response.body).to eq('{"git_sha1":"test"}') }
     it { expect(response).to have_http_status(:ok) }
   end
 
   describe 'GET #checkz' do
     subject(:response) { get :checkz }
+
     it { expect(response).to have_http_status(:ok) }
   end
 end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HealthcheckController do
     it { expect(response).to have_http_status(:ok) }
   end
 
-  describe 'GET #healthcheckz' do
+  describe 'GET #checkz' do
     subject(:response) { get :healthcheckz }
 
     it { expect(response.body).to eq('{"git_sha1":"test"}') }

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe HealthcheckController do
-  describe 'GET #ping' do
-    subject(:response) { get :ping }
+  describe 'GET #healthcheck' do
+    subject(:response) { get :healthcheck }
 
-    it { expect(response.body).to eq('PONG') }
+    it { expect(response.body).to eq('{"git_sha1":"test"}') }
     it { expect(response).to have_http_status(:ok) }
   end
 
-  describe 'GET #healthcheck' do
-    subject(:response) { get :healthcheck }
+  describe 'GET #healthcheckz' do
+    subject(:response) { get :healthcheckz }
 
     it { expect(response.body).to eq('{"git_sha1":"test"}') }
     it { expect(response).to have_http_status(:ok) }


### PR DESCRIPTION
### Jira link

[HOTT-3621](https://transformuk.atlassian.net/browse/HOTT-3621)

### What?

_I have added/removed/altered:_

- This adds a healthcheckz route that replaces the ping route.
- Removed `force_ssl` as we're not using it.
- Modified the ci config to use many of the jobs that were ported across to the orb, and to update the app deployment healthcheck route.


### Why?

_I am doing this because:_

- We need a route that is consistent across all the applications that can be used for container health checking on ECS; we decided on `healthcheckz` for the frontend so let's keep it consistent here, too.
