### PR TITLE
BAU: Removes planning step in staging and production

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -28,11 +28,6 @@ jobs:
       - uses: actions/checkout@v4
       - id: docker-tag
         run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - uses: trade-tariff/trade-tariff-tools/.github/actions/terraform-plan@main
-        with:
-          environment: ${{ env.ENVIRONMENT }}
-          ref: ${{ inputs.ref || steps.docker-tag.outputs.DOCKER_TAG }}
-          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/build-and-push@main
         with:
           ecr-url: ${{ env.ECR_URL }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -28,11 +28,6 @@ jobs:
       - uses: actions/checkout@v4
       - id: docker-tag
         run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - uses: trade-tariff/trade-tariff-tools/.github/actions/terraform-plan@main
-        with:
-          environment: ${{ env.ENVIRONMENT }}
-          ref: ${{ inputs.ref || steps.docker-tag.outputs.DOCKER_TAG }}
-          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/build-and-push@main
         with:
           ecr-url: ${{ env.ECR_URL }}


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removed plans on staging/production

### Why?

I am doing this because:

- Plans will have already happened in development and these environments are effectively cows/the same https://www.hava.io/blog/cattle-vs-pets-devops-explained
- Plans are causing locks failings during builds and the build should just be able to happen
