### PR TITLE
HOTT-3622: Add CI config to deploy Terraform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
+  terraform: circleci/terraform@3.2.1
   cloudfoundry: circleci/cloudfoundry@1.0
   cypress: cypress-io/cypress@1.27.0
   node: circleci/node@5
@@ -10,6 +11,16 @@ orbs:
   slack: circleci/slack@4.3.0
   queue: eddiewebb/queue@1.6.4
   tariff: trade-tariff/trade-tariff-ci-orb@0
+
+executors:
+  terraform:
+    docker:
+      - image: hashicorp/terraform:1.4.6
+    resource_class: small
+    working_directory: "/tmp/terraform"
+    environment:
+      TF_INPUT: 0
+      TF_IN_AUTOMATION: 1
 
 commands:
   cf_deploy_docker:
@@ -84,6 +95,71 @@ commands:
           template: basic_success_1
 
 jobs:
+  write_docker_tag:
+    parameters:
+      environment:
+        type: string
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: echo "docker_tag = \"$(git rev-parse --short HEAD)\"" >> terraform/config_<< parameters.environment >>.tfvars
+      - persist_to_workspace:
+          root: .
+          paths:
+            - terraform/
+
+  fmt_validate_terraform:
+    executor: terraform
+    parameters:
+      environment:
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - terraform/init:
+          path: terraform/
+          backend_config_file: backends/<< parameters.environment >>.tfbackend
+      - terraform/fmt:
+          path: terraform/
+      - terraform/validate:
+          path: terraform/
+
+  plan_terraform:
+    executor: terraform
+    parameters:
+      environment:
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - terraform/init:
+          path: terraform/
+          backend_config_file: backends/<< parameters.environment >>.tfbackend
+      - terraform/plan:
+          path: terraform/
+          backend_config_file: backends/<< parameters.environment >>.tfbackend
+          var_file: config_<< parameters.environment >>.tfvars
+
+  apply_terraform:
+    executor: terraform
+    parameters:
+      environment:
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - terraform/init:
+          path: terraform/
+          backend_config_file: backends/<< parameters.environment >>.tfbackend
+      - terraform/apply:
+          path: terraform/
+          backend_config_file: backends/<< parameters.environment >>.tfbackend
+          var_file: config_<< parameters.environment >>.tfvars
+
   checking:
     docker:
       - image: cimg/ruby:3.2.2-node
@@ -224,6 +300,9 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - write_docker_tag:
+          environment: development
+
       - checking
 
       - test:
@@ -233,8 +312,31 @@ workflows:
               ignore:
                 - main
 
+      - fmt_validate_terraform:
+          context: trade-tariff-terraform-aws-development
+          environment: development
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^dependabot/(?!docker/).*/
+                - /^hotfix\/.+/
+
+      - plan_terraform:
+          context: trade-tariff-terraform-aws-development
+          environment: development
+          requires:
+            - write_docker_tag
+            - fmt_validate_terraform
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^dependabot/(?!docker/).*/
+                - /^hotfix\/.+/
+
       - build:
-          name: build_dev
+          name: build_paas_development
           context: trade-tariff
           dev-build: true
           filters:
@@ -246,6 +348,19 @@ workflows:
           requires:
             - test
 
+      - tariff/build-and-push:
+          name: build_and_push_dev
+          context: trade-tariff-terraform-aws-development
+          environment: development
+          image_name: tariff-duty-calculator
+          ssm_parameter: "/development/DUTY_CALCULATOR_ECR_URL"
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^dependabot/(?!docker/).*/
+                - /^hotfix\/.+/
+
       - deploy_dev:
           context: trade-tariff
           filters:
@@ -255,7 +370,19 @@ workflows:
                 - /^hotfix\/.+/
                 - /^dependabot/(?!docker/).*/
           requires:
-            - build_dev
+            - build_paas_development
+
+      - apply_terraform:
+          context: trade-tariff-terraform-aws-development
+          environment: development
+          requires:
+            - plan_terraform
+            - build_and_push_dev
+          filters:
+            branches:
+              ignore:
+                - /^dependabot/(?!docker/).*/
+                - /^hotfix\/.+/
 
       - tariff/smoketests:
           name: smoketest_dev
@@ -271,7 +398,7 @@ workflows:
                 - /^hotfix\/.+/
 
       - build:
-          name: build_live
+          name: build_paas_live
           context: trade-tariff
           filters:
             branches:
@@ -287,7 +414,7 @@ workflows:
                 - main
                 - /^hotfix\/.+/
           requires:
-            - build_live
+            - build_paas_live
 
       - tariff/smoketests:
           name: smoketest_staging

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.6.0 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.6.1 |
 
 ## Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.6.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.6.1"
 
   environment = var.environment
   region      = var.region


### PR DESCRIPTION
### Jira link

[HOTT-3622](https://transformuk.atlassian.net/browse/HOTT-3622)

### What?

_I have added/removed/altered:_

- Added CI jobs to write out the docker tag and run Terraform

### Why?

_I am doing this because:_

- This is the remaining bit required to deploy this app on ECS :)