### PR TITLE
OTT-275: Adds handling for frontend-forwarded import date

### DIFF
--- a/app/controllers/steps/import_date_controller.rb
+++ b/app/controllers/steps/import_date_controller.rb
@@ -1,7 +1,7 @@
 module Steps
   class ImportDateController < BaseController
     def show
-      @step = Steps::ImportDate.new
+      @step = Steps::ImportDate.new(initial_date_params)
 
       persist_commodity_data
     end
@@ -22,10 +22,35 @@ module Steps
       )
     end
 
+    def initial_date_params
+      {
+        'import_date(3i)' => day.to_s,
+        'import_date(2i)' => month.to_s,
+        'import_date(1i)' => year.to_s,
+      }
+    end
+
     def persist_commodity_data
       user_session.commodity_code = commodity_code
       user_session.commodity_source = params[:referred_service]
       user_session.referred_service = params[:referred_service]
+      user_session.import_date = @step.import_date.strftime('%Y-%m-%d')
+    end
+
+    def day
+      params[:day] || now.day
+    end
+
+    def month
+      params[:month] || now.month
+    end
+
+    def year
+      params[:year] || now.year
+    end
+
+    def now
+      @now ||= Time.zone.now
     end
   end
 end

--- a/app/models/steps/base.rb
+++ b/app/models/steps/base.rb
@@ -9,7 +9,11 @@ module Steps
     STEPS_TO_REMOVE_FROM_SESSION = [].freeze
 
     def initialize(attributes = {})
-      clean_user_session if attributes.except(:measure_type_id).empty?
+      attributes = HashWithIndifferentAccess.new(attributes)
+
+      if attributes.except(:measure_type_id, :"import_date(3i)", :"import_date(2i)", :"import_date(1i)").empty?
+        clean_user_session
+      end
 
       super(attributes)
     end

--- a/app/models/steps/import_date.rb
+++ b/app/models/steps/import_date.rb
@@ -25,7 +25,6 @@ module Steps
 
     def initialize(attributes = {})
       check_attributes_validity(attributes)
-
       super
     end
 

--- a/spec/controllers/steps/import_date_controller_spec.rb
+++ b/spec/controllers/steps/import_date_controller_spec.rb
@@ -17,6 +17,27 @@ RSpec.describe Steps::ImportDateController, :user_session do
     it { expect { response }.to change(user_session, :commodity_source).from(nil).to(referred_service) }
     it { expect { response }.to change(user_session, :referred_service).from(nil).to(referred_service) }
     it { expect { response }.to change(user_session, :country_of_origin).from('GB').to(nil) }
+    it { expect { response }.to change(user_session, :import_date).from(nil).to(Time.zone.today) }
+
+    context 'when the url path includes a day, month, year' do
+      subject(:response) do
+        get :show, params: {
+          commodity_code:,
+          referred_service:,
+          day:,
+          month:,
+          year:,
+        }
+      end
+
+      let(:day) { '12' }
+      let(:month) { '12' }
+      let(:year) { 1.year.from_now.year.to_s }
+
+      let(:expected) { Date.new(year.to_i, month.to_i, day.to_i) }
+
+      it { expect { response }.to change(user_session, :import_date).from(nil).to(expected) }
+    end
   end
 
   describe 'POST #create' do


### PR DESCRIPTION
### Jira link

OTT-275

### What?

I have added/removed/altered:

- [x] Added handling for custom as_of dates from the frontend

### Why?

I am doing this because:

- This enables us to let users use the duty calculator even when the
commodity is not current (and therefore visible via the api on today's
date).
