### PR TITLE
HMRC-686: Simplify routing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # build-base: compilation tools for bundle
 # git: used to pull gems from git
 # yarn: node package manager
-RUN apk add --update --no-cache build-base git yarn tzdata && \
+RUN apk add --update --no-cache build-base git yarn tzdata yaml-dev && \
   cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
   echo "Europe/London" > /etc/timezone
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,9 @@ group :development, :test do
   gem 'scss_lint-govuk'
 end
 group :development do
+  gem 'awesome_print'
   gem 'listen'
-  gem 'solargraph'
+  gem 'solargraph-rails'
   gem 'spring'
   gem 'spring-watcher-listen'
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/trade-tariff/uktt.git
-  revision: 7f52e975697f9bd680f265613474113c881e16e0
+  revision: ba001971e01d7ceaa4437e712a24ed91271cdff8
   specs:
     uktt (2.6.0)
       faraday
@@ -85,6 +85,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    awesome_print (1.9.2)
     backport (1.2.0)
     base64 (0.2.0)
     benchmark (0.4.0)
@@ -101,7 +102,7 @@ GEM
     connection_pool (2.5.0)
     crass (1.0.6)
     date (3.4.1)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.0)
     docile (1.4.1)
     dotenv (3.1.7)
     dotenv-rails (3.1.7)
@@ -208,7 +209,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.5)
+    logger (1.6.6)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -641,6 +642,9 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
+    solargraph-rails (1.1.0)
+      activesupport
+      solargraph
     spring (4.2.1)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
@@ -653,7 +657,7 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
-    stringio (3.1.2)
+    stringio (3.1.3)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -685,6 +689,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   bootsnap
   brakeman
   dotenv-rails
@@ -708,7 +713,7 @@ DEPENDENCIES
   sentry-rails
   shoulda-matchers
   simplecov
-  solargraph
+  solargraph-rails
   spring
   spring-watcher-listen
   uktt!

--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -11,7 +11,6 @@ class ClientBuilder
       host,
       DEFAULT_VERSION,
       DEFAULT_FORMAT,
-      public_routing,
     )
   end
 
@@ -19,9 +18,5 @@ class ClientBuilder
 
   def host
     Rails.application.config.api_options[@service]
-  end
-
-  def public_routing
-    Rails.application.config.public_routing
   end
 end

--- a/config/initializers/backend.rb
+++ b/config/initializers/backend.rb
@@ -1,6 +1,4 @@
-require 'client_builder'
-
-Rails.application.config.public_routing = ENV.fetch('ROUTE_THROUGH_FRONTEND', 'false') == 'true'
+require_relative '../../app/services/client_builder'
 
 api_options = ENV['API_SERVICE_BACKEND_URL_OPTIONS'] || '{}'
 

--- a/spec/services/client_builder_spec.rb
+++ b/spec/services/client_builder_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe ClientBuilder do
           'http://uk.localhost:3018',
           'v2',
           'jsonapi',
-          false,
         )
       end
     end
@@ -39,7 +38,6 @@ RSpec.describe ClientBuilder do
           'http://xi.localhost:3019',
           'v2',
           'jsonapi',
-          false,
         )
       end
     end


### PR DESCRIPTION
### Jira link

HMRC-686

### What?

I have added/removed/altered:

- [x] Bumped uktt gem which removes support for anything but one kind of routes /api/v2/
- [x] Removed dead references to the public_routing param

### Why?

I am doing this because:

- This is just part of simplifying our routing
