### PR TITLE
BAU: Fixes production duty calculator release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
 
             cf map-route \
               "$CF_APP-<< parameters.environment_key >>-dark" \
-                << parameters.environment_key >>.trade-tariff.service.gov.uk \
+                << parameters.app_domain_prefix >>.trade-tariff.service.gov.uk \
                 --path "/duty-calculator"
 
             cf add-network-policy \


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes mapping route in duty calculator release

### Why?

I am doing this because:

- This is required to make sure we can deploy properly
