### PR TITLE
HOTT-4302 Updated bin/setup and README file

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
-API_SERVICE_BACKEND_URL_OPTIONS={"uk":"https://tariff-frontend-dev.london.cloudapps.digital/","xi":"https://tariff-frontend-dev.london.cloudapps.digital/xi"}
-DUTY_CALCULATOR_HOST=http://test.host
+API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000/","xi":"http://localhost:3000/xi"}
+DUTY_CALCULATOR_HOST=http://localhost:3002
 PORT=3002
-ROUTE_THROUGH_FRONTEND=true
-TRADE_TARIFF_FRONTEND_URL="https://dev.trade-tariff.service.gov.uk"
+ROUTE_THROUGH_FRONTEND=false
+TRADE_TARIFF_FRONTEND_URL="http://localhost:3001/"
+WEB_CONCURRENCY=0

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec puma -p $PORT

--- a/README.md
+++ b/README.md
@@ -4,65 +4,27 @@
 
 ## Prerequisites
 
-- Ruby 2.7.1
-- PostgreSQL
-- NodeJS 12.13.x
-- Yarn 1.12.x
+- Ruby 3.2
+- Rails 7.0
+- NodeJS & Yarn
 
 ## Setting up the app in development
 
-1. Run `bundle install` to install the gem dependencies
-2. Run `yarn` to install node dependencies
-3. Run `bundle exec rails server` to launch the app on http://localhost:3000
-4. Run `bin/webpack-dev-server` in a separate shell for faster compilation of assets
+1. Run `bin/setup`
+2. Followed by `bin/rails s`
+3. Navigate to http://localhost:3002
 
 ## Whats included?
 
-- Rails 6.0 with Webpacker
+- Rails 7.0 with Webpacker
 - [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend)
 - RSpec
 - Dotenv (managing environment variables)
-
-## Running specs, linter(without auto correct) and annotate models and serializers
-```
-bundle exec rake
-```
 
 ## Running specs
 ```
 bundle exec rspec
 ```
-
-## Linting
-
-It's best to lint just your app directories and not those belonging to the framework, e.g.
-
-```bash
-bundle exec rubocop app config db lib spec Gemfile --format clang -a
-
-or
-
-bundle exec scss-lint app/webpacker/styles
-```
-
-## Deploying on GOV.UK PaaS
-
-### Prerequisites
-
-- Your department, agency or team has a GOV.UK PaaS account
-- You have a personal account granted by your organisation manager
-- You have downloaded and installed the [Cloud Foundry CLI](https://github.com/cloudfoundry/cli#downloads) for your platform
-
-### Deploy (This is automated via CircleCI)
-
-1. Run `cf login -a api.london.cloud.service.gov.uk -u USERNAME`, `USERNAME` is your personal GOV.UK PaaS account email address
-2. Run `bundle package --all` to vendor ruby dependencies
-3. Run `yarn` to vendor node dependencies
-4. Run `bundle exec rails webpacker:compile` to compile assets
-5. Run `cf push` to push the app to Cloud Foundry Application Runtime
-
-Check the file `manifest.yml` for customisation of name (you may need to change it as there could be a conflict on that name), buildpacks and eventual services (PostgreSQL needs to be [set up](https://docs.cloud.service.gov.uk/deploying_services/postgresql/)).
-
 
 ## Running locally in docker-compose
 

--- a/bin/setup
+++ b/bin/setup
@@ -13,13 +13,13 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts "== Installing dependencies =="
+  puts "== Installing ruby dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
-  puts "\n== Removing old logs and tempfiles =="
-  system! "bin/rails log:clear tmp:clear"
+  puts "== Installing node dependencies =="
+  system! "yarn install"
 
-  puts "\n== Restarting application server =="
-  system! "bin/rails restart"
+  puts "\n== Removing old logs and tempfiles =="
+  system! "bin/rails log:clear tmp:clear webpacker:clobber"
 end


### PR DESCRIPTION
### Jira link

HOTT-4302

### What?

I have added/removed/altered:

- [x] Updated `bin/setup` to reflect the steps needed to set duty calculator up
- [x] Updated the README file to remove old or incorrect information, and reference the now-working `bin/setup` file
- [x] Dropped old foreman files
- [x] Configured the local dev environment to rely on a locally running backend

### Why?

I am doing this because:

- To simplify the developer onboarding experience

### Deployment risks (optional)

- Low, only affects developer experience
