### PR TITLE
Add guard for when the duty returns nil for a commodity

### DIFF
--- a/app/models/api/base_component.rb
+++ b/app/models/api/base_component.rb
@@ -41,6 +41,12 @@ module Api
       spq: %w[SPQ],
     }
 
+    def duty_zero?
+      return true if duty_amount.nil?
+
+      duty_amount.zero?
+    end
+
     def ad_valorem?
       no_specific_duty?
     end

--- a/app/models/api/measure.rb
+++ b/app/models/api/measure.rb
@@ -87,7 +87,7 @@ module Api
     def all_duties_zero?
       return false if vat.present?
 
-      applicable_components.all? { |component| component.duty_amount.zero? }
+      applicable_components.all?(&:duty_zero?)
     end
 
     def vat_type

--- a/spec/models/api/base_component_spec.rb
+++ b/spec/models/api/base_component_spec.rb
@@ -63,6 +63,28 @@ RSpec.describe Api::BaseComponent do
     end
   end
 
+  describe '#duty_zero?' do
+    subject(:component) { described_class.new(duty_amount:) }
+
+    context 'when duty_amount is zero' do
+      let(:duty_amount) { 0 }
+
+      it { expect(component.duty_zero?).to be true }
+    end
+
+    context 'when duty_amount is nil' do
+      let(:duty_amount) { nil }
+
+      it { expect(component.duty_zero?).to be true }
+    end
+
+    context 'when duty_amount is present' do
+      let(:duty_amount) { 1.1589 }
+
+      it { expect(component.duty_zero?).to be false }
+    end
+  end
+
   describe '#specific_duty?' do
     subject(:component) { described_class.new(measurement_unit_code:) }
 


### PR DESCRIPTION
### Jira link

HOTT-3916

### What?

I have added/removed/altered:

- [ ] Catch for when the duty returns nil instead of a numeric value


https://engine-le.sentry.io/issues/4438500131/?alert_rule_id=6424017&alert_type=issue&project=5701976&referrer=slack

