### PR TITLE
BAU: Don't log healthchecks in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,4 +63,10 @@ Rails.application.configure do
   config.logger = ActiveSupport::Logger.new($stdout)
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Logstash.new
+
+  config.lograge.ignore_actions = [
+    'HealthcheckController#index',
+    'HealthcheckController#checkz',
+  ]
+
 end


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Ignored `checkz` action of the healthcheck controller in lograge options.

### Why?

I am doing this because:

- We don't need this to be logged in production mode, it's just noise.