### PR TITLE
HMRC-814: Adds dependency in production deploy on build

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -42,6 +42,7 @@ jobs:
   deploy:
     environment: production
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v4
       - id: docker-tag


### PR DESCRIPTION
### Jira link

[HMRC-814](https://transformuk.atlassian.net/browse/HMRC-814)

### What?

I have added/removed/altered:

- [x] Added needs on the production apply stage on the build stage

### Why?

I am doing this because:

- This reflects that the image must exist for the apply to actually run
- Technically staging will have already built this image but we should add guarantees
