### PR TITLE
BAU: Fix image-name in prod release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ workflows:
 
       - tariff/create-production-release:
           context: trade-tariff-releases
-          image-name: tariff-dutycalculator
+          image-name: tariff-duty-calculator-production
           requires:
             - promote-to-production?
           <<: *filter-main


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Fixed broken `image-name` parameter in release job

### Why?

I am doing this because:

- It's wrong and blocking releases
