### PR TITLE
HMRC-968 Fix deployment marking

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -66,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
+      - uses: actions/checkout@v4
       - id: docker-tag
         run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: New Relic Application Deployment Marker


### PR DESCRIPTION
### Jira link

HMRC-968

### What?

I have 

- Fixed getting the git commit for the deploy

### Why?

So deployment marking in New Relic will work
