### PR TITLE
HOTT-3649: Adds support for simple excise threshold conditions

### DIFF
--- a/app/models/api/measure_condition.rb
+++ b/app/models/api/measure_condition.rb
@@ -1,13 +1,10 @@
 module Api
   class MeasureCondition < Api::Base
-    DOCUMENT_CONDITION_CODES = [
-      'B', # Presentation of a certificate/licence/document'
-      'H', # Presentation of a certificate/licence/document'
-      'E', # The quantity or the price per unit declared, as appropriate, is equal or less than the specified maximum, or presentation of the required document'
-      'A', # Presentation of an anti-dumping/countervailing document'
-      'C', # Presentation of a certificate/licence/document'
-      'I', # The quantity or the price per unit declared, as appropriate, is equal or less than the specified maximum, or presentation of the required document'
-    ].freeze
+    REQUIREMENT_OPERATOR_MAPPINGS = {
+      '=<' => '<=',
+      '=>' => '>=',
+      '>' => '>',
+    }.freeze
 
     attributes :id,
                :action,
@@ -22,7 +19,8 @@ module Api
                :certificate_description,
                :duty_expression,
                :monetary_unit_abbreviation,
-               :requirement
+               :requirement,
+               :requirement_operator
 
     has_many :measure_condition_components, MeasureConditionComponent
 
@@ -41,7 +39,41 @@ module Api
         '34', # Apply exemption/reduction of the anti-dumping duty
         '36', # Apply export refund
       ],
+      not_applicable: [
+        '04',  # 'The entry into free circulation is not allowed'
+        '05',  # 'Export is not allowed'
+        '06',  # 'Import is not allowed'
+        '07',  # 'Measure not applicable'
+        '08',  # 'Declared subheading not allowed'
+        '09',  # 'Import/export not allowed after control'
+        '10',  # 'Declaration to be corrected - box 33, 37, 38, 41 or 46 incorrect'
+        '16',  # 'Export refund not applicable'
+        '30',  # 'Suspicious case'
+      ],
     }
+
+    enum :condition_code, {
+      condition_code_supported: [
+        'A', # Presentation of an anti-dumping/countervailing document
+        'B', # Presentation of a certificate/licence/document
+        'C', # Presentation of a certificate/licence/document
+        'E', # The quantity or the price per unit declared, as appropriate, is equal or less than the specified maximum, or presentation of the required document
+        'H', # Presentation of a certificate/licence/document
+        'I', # The quantity or the price per unit declared, as appropriate, is equal or less than the specified maximum, or presentation of the required document
+      ],
+    }
+
+    def requirement_operator
+      REQUIREMENT_OPERATOR_MAPPINGS[attributes[:requirement_operator]] || attributes[:requirement_operator]
+    end
+
+    def expresses_document?
+      attributes[:document_code].present? && condition_code_supported?
+    end
+
+    def expresses_unit?
+      condition_measurement_unit_code.present?
+    end
 
     def document_code
       return attributes[:document_code] if attributes[:document_code].present?
@@ -55,12 +87,8 @@ module Api
       'None of the above'
     end
 
-    def expresses_unit?
-      (condition_measurement_unit_code || condition_monetary_unit_code).present?
-    end
-
-    def expresses_document?
-      condition_code.in?(DOCUMENT_CONDITION_CODES)
+    def condition_measurement_unit
+      "#{condition_measurement_unit_code}#{condition_measurement_unit_qualifier_code}" if expresses_unit?
     end
   end
 end

--- a/app/models/api/measure_condition_component.rb
+++ b/app/models/api/measure_condition_component.rb
@@ -1,7 +1,13 @@
 module Api
   class MeasureConditionComponent < Api::BaseComponent
+    ID_REGEX = /^(?<measure_condition_sid>(?<optional>-)?\d+)-(?<duty_expression_id>\d+)$/
+
     def measure_condition_sid
-      id.split('-').first
+      match_data = id.match(ID_REGEX)
+
+      return unless match_data
+
+      match_data[:measure_condition_sid]
     end
 
     def belongs_to_measure_condition?

