### PR TITLE
HMRC-814: Removes approval for building production image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -23,7 +23,6 @@ env:
 
 jobs:
   build:
-    environment: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Jira link

[HMRC-814](https://transformuk.atlassian.net/browse/HMRC-814)

### What?

I have added/removed/altered:

- [x] Removes approval for the build step in production

### Why?

I am doing this because:

- This is just annoying/creates extra buttons to click
