### PR TITLE
HOTT-3162: Support customs union quotas

### DIFF
--- a/app/models/api/measure_type.rb
+++ b/app/models/api/measure_type.rb
@@ -15,6 +15,7 @@ module Api
       '123' => ::DutyOptions::Quota::NonPreferentialEndUse,
       '143' => ::DutyOptions::Quota::Preferential,
       '146' => ::DutyOptions::Quota::PreferentialEndUse,
+      '147' => ::DutyOptions::Quota::CustomsUnion,
     }.freeze
 
     TYPE_ADDITIONAL_OPTION_MAPPING = {

--- a/app/services/duty_options/quota/customs_union.rb
+++ b/app/services/duty_options/quota/customs_union.rb
@@ -1,0 +1,6 @@
+module DutyOptions
+  module Quota
+    class CustomsUnion < DutyOptions::Quota::Base
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
           certain_category_goods: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms
           preferential: Preferential Suspension
         quota:
+          customs_union: Customs Union Quota
           preferential: Preferential Quota
           preferential_end_use: Preferential Quota Under End Use
           non_preferential: Non Preferential Quota
@@ -108,6 +109,7 @@ en:
           certain_category_goods: "Option %{option_no}: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms"
           preferential: "Option %{option_no}: Preferential suspension"
         quota:
+          customs_union: "Option %{option_no}: Customs Union quota %{order_number}"
           preferential: "Option %{option_no}: Preferential tariff quota %{order_number}"
           preferential_end_use: "Option %{option_no}: Preferential tariff quota under end-use %{order_number}"
           non_preferential: "Option %{option_no}: Non-preferential quota %{order_number}"

--- a/config/locales/footnotes.en.yml
+++ b/config/locales/footnotes.en.yml
@@ -147,7 +147,7 @@ en:
 
     '145': >- # Preference under end-use
       <p class="govuk-body">
-        A tariff preference is the rate available if a free trade agreement or another arrangement is in place between the UK and an overseas country. Goods will need to comply with the <a target="_blank" href="https://www.gov.uk/guidance/check-your-goods-meet-the-rules-of-origin" class="govuk-link">rules of origin</a> to benefit from this rate and you will need to provide evidence of compliance with your shipment.  
+        A tariff preference is the rate available if a free trade agreement or another arrangement is in place between the UK and an overseas country. Goods will need to comply with the <a target="_blank" href="https://www.gov.uk/guidance/check-your-goods-meet-the-rules-of-origin" class="govuk-link">rules of origin</a> to benefit from this rate and you will need to provide evidence of compliance with your shipment.
       </p>
       <p class="govuk-body">
         This reduced duty rate applies only when the goods are being imported for certain uses. In order to benefit from this you have to first be authorised. <a href="https://www.gov.uk/guidance/apply-to-pay-less-duty-on-goods-you-import-for-specific-uses" class="govuk-link" target="_blank">Apply to pay less duty on goods you import for specific uses</a>.
@@ -163,6 +163,7 @@ en:
 
     '147': >- # Customs Union Quota
       <p class="govuk-body">
+        A Customs Union Quota (CUQ) applies to this commodity code. A quota allows you to import goods into the UK at a reduced or zero customs duty rate. Read more about <a target="_blank" href="https://www.gov.uk/government/publications/notice-375-tariff-quotas/notice-375-tariff-quotas" class="govuk-link"> claiming quotas to reduce your duty liability</a>.
       </p>
 
     '166': >- # Provisional exclusion
@@ -1179,7 +1180,7 @@ en:
       <p class="govuk-body">
       </p>
 
-  
+
   row_to_ni_measure_type_footnotes_suffixes:
     third_country_tariff:
       uk_html:

--- a/spec/factories/api/measure.rb
+++ b/spec/factories/api/measure.rb
@@ -82,6 +82,11 @@ FactoryBot.define do
       scheme_code { 'andean' }
     end
 
+    trait :customs_union do
+      measure_type { attributes_for :measure_type, :customs_union }
+      scheme_code { 'albania' }
+    end
+
     trait :vat do
       measure_type { attributes_for :measure_type, :vat }
       vat { true }

--- a/spec/factories/api/measure_type.rb
+++ b/spec/factories/api/measure_type.rb
@@ -77,6 +77,12 @@ FactoryBot.define do
       measure_type_series_id { 'C' }
     end
 
+    trait :customs_union do
+      id { '147' }
+      description { 'Customs Union Quota' }
+      measure_type_series_id { 'C' }
+    end
+
     trait :vat do
       id { '305' }
       description { 'Value added tax' }

--- a/spec/services/duty_options/quota/customs_union_spec.rb
+++ b/spec/services/duty_options/quota/customs_union_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe DutyOptions::Quota::CustomsUnion, :user_session do
+  include_context 'with a standard duty option setup', :customs_union
+
+  describe '#call' do
+    let(:expected_table) do
+      {
+        footnote: I18n.t('measure_type_footnotes.147'),
+        warning_text: nil,
+        values: [
+          ['Valuation for import', 'Value of goods + freight + insurance costs', '£1,200.00'],
+          ['Import duty<br><span class="govuk-green govuk-body-xs"> Customs Union Quota (UK)</span>', '8.00% * £1200.00', '£96.00'],
+          ['<strong>Duty Total</strong>', nil, '<strong>£96.00</strong>'],
+        ],
+        value: 96,
+        measure_sid: measure.id,
+        source: 'uk',
+        type: 'customs_union',
+        category: :quota,
+        priority: 3,
+        scheme_code: 'albania',
+        order_number: '058048',
+        geographical_area_description: nil,
+      }
+    end
+
+    it { expect(service.call.attributes.deep_symbolize_keys).to eq(expected_table) }
+  end
+
+  it_behaves_like 'a duty option that excludes safeguard additional duties'
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3162

![image](https://github.com/trade-tariff/trade-tariff-duty-calculator/assets/8156884/380d232b-f9ae-46c9-9002-c07d49f35ab6)
![image](https://github.com/trade-tariff/trade-tariff-duty-calculator/assets/8156884/71f0c5ff-4e00-489e-8f37-37e3db03ec47)


### What?

I have added/removed/altered:

- [x] Added support for a customs union quota option

### Why?

I am doing this because:

- This is required to support measure options of this type