--- a/app/models/steps/excise.rb
+++ b/app/models/steps/excise.rb
@@ -22,7 +22,7 @@ module Steps
 
         OpenStruct.new(
           id: code,
-          name: additional_code['overlay'],
+          name: additional_code['overlay'].to_s.html_safe,
           disabled: code.in?(DISABLED_ADDITIONAL_CODES),
         )
       end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -114,6 +114,10 @@ class UserSession
     public_send("document_code_#{source}")[measure_type_id]
   end
 
+  def measure_amount_for(measurement_unit)
+    measure_amount[measurement_unit.to_s.downcase]
+  end
+
   def excise_additional_code=(value)
     session['answers'][Steps::Excise.id].merge!(value)
   end

--- a/spec/models/api/measure_condition_component_spec.rb
+++ b/spec/models/api/measure_condition_component_spec.rb
@@ -5,8 +5,18 @@ RSpec.describe Api::MeasureConditionComponent do
   it { is_expected.to be_belongs_to_measure_condition }
 
   describe '#measure_condition_sid' do
-    subject(:component) { build(:measure_condition_component, id: '12345-01') }
+    subject(:component) { build(:measure_condition_component, id:).measure_condition_sid }
 
-    it { expect(component.measure_condition_sid).to eq('12345') }
+    context 'when the measure condition sid is a negative number' do
+      let(:id) { '-12345-1' }
+
+      it { is_expected.to eq('-12345') }
+    end
+
+    context 'when the measure condition sid is a positive number' do
+      let(:id) { '12345-1' }
+
+      it { is_expected.to eq('12345') }
+    end
   end
 end

--- a/spec/models/api/measure_condition_spec.rb
+++ b/spec/models/api/measure_condition_spec.rb
@@ -25,42 +25,78 @@ RSpec.describe Api::MeasureCondition do
 
   it_behaves_like 'a resource that has an enum', :action_code, {
     applicable: %w[01 24 25 26 27 28 29 34 36],
+    not_applicable: %w[04 05 06 07 08 09 10 16 30],
     stopping: %w[08],
   }
 
-  describe '#expresses_unit?' do
-    it 'returns false' do
-      expect(measure_condition).not_to be_expresses_unit
-    end
+  describe '#requirement_operator' do
+    shared_examples_for 'a measure condition operator translation' do |input_operator, output_operator|
+      it "translates #{input_operator} to #{output_operator}" do
+        measure_condition.requirement_operator = input_operator
 
-    context 'when condition_monetary_unit_code is present' do
-      let(:condition_monetary_unit_code) { 'EUR' }
-
-      it 'returns true' do
-        expect(measure_condition).to be_expresses_unit
+        expect(measure_condition.requirement_operator).to eq(output_operator)
       end
     end
 
+    it_behaves_like 'a measure condition operator translation', '=<', '<='
+    it_behaves_like 'a measure condition operator translation', '=>', '>='
+    it_behaves_like 'a measure condition operator translation', '>', '>'
+    it_behaves_like 'a measure condition operator translation', '<', '<'
+    it_behaves_like 'a measure condition operator translation', '=', '='
+    it_behaves_like 'a measure condition operator translation', nil, nil
+  end
+
+  describe '#expresses_unit?' do
     context 'when condition_measurement_unit_code is present' do
       let(:condition_measurement_unit_code) { 'DTN' }
 
-      it 'returns true' do
-        expect(measure_condition).to be_expresses_unit
-      end
+      it { is_expected.to be_expresses_unit }
+    end
+
+    context 'when condition_measurement_unit_code is not present' do
+      let(:condition_measurement_unit_code) { nil }
+
+      it { is_expected.not_to be_expresses_unit }
     end
   end
 
   describe '#expresses_document?' do
-    subject(:measure_condition) { described_class.new(condition_code:) }
-
-    context 'when the condition_code is a document condition code' do
-      let(:condition_code) { 'I' }
+    shared_examples_for 'a measure condition that requires a document' do |document_code, condition_code|
+      subject(:measure_condition) { described_class.new(document_code:, condition_code:) }
 
       it { is_expected.to be_expresses_document }
     end
 
