### PR TITLE
update nodejs - tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 16.5.0
+nodejs 20.8.0
 yarn 1.22.10


### PR DESCRIPTION
Suggest a more recent nodejs version, to avoid the precompile assets error, which happens with old nodejs ver (v16 for example).
