### PR TITLE
BAU: Handle restarting calculation on failure

### DIFF
--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -84,6 +84,10 @@ class UserSession
     end
   end
 
+  def can_redirect_to_start?
+    commodity_code.present? && referred_service.present?
+  end
+
   def remove_step_ids(ids)
     ids.map { |id| session['answers'].delete(id) } unless ids.empty?
   end


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added generic handling of errors to default to redirecting to the start if possible

### Why?

I am doing this because:

- This will cover a lot of combinations of session integrity issues/deep linking
- The risk in terms of propagating the exception versus going to the start is very low/actually improves the user experience
