### PR TITLE
HMRC-814: Enable ecs-exec

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -25,14 +25,15 @@ Terraform to deploy the service into AWS.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_secretsmanager_secret.duty_calculator_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.new_relic_license_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
-| [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -32,7 +32,3 @@ data "aws_secretsmanager_secret" "new_relic_license_key" {
 data "aws_kms_key" "secretsmanager_key" {
   key_id = "alias/secretsmanager-key"
 }
-
-data "aws_ssm_parameter" "ecr_url" {
-  name = "/${var.environment}/DUTY_CALCULATOR_ECR_URL"
-}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -34,3 +34,24 @@ resource "aws_iam_policy" "secrets" {
   name   = "${local.service}-execution-role-secrets-policy"
   policy = data.aws_iam_policy_document.secrets.json
 }
+
+data "aws_iam_policy_document" "exec" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "exec" {
+  name   = "duty-calculator-task-role-exec-policy"
+  policy = data.aws_iam_policy_document.exec.json
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@ module "service" {
 
   region = var.region
 
-  service_name  = local.service
+  service_name  = "duty-calculator"
   service_count = var.service_count
 
   cluster_name              = "trade-tariff-cluster-${var.environment}"
@@ -15,7 +15,7 @@ module "service" {
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity
 
-  docker_image = data.aws_ssm_parameter.ecr_url.value
+  docker_image = "382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-duty-calculator-production"
   docker_tag   = var.docker_tag
   skip_destroy = true
 
@@ -26,6 +26,10 @@ module "service" {
 
   execution_role_policy_arns = [
     aws_iam_policy.secrets.arn
+  ]
+
+  task_role_policy_arns = [
+    aws_iam_policy.exec.arn,
   ]
 
   service_environment_config = [
@@ -81,4 +85,5 @@ module "service" {
       valueFrom = data.aws_secretsmanager_secret.duty_calculator_secret_key_base.arn
     },
   ]
+  enable_ecs_exec = true
 }


### PR DESCRIPTION
### Jira link

[HMRC-814](https://transformuk.atlassian.net/browse/HMRC-814)

### What?

I have added/removed/altered:

- [x] Enabled ecs-exec

### Why?

I am doing this because:

- This is required to enable the migration to github actions