-    context 'when the condition_code is not a document condition code' do
-      let(:condition_code) { 'V' }
+    it_behaves_like 'a measure condition that requires a document', 'C990', 'B'
+    it_behaves_like 'a measure condition that requires a document', 'C990', 'H'
+    it_behaves_like 'a measure condition that requires a document', 'C990', 'E'
+    it_behaves_like 'a measure condition that requires a document', 'C990', 'A'
+    it_behaves_like 'a measure condition that requires a document', 'C990', 'C'
+    it_behaves_like 'a measure condition that requires a document', 'C990', 'I'
+
+    context 'when the condition_code is an unsupported value' do
+      subject(:measure_condition) { described_class.new(document_code:, condition_code:) }
+
+      let(:document_code) { 'C990' }
+      let(:condition_code) { 'Z' }
+
+      it { is_expected.not_to be_expresses_document }
+    end
+
+    context 'when the condition_code is blank' do
+      subject(:measure_condition) { described_class.new(document_code:, condition_code:) }
+
+      let(:document_code) { 'C990' }
+      let(:condition_code) { nil }
+
+      it { is_expected.not_to be_expresses_document }
+    end
+
+    context 'when the document code is blank' do
+      subject(:measure_condition) { described_class.new(document_code:, condition_code:) }
+
+      let(:document_code) { nil }
+      let(:condition_code) { 'B' }
 
       it { is_expected.not_to be_expresses_document }
     end
@@ -95,6 +131,24 @@ RSpec.describe Api::MeasureCondition do
       let(:document_code) { '' }
 
       it { expect(measure_condition.certificate_description).to eq('None of the above') }
+    end
+  end
+
+  describe '#condition_measurement_unit' do
+    subject(:measure_condition) { described_class.new(condition_measurement_unit_code:, condition_measurement_unit_qualifier_code:) }
+
+    context 'when the measure condition has a measurement unit code' do
+      let(:condition_measurement_unit_code) { 'DTN' }
+      let(:condition_measurement_unit_qualifier_code) { 'R' }
+
+      it { expect(measure_condition.condition_measurement_unit).to eq('DTNR') }
+    end
+
+    context 'when the measure condition does not have a measurement unit code' do
+      let(:condition_measurement_unit_code) { nil }
+      let(:condition_measurement_unit_qualifier_code) { nil }
+
+      it { expect(measure_condition.condition_measurement_unit).to be_nil }
     end
   end
 end

--- a/spec/models/api/measure_spec.rb
+++ b/spec/models/api/measure_spec.rb
@@ -403,7 +403,7 @@ RSpec.describe Api::Measure, :user_session do
       end
     end
 
-    context 'when there are measure conditions with a matching document answer' do
+    context 'when there are document measure conditions with a matching document answer' do
       let(:user_session) do
         build(:user_session, document_code: { 'uk' => { '117' => 'C990' } })
       end
@@ -522,7 +522,7 @@ RSpec.describe Api::Measure, :user_session do
       let(:measure_conditions) do
         [
           {
-            'condition' => 'B: Presentation of a certificate/licence/document',
+            'document_code' => 'C990',
             'condition_code' => 'B',
           },
         ]
@@ -535,8 +535,8 @@ RSpec.describe Api::Measure, :user_session do
       let(:measure_conditions) do
         [
           {
-            'condition' => 'Import price must be equal to or greater than the entry price (see components)',
-            'condition_code' => 'V',
+            'document_code' => nil,
+            'condition_code' => 'B',
           },
         ]
       end
@@ -564,7 +564,7 @@ RSpec.describe Api::Measure, :user_session do
       )
     end
 
