### PR TITLE
HMRC-765: Adds job to trigger e2e-test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ orbs:
   ruby: circleci/ruby@2
   slack: circleci/slack@4.3.0
   tariff: trade-tariff/trade-tariff-ci-orb@0
+  github-cli: circleci/github-cli@2.7.0
 
 executors:
   terraform:
@@ -41,6 +42,64 @@ executors:
       TF_IN_AUTOMATION: 1
 
 jobs:
+  trigger-github-e2e-tests:
+    docker:
+      - image: cimg/base:stable
+    parameters:
+      test_url:
+        type: string
+    steps:
+      - checkout
+      - github-cli/install
+      - run:
+          name: Trigger GitHub Workflow and Monitor
+          command: |
+            gh workflow run e2e-tests.yml \
+              -R trade-tariff/trade-tariff-tools \
+              --ref main \
+              -f test-url="<< parameters.test_url >>"
+
+            sleep 5 # Give it a moment to register
+            RUN_ID=$(gh run list \
+              --repo trade-tariff/trade-tariff-tools \
+              --workflow=e2e-tests.yml \
+              --branch=main \
+              --limit=1 \
+              --json databaseId \
+              -q '.[0].databaseId')
+
+            echo "GitHub Workflow triggered with Run ID: $RUN_ID"
+            echo "Checking status (will not block pipeline)..."
+
+            END_TIME=$((SECONDS+100))
+            while [ $SECONDS -lt $END_TIME ]; do
+              STATUS=$(gh run view $RUN_ID \
+                --repo trade-tariff/trade-tariff-tools \
+                --json conclusion,status \
+                -q '.status')
+
+              CONCLUSION=$(gh run view $RUN_ID \
+                --repo trade-tariff/trade-tariff-tools \
+                --json conclusion,status \
+                -q '.conclusion')
+
+              echo "Current status: $STATUS"
+
+              if [ "$STATUS" = "completed" ]; then
+                echo "Workflow completed with conclusion: $CONCLUSION"
+                echo "GITHUB_WORKFLOW_RESULT=$CONCLUSION" >> $BASH_ENV
+                break
+              fi
+
+              sleep 30
+            done
+
+            if [ "$STATUS" != "completed" ]; then
+              echo "Workflow did not complete within 15 minutes"
+              echo "GITHUB_WORKFLOW_RESULT=timed_out" >> $BASH_ENV
+            fi
+
+            echo "Continuing pipeline regardless of GitHub workflow outcome"
   write-docker-tag:
     parameters:
       environment:
@@ -229,6 +288,13 @@ workflows:
             - apply-terraform-dev
           <<: *filter-not-main
 
+      - trigger-github-e2e-tests:
+          name: trigger-e2e-tests-dev
+          test_url: https://dev.trade-tariff.service.gov.uk
+          context: trade-tariff-dev
+          requires:
+            - apply-terraform-dev
+          <<: *filter-not-main
   deploy-to-staging:
     jobs:
       - write-docker-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,20 +263,21 @@ workflows:
           ssm_parameter: "/development/DUTY_CALCULATOR_ECR_URL"
           <<: *filter-not-main
 
-      - confirm-deploy-for-qa?:
-          type: approval
-          requires:
-            - test
-            - plan-terraform-dev
-            - build-and-push-dev
-          <<: *filter-not-main
-
       - apply-terraform:
           name: apply-terraform-dev
           context: trade-tariff-terraform-aws-development
           environment: development
           requires:
-            - confirm-deploy-for-qa?
+            - plan-terraform-dev
+            - build-and-push-dev
+          <<: *filter-not-main
+
+      - trigger-github-e2e-tests:
+          name: trigger-e2e-tests-dev
+          test_url: https://dev.trade-tariff.service.gov.uk
+          context: trade-tariff-terraform-aws-development
+          requires:
+            - apply-terraform-dev
           <<: *filter-not-main
 
       - tariff/smoketests:
@@ -288,13 +289,6 @@ workflows:
             - apply-terraform-dev
           <<: *filter-not-main
 
-      - trigger-github-e2e-tests:
-          name: trigger-e2e-tests-dev
-          test_url: https://dev.trade-tariff.service.gov.uk
-          context: trade-tariff-dev
-          requires:
-            - apply-terraform-dev
-          <<: *filter-not-main
   deploy-to-staging:
     jobs:
       - write-docker-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,6 +321,14 @@ workflows:
             - build-and-push-live
           <<: *filter-main
 
+      - trigger-github-e2e-tests:
+          name: trigger-e2e-tests-staging
+          test_url: https://dev.trade-tariff.service.gov.uk
+          context: trade-tariff-terraform-aws-staging
+          requires:
+            - apply-terraform-staging
+          <<: *filter-main
+
       - tariff/smoketests:
           context: trade-tariff-testing
           url: https://staging.trade-tariff.service.gov.uk

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.86.0
+    rev: v1.97.4
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -13,34 +13,35 @@ repos:
           - --hook-config=--create-file-if-not-exist=true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
 
   - repo: https://github.com/zahorniak/pre-commit-circleci.git
-    rev: v0.6
+    rev: v1.1.0
     hooks:
       - id: circleci_validate
         args:
           - --org-id=da607531-93bb-4321-90ed-08710434ce1c
 
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.1
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.88.15
     hooks:
-      - id: gitleaks
+      - id: trufflehog
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.38.0
+    rev: v0.44.0
     hooks:
-      - id: markdownlint
+      - id: markdownlint-docker
         args:
           - "--ignore"
           - terraform
           - "--fix"
 
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.1
+  - repo: https://github.com/mattlqx/pre-commit-ruby
+    rev: v1.3.6
     hooks:
-      - id: gitleaks
+      - id: rubocop
+        args: ["--autocorrect"]

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
           buildInputs = [
             lint
-            pkgs.rufo
+            pkgs.circleci-cli
             pkgs.yarn
             ruby
           ];

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,7 +1,7 @@
 # trade-tariff-duty-calculator terraform
 
 Terraform to deploy the service into AWS.
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -55,4 +55,4 @@ Terraform to deploy the service into AWS.
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
### Jira link

[HMRC-765](https://transformuk.atlassian.net/browse/HMRC-765)

### What?

I have added/removed/altered:

- [x] Added a job to trigger the github action to run the e2e tests in the tools repo
- [x] Integrated this job as part of the developer feature workflow
- [x] Integrated this job as part of the staging release workflow

### Why?

I am doing this because:

- This is required to start getting value out of the e2e journeys as early as possible
