### PR TITLE
HMRC-945: Adjusts e2e-test inputs

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -106,11 +106,13 @@ jobs:
           ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
 
   post-deploy:
-    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     needs: deploy
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     with:
       test-url: "https://dev.trade-tariff.service.gov.uk"
-      ref: main
+      admin-test-url: "https://admin.dev.trade-tariff.service.gov.uk"
+    secrets:
+      basic_password: ${{ secrets.BASIC_PASSWORD }}
 
   notifications:
       runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -67,7 +67,6 @@ jobs:
     needs: deploy
     with:
       test-url: "https://www.trade-tariff.service.gov.uk"
-      ref: main
 
   notifications:
       runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -47,11 +47,13 @@ jobs:
           ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
 
   post-deploy:
-    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     needs: deploy
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     with:
       test-url: "https://staging.trade-tariff.service.gov.uk"
-      ref: main
+      admin-test-url: "https://admin.staging.trade-tariff.service.gov.uk"
+    secrets:
+      basic_password: ${{ secrets.BASIC_PASSWORD }}
 
   notifications:
       runs-on: ubuntu-latest


### PR DESCRIPTION
### Jira link

[HMRC-945](https://transformuk.atlassian.net/browse/HMRC-945)

### What?

I have added/removed/altered:

- [x] Added missing inputs to the e2e tests
- [x] Removed extra ref input in production which was configured the same as the default

### Why?

I am doing this because:

- This is required to make sure the admin tests can pass/be green
