### PR TITLE
BAU: Update Backend URLs

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
   service = "duty-calculator"
   api_service_backend_url_options = {
-    uk = "https://${var.base_domain}/uk/"
-    xi = "https://${var.base_domain}/xi/"
+    uk = "http://backend-uk.tariff.internal:8080"
+    xi = "http://backend-xi.tariff.internal:8080"
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,7 +35,7 @@ module "service" {
       value = "8080"
     },
     {
-      name  = "API_SERVICE_BACKEND_OPTIONS"
+      name  = "API_SERVICE_BACKEND_URL_OPTIONS"
       value = jsonencode(local.api_service_backend_url_options)
     },
     {


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Updated the backend API URL options environment variable to use the `tariff.internal` addresses.

### Why?

I am doing this because:

- The backends should be reached internally.