-    context 'when the matching condition is applicable' do
+    context 'when the matching document condition is applicable' do
       let(:user_session) do
         build(
           :user_session,
@@ -595,7 +595,7 @@ RSpec.describe Api::Measure, :user_session do
       it { is_expected.to be_applicable }
     end
 
-    context 'when the matching condition is not applicable' do
+    context 'when the matching document condition is not applicable' do
       let(:user_session) do
         build(
           :user_session,
@@ -624,6 +624,54 @@ RSpec.describe Api::Measure, :user_session do
       end
 
       it { is_expected.not_to be_applicable }
+    end
+
+    context 'when the matching threshold condition is applicable' do
+      let(:user_session) do
+        build(
+          :user_session,
+          measure_amount: { 'asv' => 10.42 },
+        )
+      end
+
+      let(:matching_condition) do
+        {
+          'id' => '-1010130922',
+          'action' => 'Apply the amount of the action (see components)',
+          'action_code' => '01',
+          'certificate_description' => nil,
+          'condition' => 'E: The quantity or the price per unit declared, as appropriate, is equal or less than the specified maximum, or presentation of the required document',
+          'condition_code' => 'E',
+          'condition_duty_amount' => 14.499999999999998,
+          'condition_measurement_unit_code' => 'ASV',
+          'condition_measurement_unit_qualifier_code' => nil,
+          'condition_monetary_unit_code' => nil,
+          'document_code' => '',
+          'duty_expression' => "<span>35.62</span> GBP / <abbr title='%vol'>% vol/hl</abbr>",
+          'guidance_cds' => nil,
+          'guidance_chief' => nil,
+          'measure_condition_class' => 'threshold',
+          'monetary_unit_abbreviation' => nil,
+          'requirement' => "<span>14.50</span> <abbr title='%vol'>% vol</abbr>",
+          'requirement_operator' => '=<',
+          'threshold_unit_type' => nil,
+          'measure_condition_components' => [
+            {
+              'id' => '-1010130922-01',
+              'duty_expression_id' => '01',
+              'duty_amount' => 35.62,
+              'monetary_unit_code' => 'GBP',
+              'monetary_unit_abbreviation' => nil,
+              'measurement_unit_code' => 'ASV',
+              'measurement_unit_qualifier_code' => 'X',
+              'duty_expression_description' => '% or amount',
+              'duty_expression_abbreviation' => '%',
+            },
+          ],
+        }
+      end
+
+      it { is_expected.to be_applicable }
     end
 
     context 'when there is no matching condition' do

--- a/spec/models/steps/excise_spec.rb
+++ b/spec/models/steps/excise_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe Steps::Excise, :step, :user_session do
     end
 
     it { expect(step.options).to eq(expected_options) }
+    it { expect(step.options.first.name).to be_html_safe }
   end
 
   describe '#additional_code' do

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -603,6 +603,12 @@ RSpec.describe UserSession do
     end
   end
 
+  describe '#measure_amount_for' do
+    subject(:user_session) { build(:user_session, measure_amount: { 'asvx' => :bar }) }
+
+    it { expect(user_session.measure_amount_for('ASVX')).to eq(:bar) }
+  end
+
   describe '#origin_country_code' do
     context 'when country of origin is OTHER' do
       subject(:origin_country_code) { build(:user_session, country_of_origin: 'OTHER', other_country_of_origin: 'AD').origin_country_code }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3649

**Calculating excise using ASVX components on an ASV condition threshold:**

![image](https://github.com/trade-tariff/trade-tariff-duty-calculator/assets/8156884/aaa830d1-6483-4d20-8fdf-9710550173f4)

**Calculating excise using LPA components on an ASV condition threshold:**

![image](https://github.com/trade-tariff/trade-tariff-duty-calculator/assets/8156884/d52f4c10-cda8-4177-9d00-a728156fbbc1)


### What?

I have added/removed/altered:

- [x] Added support for calculating simple threshold conditions for excise conditions

### Why?

I am doing this because:

- This only applies to measure conditions that are on excise measures. Non-excise measures are not supported as this would require much more extensive testing
- This is needed as part of a computation of LPA and ASVX components on excise measure condition components and does not include the handling of SPQ components
