### PR TITLE
BAU: Ensure apply requires written tag [ci skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,6 +421,7 @@ workflows:
           context: trade-tariff-terraform-aws-staging
           environment: staging
           requires:
+            - write-docker-tag-staging
             - plan-terraform-staging
             - build-and-push-live
           <<: *filter-main


### PR DESCRIPTION
## What?

I have added/removed/altered:

- Added the `write-docker-tag-staging` job as a requirement for the `apply-terraform-staging` job in the CircleCi config. 

### Why?

I am doing this because:

- Without this `require`, the workspace layer is not loaded into the apply job, so the docker tag is missing from the config file, and the apply fails.
